### PR TITLE
docs: add architecture blueprint for SQLite, ingestion, and AI reasoning

### DIFF
--- a/docs/AI_REASONING_ARCHITECTURE.md
+++ b/docs/AI_REASONING_ARCHITECTURE.md
@@ -1,0 +1,568 @@
+# LegionTrap TI — AI Reasoning Architecture
+
+**Document type:** Implementation blueprint — AI context retrieval, prompt design, and reasoning pipeline
+**Audience:** Engineers, autonomous agents performing Phase 5+ work
+**Last reviewed:** 2026-05-23
+**Status:** Design-complete. Describes the system that Phases 5 and 6 implement. Prerequisites: DATABASE_SCHEMA.md (Phase 1), INGESTION_PIPELINE.md (Phase 2), GeoIP enrichment (Phase 3), and event type taxonomy (Phase 4).
+
+---
+
+## Core Design Principle
+
+**The AI does not read raw events. It reads structured summaries derived from SQL queries.**
+
+This is the critical design decision that separates a useful AI analysis layer from an expensive toy. The difference:
+
+| Approach | What the AI receives | Result |
+|---|---|---|
+| Raw event injection | 10,000 JSON lines | Context window exhaustion; unreliable counting; hallucinated aggregations |
+| Structured context | Pre-aggregated SQL summaries | Accurate counts; reliable pattern analysis; grounded, citeable conclusions |
+
+Every AI prompt in this system is built from SQL query results. The AI never sees raw event content. This is not an optimization — it is a correctness requirement.
+
+---
+
+## Prerequisites (AI Stage 0)
+
+These must be complete before any AI feature work begins. See [ROADMAP.md](ROADMAP.md) Phase 1–4 and [AI_ROADMAP.md](AI_ROADMAP.md) Stage 0.
+
+- [ ] SQLite event store (`events` table, Phase 1)
+- [ ] `HoneypotEvent` Pydantic schema (Phase 1)
+- [ ] GeoIP enrichment on ingestion — `country_code`, `country_name`, `asn`, `asn_org` populated (Phase 3)
+- [ ] `event_types` table with ATT&CK taxonomy (Phase 4)
+- [ ] `POST /api/ingest` pipeline operational (Phase 2)
+
+Attempting to build the AI layer before these are in place produces a prototype that cannot be evolved into a production capability.
+
+---
+
+## AI Backend Configuration
+
+The AI backend is selected via the `AI_BACKEND` environment variable:
+
+```bash
+AI_BACKEND=claude     # Uses Claude API. Event summaries sent to external API.
+AI_BACKEND=ollama     # Local inference. No data leaves the system.
+AI_BACKEND=none       # AI features disabled. Non-AI functionality unaffected.
+```
+
+**When `AI_BACKEND=none`:** All AI-dependent endpoints return:
+```json
+{"status": "ai_disabled", "message": "AI_BACKEND is set to 'none'. Set AI_BACKEND=claude or AI_BACKEND=ollama to enable AI analysis."}
+```
+with HTTP 200. Non-AI endpoints continue operating normally.
+
+**When `AI_BACKEND=claude`:** The Claude API is called with structured context. Event summaries are sent externally. Privacy masking rules apply — see the Privacy section below.
+
+**When `AI_BACKEND=ollama`:** A local Ollama instance is called. No data leaves the system. Suitable for air-gapped deployments. Reasoning quality is lower than Claude API for complex analysis.
+
+The backend selection is an operator decision. The code must not hardcode a preference.
+
+---
+
+## The Retrieval-Then-Reason Pattern
+
+All AI analysis follows this pattern:
+
+```
+1. Operator query (or scheduled trigger)
+         │
+         ▼
+2. Intent parsing — determine time window, event filters, analysis type
+         │
+         ▼
+3. Context retrieval — run structured SQL aggregation queries
+         │
+         ▼
+4. Context serialization — format query results as structured JSON for the prompt
+         │
+         ▼
+5. Privacy filtering — apply IP masking/hashing if PRIVACY_MODE is active
+         │
+         ▼
+6. Prompt construction — combine context with system instructions and analyst question
+         │
+         ▼
+7. AI model call — send to Claude API or Ollama
+         │
+         ▼
+8. Response parsing — extract summary, key_findings, recommended_actions, confidence
+         │
+         ▼
+9. Citation grounding — verify factual claims are traceable to retrieved data
+         │
+         ▼
+10. Persistence — INSERT INTO ai_analyses
+         │
+         ▼
+11. API response — return structured AIAnalysisResult
+```
+
+---
+
+## Context Retrieval Queries
+
+These are the SQL queries that populate the AI context. Each query is named; the context builder calls them by name and assembles their results into the prompt.
+
+### `ctx_event_summary` — overall activity in time window
+
+```sql
+SELECT
+    COUNT(*)                                     AS total_events,
+    COUNT(DISTINCT src_ip)                       AS unique_ips,
+    COUNT(DISTINCT asn)                          AS unique_asns,
+    COUNT(DISTINCT country_code)                 AS unique_countries,
+    MIN(ts)                                      AS window_start,
+    MAX(ts)                                      AS window_end
+FROM events
+WHERE ts BETWEEN :start AND :end;
+```
+
+### `ctx_top_event_types` — most common attack types
+
+```sql
+SELECT
+    event_type,
+    et.attack_tactic,
+    et.attack_technique,
+    COUNT(*)                AS count,
+    COUNT(DISTINCT src_ip)  AS unique_ips
+FROM events e
+LEFT JOIN event_types et ON e.event_type = et.id
+WHERE e.ts BETWEEN :start AND :end
+GROUP BY e.event_type
+ORDER BY count DESC
+LIMIT 10;
+```
+
+### `ctx_top_asns` — most active attacking ASNs
+
+```sql
+SELECT
+    asn,
+    asn_org,
+    country_code,
+    COUNT(*)                AS event_count,
+    COUNT(DISTINCT src_ip)  AS unique_ips,
+    MIN(ts)                 AS first_seen,
+    MAX(ts)                 AS last_seen
+FROM events
+WHERE ts BETWEEN :start AND :end
+  AND asn IS NOT NULL
+GROUP BY asn
+ORDER BY event_count DESC
+LIMIT 10;
+```
+
+### `ctx_top_countries` — geographic distribution
+
+```sql
+SELECT
+    country_code,
+    country_name,
+    COUNT(*)                AS event_count,
+    COUNT(DISTINCT src_ip)  AS unique_ips
+FROM events
+WHERE ts BETWEEN :start AND :end
+  AND country_code IS NOT NULL
+GROUP BY country_code
+ORDER BY event_count DESC
+LIMIT 10;
+```
+
+### `ctx_timing_distribution` — probe timing patterns (per-hour activity)
+
+```sql
+SELECT
+    strftime('%H', ts)   AS hour_of_day,
+    COUNT(*)             AS event_count
+FROM events
+WHERE ts BETWEEN :start AND :end
+GROUP BY hour_of_day
+ORDER BY hour_of_day;
+```
+
+### `ctx_new_vs_returning_ips` — repeat attacker detection
+
+```sql
+-- IPs seen before the analysis window
+WITH prior_ips AS (
+    SELECT DISTINCT src_ip FROM events
+    WHERE ts < :start AND src_ip IS NOT NULL
+),
+window_ips AS (
+    SELECT DISTINCT src_ip FROM events
+    WHERE ts BETWEEN :start AND :end AND src_ip IS NOT NULL
+)
+SELECT
+    COUNT(*) FILTER (WHERE w.src_ip IN (SELECT src_ip FROM prior_ips)) AS returning_ips,
+    COUNT(*) FILTER (WHERE w.src_ip NOT IN (SELECT src_ip FROM prior_ips)) AS new_ips,
+    COUNT(*) AS total_unique_ips
+FROM window_ips w;
+```
+
+### `ctx_active_campaigns` — known campaigns in this window (Phase 6+)
+
+```sql
+SELECT
+    c.id, c.label, c.status,
+    c.event_count, c.confidence,
+    bf.targeting_category, bf.primary_protocol, bf.timing_type
+FROM campaigns c
+LEFT JOIN behavioral_fingerprints bf ON c.fingerprint_id = bf.id
+WHERE c.status = 'active'
+  AND c.last_seen BETWEEN :start AND :end
+ORDER BY c.last_seen DESC
+LIMIT 5;
+```
+
+This query returns `[]` before Phase 6 — the AI context builder handles empty campaign results gracefully.
+
+---
+
+## Prompt Architecture
+
+### System prompt (constant)
+
+```
+You are a threat intelligence analyst for a self-hosted honeypot network.
+You receive structured attack data and produce accurate, evidence-grounded analysis.
+
+Rules:
+- Every factual claim must be traceable to the provided data.
+- State uncertainty explicitly when the data is insufficient for a conclusion.
+- Never hallucinate IP addresses, ASN names, event counts, or time ranges.
+- If asked about something the data does not contain, say so directly.
+- Output must be valid JSON matching the schema provided.
+```
+
+### Context block (assembled from SQL query results)
+
+```json
+{
+  "analysis_window": {
+    "start": "2026-05-22T00:00:00Z",
+    "end": "2026-05-22T23:59:59Z"
+  },
+  "event_summary": {
+    "total_events": 412,
+    "unique_ips": 17,
+    "unique_asns": 8,
+    "unique_countries": 5
+  },
+  "top_event_types": [
+    {"event_type": "auth_failed", "attack_technique": "T1110.001", "count": 387, "unique_ips": 14},
+    {"event_type": "port_scan", "attack_technique": "T1046", "count": 25, "unique_ips": 6}
+  ],
+  "top_asns": [
+    {"asn": 12345, "asn_org": "Example ISP", "country_code": "RU", "event_count": 203, "unique_ips": 6},
+    {"asn": 67890, "asn_org": "Another Provider", "country_code": "CN", "event_count": 145, "unique_ips": 4}
+  ],
+  "top_countries": [
+    {"country_code": "RU", "country_name": "Russia", "event_count": 203},
+    {"country_code": "CN", "country_name": "China", "event_count": 145}
+  ],
+  "returning_vs_new": {
+    "returning_ips": 3,
+    "new_ips": 14,
+    "total_unique_ips": 17
+  },
+  "active_campaigns": []
+}
+```
+
+### Output schema (requested from the model)
+
+```json
+{
+  "summary": "string — 2-5 sentence narrative summary",
+  "key_findings": ["string", "..."],
+  "recommended_actions": ["string", "..."],
+  "confidence": "low | medium | high",
+  "notable_actors": [
+    {"asn": 12345, "asn_org": "...", "pattern": "..."}
+  ]
+}
+```
+
+The model is instructed to produce JSON matching this schema. The response is parsed with Pydantic and stored in `ai_analyses`.
+
+---
+
+## Privacy Controls for AI Prompts
+
+When `PRIVACY_MODE=on`, IP addresses in the context block are transformed before being included in the prompt. The same masking logic used in IOC exports (`iocs_pf.py`) applies here.
+
+A separate `AI_PRIVACY_MODE` environment variable (defaulting to the value of `PRIVACY_MODE`) allows independent control:
+
+```bash
+PRIVACY_MODE=on          # controls IOC exports
+AI_PRIVACY_MODE=on       # controls what reaches external AI APIs (defaults to PRIVACY_MODE)
+```
+
+This allows an operator to export unmasked IPs locally but mask them when sending to an external AI API — useful when the AI backend is Claude (external) but IOC exports are consumed locally.
+
+**Masking in context blocks:**
+- IP addresses in `top_asns` source IP fields → masked/hashed
+- IP addresses in `returning_vs_new` analysis → counts only (no IPs ever appear in aggregate queries)
+- ASN numbers and organization names → **never masked** (ASN data is public; masking it degrades AI reasoning quality with no privacy benefit)
+
+**Absolute prohibitions in AI prompts (regardless of privacy settings):**
+- `data.password` from any event — attacker-submitted credentials, never included
+- `data.username` from any event — attacker-submitted strings
+- Any free-text attacker content
+- Raw event JSON lines
+
+---
+
+## The `POST /api/analyze` Endpoint
+
+### Request
+
+```http
+POST /api/analyze
+Authorization: Bearer <jwt>
+Content-Type: application/json
+
+{
+  "window_hours": 24,
+  "window_start": null,
+  "window_end": null
+}
+```
+
+`window_hours` is the convenience parameter. If `window_start` and `window_end` are provided, they take precedence.
+
+### Response
+
+```json
+{
+  "analysis_id": "uuid",
+  "created_at": "2026-05-22T20:00:00Z",
+  "window_start": "2026-05-21T20:00:00Z",
+  "window_end": "2026-05-22T20:00:00Z",
+  "backend": "claude",
+  "summary": "17 distinct source IPs were observed over the 24-hour window...",
+  "key_findings": [
+    "ASN 12345 (Russia) accounted for 49% of all events with 6 distinct source IPs",
+    "3 returning IPs from prior observations; 14 new IPs not seen before",
+    "All attack activity was SSH credential brute-force (T1110.001) with no port scan precursors"
+  ],
+  "recommended_actions": [
+    "Consider blocking ASN 12345 at the perimeter if SSH exposure is not required from Russia",
+    "Review the 3 returning IPs against prior campaign records for attribution"
+  ],
+  "confidence": "medium"
+}
+```
+
+### Authentication
+
+`POST /api/analyze` accepts either JWT or API key (`require_jwt_or_api_key`). It is a read + AI call, not an ingest operation. Both auth methods are appropriate.
+
+---
+
+## Query Architecture for Dashboard and Advanced Analysis
+
+### Dashboard stats (after Phase 1 migration)
+
+```sql
+-- Single query replaces the full JSONL scan in stats.py
+SELECT
+    COUNT(*)                                                        AS total_events,
+    COUNT(DISTINCT src_ip)                                          AS unique_ips,
+    SUM(CASE WHEN ts > datetime('now', '-24 hours') THEN 1 ELSE 0 END) AS last_24h
+FROM events;
+```
+
+This runs in milliseconds on 1M+ rows with the `idx_events_ts` index.
+
+### Event timeline (trend chart)
+
+```sql
+SELECT
+    strftime('%Y-%m-%dT%H:00:00', ts) AS hour,
+    event_type,
+    COUNT(*)                          AS count
+FROM events
+WHERE ts > datetime('now', :hours_back)
+GROUP BY hour, event_type
+ORDER BY hour;
+```
+
+### Attack sequence reconstruction (per-IP history)
+
+```sql
+SELECT e.ts, e.event_type, e.dst_port, e.protocol,
+       et.attack_tactic, et.attack_technique,
+       s.asn_org, s.country_name
+FROM events e
+LEFT JOIN event_types et ON e.event_type = et.id
+LEFT JOIN source_ips  s  ON e.src_ip = s.ip
+WHERE e.src_ip = :ip
+ORDER BY e.ts;
+```
+
+### Repeated attacker detection
+
+```sql
+SELECT
+    src_ip,
+    COUNT(*)                          AS total_events,
+    COUNT(DISTINCT DATE(ts))          AS active_days,
+    MIN(ts)                           AS first_seen,
+    MAX(ts)                           AS last_seen,
+    asn_org,
+    country_name
+FROM events e
+JOIN source_ips s ON e.src_ip = s.ip
+WHERE src_ip IS NOT NULL
+GROUP BY src_ip
+HAVING active_days > 1
+ORDER BY total_events DESC
+LIMIT 20;
+```
+
+### GeoIP / ASN correlation
+
+```sql
+SELECT
+    asn,
+    asn_org,
+    country_code,
+    COUNT(*)                AS event_count,
+    COUNT(DISTINCT src_ip)  AS unique_ips,
+    MIN(ts)                 AS first_seen,
+    MAX(ts)                 AS last_seen
+FROM events
+WHERE ts > datetime('now', '-7 days')
+  AND asn IS NOT NULL
+GROUP BY asn
+ORDER BY event_count DESC
+LIMIT 20;
+```
+
+### Campaign recognition query (Phase 6+)
+
+```sql
+SELECT
+    c.id, c.label, c.status, c.confidence,
+    c.first_seen, c.last_seen, c.event_count,
+    bf.targeting_category, bf.primary_protocol,
+    bf.timing_type, bf.timing_interval_ms
+FROM campaigns c
+LEFT JOIN behavioral_fingerprints bf ON c.fingerprint_id = bf.id
+WHERE c.status IN ('active', 'dormant')
+ORDER BY c.last_seen DESC;
+```
+
+### Federation fingerprint matching (Phase 7+)
+
+```sql
+SELECT
+    ff.fingerprint_id,
+    ff.contributor_id,
+    ff.confidence,
+    ff.dimensions_json,
+    ff.received_at,
+    ff.trust_tier
+FROM federation_fingerprints ff
+WHERE ff.confidence > 0.7
+  AND ff.received_at > datetime('now', '-30 days')
+ORDER BY ff.confidence DESC;
+```
+
+---
+
+## AI Limitations and Risk Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Hallucinated event counts | Context block contains pre-computed exact counts from SQL. Model is instructed counts are authoritative. |
+| Hallucinated IP addresses | IPs are never in the context unless the operator explicitly requests per-IP analysis. |
+| Prompt injection via event data | Event content (usernames, passwords, User-Agent strings) is never included in prompts. Only typed, structured aggregations appear. |
+| Model downtime blocking core functionality | AI endpoints return `503` when AI backend is unavailable. All non-AI endpoints continue working. |
+| Privacy leak via AI output | AI output is not cached or forwarded without the same privacy filtering applied to context input. |
+| Over-confident conclusions | System prompt instructs explicit uncertainty disclosure. Output schema includes `confidence` field. UI must display confidence level alongside narrative. |
+| Stale analysis | `created_at` is stored and returned. Analysis results are never presented as "live" — they are a snapshot of a specific time window. |
+
+---
+
+## Behavioral Memory Integration (Phase 6+)
+
+When behavioral fingerprints and campaign clusters exist, the AI context expands to include:
+
+1. **Campaign context:** Active and recently-dormant campaigns with their behavioral signatures
+2. **Fingerprint similarity:** Whether new events match known fingerprints from prior campaigns
+3. **Historical narrative:** "This ASN was previously associated with campaign C-2025-089 in November 2025"
+
+The AI receives this as an additional context block:
+
+```json
+{
+  "known_campaigns": [
+    {
+      "id": "C-2025-089",
+      "label": "SSH scanner from AS12345",
+      "status": "dormant",
+      "last_seen": "2025-11-15",
+      "targeting_category": "credential-brute-force",
+      "timing_type": "periodic",
+      "timing_interval_ms": 2000
+    }
+  ],
+  "fingerprint_matches": [
+    {
+      "current_pattern": "periodic SSH, 2000ms interval",
+      "matched_campaign": "C-2025-089",
+      "match_confidence": 0.87,
+      "matched_dimensions": ["timing_type", "timing_interval_ms", "primary_protocol"]
+    }
+  ]
+}
+```
+
+This is the mechanism that produces the "returning actor" detection capability: the AI can state "The timing pattern observed today matches campaign C-2025-089 from 6 months ago, with 87% confidence across 3 behavioral dimensions."
+
+---
+
+## Implementation File Map
+
+```
+app/
+  routers/
+    analyze.py              # POST /api/analyze endpoint
+  services/
+    ai_context.py           # context retrieval — runs SQL queries, assembles context dict
+    ai_prompt.py            # prompt construction — system prompt + context → final prompt
+    ai_backends.py          # Claude API and Ollama client wrappers
+    ai_privacy.py           # privacy filtering for AI context (IP masking)
+  models/
+    ai.py                   # AIAnalysisResult, IngestRequest Pydantic models
+  db/
+    repository.py           # all SQL including the context retrieval queries above
+```
+
+No AI logic belongs in routers. Routers call services. Services call repository. Repository calls SQL.
+
+---
+
+## Testing Requirements
+
+Before Phase 5 is complete:
+
+| Test | Assertion |
+|---|---|
+| `test_analyze_returns_disabled_when_backend_none` | `AI_BACKEND=none` → 200 with `status: ai_disabled` |
+| `test_context_retrieval_queries_are_accurate` | Insert known events, run context queries, assert exact counts |
+| `test_privacy_filtering_masks_ips` | `PRIVACY_MODE=on` → no raw IPs in context block |
+| `test_password_not_in_ai_context` | Ingest Cowrie event with password, build context, assert no password in output |
+| `test_analyze_stores_result_in_db` | POST /api/analyze → ai_analyses table has one row |
+| `test_analyze_window_parameters` | `window_hours=24` and explicit `window_start/end` produce equivalent results |
+| `test_analyze_empty_window` | Analysis window with zero events returns graceful summary, not error |
+
+AI backend integration tests (calling the real Claude API or Ollama) are skipped in CI unless `AI_BACKEND` is explicitly set. They run only in manual verification environments.
+
+---
+
+*Cross-references: [AI_ROADMAP.md](AI_ROADMAP.md) · [DATABASE_SCHEMA.md](DATABASE_SCHEMA.md) · [INGESTION_PIPELINE.md](INGESTION_PIPELINE.md) · [BEHAVIORAL_INTELLIGENCE.md](BEHAVIORAL_INTELLIGENCE.md) · [ROADMAP.md](ROADMAP.md)*

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -1,0 +1,396 @@
+# LegionTrap TI — Database Schema
+
+**Document type:** Implementation blueprint — canonical SQL schema reference
+**Audience:** Engineers, autonomous agents, Alembic migration authors
+**Last reviewed:** 2026-05-23
+**Status:** Design-complete. Not yet implemented. This document is the source of truth for Phase 1 implementation.
+
+---
+
+## Design Principles
+
+1. **PostgreSQL-compatible from day one.** Use only standard SQL types (`TEXT`, `INTEGER`, `REAL`, `BLOB`). Avoid SQLite-specific extensions. Migration from SQLite to PostgreSQL must require only driver and connection-string changes.
+2. **Never mix raw and derived data.** The `raw_events` table is immutable provenance. The `events` table is the analytical surface. Behavioral and AI tables are derived. Federation tables are external. Each layer has a distinct trust level and retention policy.
+3. **No SQL in routers.** All database access goes through `app/db/repository.py`. Routers call repository methods. Repository methods call SQL. This abstraction is the migration safety net.
+4. **Index for the actual queries.** Every index listed below corresponds to a real query pattern defined in [INGESTION_PIPELINE.md](INGESTION_PIPELINE.md) or [AI_REASONING_ARCHITECTURE.md](AI_REASONING_ARCHITECTURE.md).
+5. **`schema_version` on every derived table.** Enables selective reprocessing when extraction logic changes.
+
+---
+
+## Storage Location
+
+```
+storage/legiontrap.db       # production database
+storage/legiontrap-test.db  # test database (created by conftest.py, gitignored)
+```
+
+Both paths will be controlled by the `DB_PATH` environment variable (added to `app/core/config.py` in Phase 1). The `storage/` directory is gitignored for `*.db` files. The database file itself is the complete state of the system; backup = copy this file.
+
+Enable WAL mode immediately on connection:
+
+```sql
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA foreign_keys = ON;
+```
+
+---
+
+## Table Reference
+
+### Dependency order (creation order)
+
+```
+event_types
+raw_events
+source_ips
+events                    → raw_events, event_types
+behavioral_fingerprints
+campaigns                 → behavioral_fingerprints
+campaign_events           → campaigns, events
+ai_analyses
+federation_fingerprints
+audit_log
+```
+
+---
+
+## Core Event Tables
+
+### `event_types`
+
+Lookup table for the normalized event type taxonomy. Enables ATT&CK mapping without reprocessing events.
+
+```sql
+CREATE TABLE event_types (
+    id               TEXT PRIMARY KEY,   -- e.g. 'auth_failed', 'port_scan', 'http_probe'
+    label            TEXT NOT NULL,      -- human-readable: 'SSH Authentication Failure'
+    attack_tactic    TEXT,               -- MITRE ATT&CK tactic: 'Credential Access'
+    attack_technique TEXT,               -- MITRE ATT&CK ID: 'T1110.001'
+    description      TEXT
+);
+```
+
+**Initial seed values:**
+
+| id | label | attack_tactic | attack_technique |
+|---|---|---|---|
+| `auth_failed` | SSH Authentication Failure | Credential Access | T1110.001 |
+| `auth_success` | SSH Authentication Success | Initial Access | T1078 |
+| `port_scan` | Port Scan Probe | Discovery | T1046 |
+| `http_probe` | HTTP Endpoint Probe | Discovery | T1595.002 |
+| `malware_upload` | Malware Upload Attempt | Execution | T1204 |
+| `command_exec` | Remote Command Execution | Execution | T1059 |
+| `unknown` | Unknown Event Type | — | — |
+
+New event types can be inserted without schema migration.
+
+---
+
+### `raw_events`
+
+Immutable provenance record. Stores the original JSON exactly as received from the sensor. Never modified after insert. Never exposed through any API endpoint.
+
+```sql
+CREATE TABLE raw_events (
+    id           TEXT PRIMARY KEY,   -- UUID from sensor, or generated on ingest
+    ts           TEXT NOT NULL,      -- ISO8601 with timezone, as received
+    ingested_at  TEXT NOT NULL,      -- datetime LegionTrap received the event (UTC)
+    source       TEXT NOT NULL,      -- 'cowrie', 'dionaea', 'custom', etc.
+    raw_json     TEXT NOT NULL       -- original JSON line verbatim
+);
+
+CREATE INDEX idx_raw_events_ts     ON raw_events(ts);
+CREATE INDEX idx_raw_events_source ON raw_events(source);
+CREATE INDEX idx_raw_events_ingested ON raw_events(ingested_at);
+```
+
+**Retention policy:** Subject to `DATA_RETENTION_DAYS` setting. When a raw event is deleted by retention, the corresponding `events` row is also deleted. Behavioral fingerprints and campaigns are **not** subject to retention — they outlive the raw data they were derived from.
+
+---
+
+### `events`
+
+The primary analytical table. Every dashboard query, every AI query, every behavioral query runs against this table. Populated by the normalization pipeline from `raw_events`.
+
+```sql
+CREATE TABLE events (
+    id             TEXT PRIMARY KEY,  -- FK to raw_events.id
+    ts             TEXT NOT NULL,     -- normalized ISO8601 UTC
+    src_ip         TEXT,              -- extracted, validated public IPv4 (nullable)
+    dst_port       INTEGER,
+    protocol       TEXT,              -- 'tcp', 'udp'
+    event_type     TEXT NOT NULL,     -- FK to event_types.id
+    service        TEXT,              -- 'ssh', 'http', 'ftp', 'telnet'
+    country_code   TEXT,              -- ISO 3166-1 alpha-2 (from GeoIP, Phase 3)
+    country_name   TEXT,
+    city           TEXT,
+    asn            INTEGER,           -- ASN number (from GeoIP, Phase 3)
+    asn_org        TEXT,              -- ASN organization name
+    campaign_id    TEXT,              -- FK to campaigns.id (nullable until Phase 6)
+    schema_version INTEGER NOT NULL DEFAULT 1,
+
+    FOREIGN KEY (id)          REFERENCES raw_events(id)  ON DELETE CASCADE,
+    FOREIGN KEY (event_type)  REFERENCES event_types(id)
+    -- campaign_id FK omitted from Phase 1 DDL: campaigns table does not exist yet.
+    -- Added via ALTER TABLE in 0004_behavioral_tables.py (Phase 6).
+);
+
+CREATE INDEX idx_events_ts            ON events(ts);
+CREATE INDEX idx_events_src_ip        ON events(src_ip);
+CREATE INDEX idx_events_type          ON events(event_type);
+CREATE INDEX idx_events_asn           ON events(asn);
+CREATE INDEX idx_events_country       ON events(country_code);
+CREATE INDEX idx_events_campaign      ON events(campaign_id);
+CREATE INDEX idx_events_ts_type       ON events(ts, event_type);   -- dashboard trend chart
+CREATE INDEX idx_events_ts_src_ip     ON events(ts, src_ip);       -- per-IP timeline
+```
+
+**Note on `src_ip`:** Nullable. Not all events have a source IP (e.g., internal alerts, malware upload events where the IP is in a different field). The normalization pipeline extracts `src_ip` via priority field order: `data.ip` → `data.src_ip` → `src_ip` → `ip` → `client_ip` → `source_ip`. See [INGESTION_PIPELINE.md](INGESTION_PIPELINE.md) for the full extraction logic.
+
+---
+
+## Source IP Enrichment
+
+### `source_ips`
+
+Denormalized IP intelligence. Updated (upserted) on every new event from a given IP. Eliminates per-request GeoIP lookups by materializing enrichment at ingestion time.
+
+```sql
+CREATE TABLE source_ips (
+    ip               TEXT PRIMARY KEY,
+    first_seen       TEXT NOT NULL,
+    last_seen        TEXT NOT NULL,
+    event_count      INTEGER NOT NULL DEFAULT 0,
+    country_code     TEXT,
+    country_name     TEXT,
+    asn              INTEGER,
+    asn_org          TEXT,
+    is_tor_exit      INTEGER NOT NULL DEFAULT 0,  -- BOOLEAN (0/1)
+    is_vpn           INTEGER NOT NULL DEFAULT 0,
+    reputation_score REAL,                         -- 0.0–1.0 (future enrichment)
+    tags             TEXT                          -- JSON array: '["scanner","brute-force"]'
+);
+
+CREATE INDEX idx_source_ips_asn       ON source_ips(asn);
+CREATE INDEX idx_source_ips_country   ON source_ips(country_code);
+CREATE INDEX idx_source_ips_last_seen ON source_ips(last_seen);
+CREATE INDEX idx_source_ips_count     ON source_ips(event_count DESC);
+```
+
+**Upsert pattern on every ingest:**
+
+```sql
+INSERT INTO source_ips (ip, first_seen, last_seen, event_count, country_code,
+                        country_name, asn, asn_org)
+VALUES (?, ?, ?, 1, ?, ?, ?, ?)
+ON CONFLICT(ip) DO UPDATE SET
+    last_seen   = excluded.last_seen,
+    event_count = event_count + 1;
+```
+
+---
+
+## Behavioral Intelligence Tables
+
+These tables are created in Phase 6. The columns are defined here for schema planning purposes; the Alembic migration that creates them is not written until Phase 6 begins.
+
+### `behavioral_fingerprints`
+
+Derived behavioral signatures stored separately from events. Enables campaign matching without re-analyzing raw events. Persists beyond event retention policy.
+
+```sql
+CREATE TABLE behavioral_fingerprints (
+    id                   TEXT PRIMARY KEY,   -- UUID
+    created_at           TEXT NOT NULL,
+    updated_at           TEXT NOT NULL,
+    event_count          INTEGER NOT NULL,
+    port_sequence_class  TEXT,      -- 'sequential-ascending', 'targeted', 'random'
+    timing_type          TEXT,      -- 'periodic', 'burst', 'slow', 'irregular'
+    timing_interval_ms   INTEGER,   -- median inter-probe interval in ms
+    timing_jitter_pct    REAL,      -- inter-probe timing jitter as % of interval
+    primary_protocol     TEXT,      -- 'SSH', 'HTTP', 'Telnet', 'FTP'
+    protocol_variant     TEXT,      -- 'OpenSSH-compatible', 'custom', 'RFC-compliant'
+    targeting_category   TEXT,      -- 'credential-brute-force', 'port-scan', 'web-probe'
+    asn_count            INTEGER,   -- number of distinct ASNs in the cluster
+    geographic_spread    TEXT,      -- 'single-country', 'multi-region', 'global'
+    confidence           REAL NOT NULL,   -- 0.0–1.0
+    schema_version       INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX idx_fp_protocol   ON behavioral_fingerprints(primary_protocol);
+CREATE INDEX idx_fp_category   ON behavioral_fingerprints(targeting_category);
+CREATE INDEX idx_fp_confidence ON behavioral_fingerprints(confidence);
+```
+
+### `campaigns`
+
+Persistent campaign cluster records. A campaign that went dormant months ago is not deleted — it is marked dormant and reactivated when a matching fingerprint is observed again.
+
+```sql
+CREATE TABLE campaigns (
+    id               TEXT PRIMARY KEY,   -- e.g. 'C-2026-031' (auto-generated)
+    fingerprint_id   TEXT,               -- FK to behavioral_fingerprints.id
+    label            TEXT,               -- analyst-editable display name
+    first_seen       TEXT NOT NULL,
+    last_seen        TEXT NOT NULL,
+    dormant_since    TEXT,               -- NULL if active
+    event_count      INTEGER NOT NULL DEFAULT 0,
+    source_ip_count  INTEGER NOT NULL DEFAULT 0,
+    asn_count        INTEGER NOT NULL DEFAULT 0,
+    status           TEXT NOT NULL DEFAULT 'active',  -- 'active', 'dormant', 'closed'
+    confidence       REAL NOT NULL,
+    analyst_notes    TEXT,
+
+    FOREIGN KEY (fingerprint_id) REFERENCES behavioral_fingerprints(id)
+);
+
+CREATE INDEX idx_campaigns_status      ON campaigns(status);
+CREATE INDEX idx_campaigns_last_seen   ON campaigns(last_seen);
+CREATE INDEX idx_campaigns_fingerprint ON campaigns(fingerprint_id);
+```
+
+### `campaign_events`
+
+Many-to-many bridge between events and campaigns. An event can be tentatively assigned to multiple campaigns during the clustering phase until confidence resolves.
+
+```sql
+CREATE TABLE campaign_events (
+    campaign_id  TEXT NOT NULL,
+    event_id     TEXT NOT NULL,
+    assigned_at  TEXT NOT NULL,
+    confidence   REAL NOT NULL,
+
+    PRIMARY KEY (campaign_id, event_id),
+    FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE,
+    FOREIGN KEY (event_id)    REFERENCES events(id)    ON DELETE CASCADE
+);
+
+CREATE INDEX idx_ce_campaign ON campaign_events(campaign_id);
+CREATE INDEX idx_ce_event    ON campaign_events(event_id);
+```
+
+---
+
+## AI Analysis Results
+
+### `ai_analyses`
+
+Immutable record of every AI analysis performed. Provides audit trail and enables feeding historical analysis context into future AI queries.
+
+```sql
+CREATE TABLE ai_analyses (
+    id                  TEXT PRIMARY KEY,   -- UUID
+    created_at          TEXT NOT NULL,
+    window_start        TEXT,               -- analysis time window start (nullable for ad-hoc)
+    window_end          TEXT,
+    backend             TEXT NOT NULL,      -- 'claude', 'ollama', 'none'
+    model               TEXT,               -- model identifier string
+    prompt_tokens       INTEGER,
+    completion_tokens   INTEGER,
+    summary             TEXT NOT NULL,      -- narrative analysis text
+    key_findings        TEXT,               -- JSON array of strings
+    recommended_actions TEXT,               -- JSON array of strings
+    confidence          TEXT NOT NULL,      -- 'low', 'medium', 'high'
+    campaign_ids        TEXT,               -- JSON array of referenced campaign IDs
+    schema_version      INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX idx_ai_created  ON ai_analyses(created_at);
+CREATE INDEX idx_ai_backend  ON ai_analyses(backend);
+CREATE INDEX idx_ai_window   ON ai_analyses(window_start, window_end);
+```
+
+**Privacy constraint:** `ai_analyses` must never store raw event content. It stores only narrative text, campaign IDs, and metadata. Raw IPs appearing in AI output summaries are subject to the same masking rules as IOC exports when `PRIVACY_MODE` is active.
+
+---
+
+## Federation Tables
+
+### `federation_fingerprints`
+
+Received behavioral fingerprints from federated peers. Kept strictly separate from locally-derived fingerprints — they have different provenance, trust levels, and retention policies.
+
+```sql
+CREATE TABLE federation_fingerprints (
+    fingerprint_id          TEXT PRIMARY KEY,
+    received_at             TEXT NOT NULL,
+    contributor_id          TEXT NOT NULL,  -- pseudonymous deployment hash (never real identity)
+    schema_version          TEXT NOT NULL,
+    observed_at             TEXT NOT NULL,
+    signature               TEXT NOT NULL,  -- base64-encoded Ed25519 signature
+    dimensions_json         TEXT NOT NULL,  -- full fingerprint JSON blob
+    confidence              REAL NOT NULL,
+    event_count             INTEGER,
+    matched_local_campaign  TEXT,           -- FK to campaigns.id if a match was found
+    trust_tier              TEXT NOT NULL DEFAULT 'peer'  -- 'peer', 'circle', 'public'
+);
+
+CREATE INDEX idx_fed_contributor ON federation_fingerprints(contributor_id);
+CREATE INDEX idx_fed_received    ON federation_fingerprints(received_at);
+CREATE INDEX idx_fed_tier        ON federation_fingerprints(trust_tier);
+```
+
+---
+
+## Audit Log
+
+### `audit_log`
+
+Structured log of security-relevant events. Required for any deployment handling real security telemetry. Never deleted by event retention policy — has its own configurable retention period (default 90 days).
+
+```sql
+CREATE TABLE audit_log (
+    id          TEXT PRIMARY KEY,   -- UUID
+    ts          TEXT NOT NULL,
+    event_type  TEXT NOT NULL,      -- 'auth_success', 'auth_failure', 'ioc_export',
+                                    -- 'ai_call', 'ingest_batch', 'federation_receive'
+    auth_method TEXT,               -- 'jwt', 'api_key', null for unauthenticated
+    source_ip   TEXT,               -- client IP (nullable; not always available)
+    detail      TEXT                -- JSON with non-sensitive context only
+);
+
+CREATE INDEX idx_audit_ts         ON audit_log(ts);
+CREATE INDEX idx_audit_event_type ON audit_log(event_type);
+CREATE INDEX idx_audit_source_ip  ON audit_log(source_ip);
+```
+
+---
+
+## Migration Management
+
+Alembic manages all schema changes. The migration version table is created by Alembic automatically (`alembic_version`).
+
+**Migration naming convention:**
+
+```
+app/db/migrations/versions/
+  0001_initial_schema.py        -- creates all Phase 1 tables
+  0002_add_geoip_fields.py      -- Phase 3: adds country/ASN fields to events
+  0003_ai_analysis_table.py     -- Phase 5: adds ai_analyses
+  0004_behavioral_tables.py     -- Phase 6: adds fingerprints, campaigns, campaign_id FK
+  0005_federation_table.py      -- Phase 7: adds federation_fingerprints
+```
+
+**Rule:** Never manually ALTER a table that Alembic manages. All schema changes go through a new migration file.
+
+---
+
+## Schema Evolution Policy
+
+| Table | When created | Retention | Can be deleted by policy? |
+|---|---|---|---|
+| `event_types` | Phase 1 | Permanent | No |
+| `raw_events` | Phase 1 | `DATA_RETENTION_DAYS` | Yes |
+| `events` | Phase 1 | `DATA_RETENTION_DAYS` | Yes (with raw_events) |
+| `source_ips` | Phase 1 | Permanent | No (intelligence asset) |
+| `behavioral_fingerprints` | Phase 6 | Permanent | No (outlives events) |
+| `campaigns` | Phase 6 | Permanent | No (outlives events) |
+| `campaign_events` | Phase 6 | With `events` | Yes (CASCADE) |
+| `ai_analyses` | Phase 5 | Separate (90d default) | Yes |
+| `federation_fingerprints` | Phase 7 | Separate configurable | Yes |
+| `audit_log` | Phase 1 | Separate (90d default) | Yes |
+
+---
+
+*Cross-references: [ARCHITECTURE.md](ARCHITECTURE.md) · [ROADMAP.md](ROADMAP.md) · [MIGRATION_GUIDE.md](MIGRATION_GUIDE.md) · [INGESTION_PIPELINE.md](INGESTION_PIPELINE.md)*

--- a/docs/INGESTION_PIPELINE.md
+++ b/docs/INGESTION_PIPELINE.md
@@ -1,0 +1,465 @@
+# LegionTrap TI — Event Ingestion Pipeline
+
+**Document type:** Implementation blueprint — ingestion API and normalization pipeline
+**Audience:** Engineers, autonomous agents performing Phase 2 work
+**Last reviewed:** 2026-05-23
+**Status:** Design-complete. Describes the system that Phases 2 and 3 implement.
+
+---
+
+## Overview
+
+The ingestion pipeline is the boundary between the outside world and the LegionTrap event store. Everything that enters the system crosses this boundary. Its job is to:
+
+1. Authenticate the sender
+2. Validate the structure of incoming data
+3. Normalize heterogeneous sensor formats into a canonical schema
+4. Enrich with GeoIP and ASN context
+5. Deduplicate against existing records
+6. Persist to SQLite and append to the JSONL replica
+7. Return a structured receipt
+
+This pipeline will be implemented in `app/routers/ingest.py` and `app/utils/`. It depends on the SQLite schema from [DATABASE_SCHEMA.md](DATABASE_SCHEMA.md) being in place (Phase 1).
+
+---
+
+## Endpoint Specification
+
+### `POST /api/ingest`
+
+**Authentication:** API key only (`x-api-key` header). JWT is not appropriate for machine-to-machine sensor ingestion. The existing `require_api_key` dependency is reused.
+
+**Request:**
+```http
+POST /api/ingest
+x-api-key: <API_KEY>
+Content-Type: application/json
+
+{
+  "events": [
+    {
+      "id": "48bd03ac-da86-4a4a-8f21-ec4fb0148b76",
+      "ts": "2025-10-28T18:31:08.354152+00:00",
+      "source": "cowrie",
+      "type": "auth_failed",
+      "data": {
+        "username": "root",
+        "password": "badpass1",
+        "ip": "203.0.113.2"
+      }
+    }
+  ]
+}
+```
+
+**Response — success:**
+```json
+{
+  "batch_id": "uuid",
+  "accepted": 1,
+  "rejected": 0,
+  "duplicate": 0,
+  "errors": []
+}
+```
+
+**Response — partial failure:**
+```json
+{
+  "batch_id": "uuid",
+  "accepted": 498,
+  "rejected": 2,
+  "duplicate": 0,
+  "errors": [
+    {"index": 3, "reason": "missing required field: ts"},
+    {"index": 201, "reason": "invalid ip address: not-an-ip"}
+  ]
+}
+```
+
+**Constraints:**
+- Maximum batch size: 500 events per request
+- Maximum request body: 5 MB (enforced at FastAPI middleware level)
+- Partial batches succeed: if 498 of 500 events are valid, 498 are accepted
+- Never fail an entire batch because of one bad event
+- Rate limit: 1000 requests/minute per API key (via `slowapi`)
+
+---
+
+## Pipeline Stages
+
+```
+POST /api/ingest
+      │
+      ▼
+┌─────────────────────────────────────────┐
+│ Stage 1: Authentication                 │
+│   require_api_key dependency            │
+│   → 401 if missing or invalid           │
+└─────────────────┬───────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────────┐
+│ Stage 2: Input Validation               │
+│   Pydantic RawEvent model               │
+│   → 400 if malformed JSON               │
+│   → 413 if oversized                    │
+│   Missing id → generate UUID            │
+│   Missing ts → reject event             │
+│   Missing type → reject event           │
+└─────────────────┬───────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────────┐
+│ Stage 3: Normalization                  │
+│   extract_src_ip()                      │
+│   normalize_event_type()                │
+│   parse_timestamp()                     │
+│   → produce HoneypotEvent               │
+└─────────────────┬───────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────────┐
+│ Stage 4: Deduplication                  │
+│   SELECT id FROM raw_events WHERE id=?  │
+│   → skip if exists (idempotent)         │
+└─────────────────┬───────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────────┐
+│ Stage 5: GeoIP Enrichment (Phase 3)     │
+│   geoip2 lookup on src_ip               │
+│   → country_code, country_name, city    │
+│   → asn, asn_org                        │
+│   → produce EnrichedEvent               │
+│   (skipped if src_ip is None)           │
+└─────────────────┬───────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────────┐
+│ Stage 6: Persistence                    │
+│   INSERT INTO raw_events                │
+│   INSERT INTO events                    │
+│   UPSERT INTO source_ips               │
+│   APPEND TO storage/events.jsonl        │
+└─────────────────┬───────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────────┐
+│ Stage 7: Audit Log                      │
+│   INSERT INTO audit_log                 │
+│   event_type='ingest_batch'             │
+│   detail={accepted, rejected, batch_id} │
+└─────────────────┬───────────────────────┘
+                  │
+                  ▼
+       Return IngestReceipt response
+```
+
+---
+
+## Normalization Functions
+
+All normalization logic belongs in `app/utils/event_utils.py`. This module has no FastAPI imports and can be unit-tested in isolation.
+
+### `extract_src_ip(event_dict: dict) -> str | None`
+
+Extracts a valid public IPv4 address from an event dictionary using a defined priority order. Returns `None` if no valid public IP is found.
+
+**Priority order:**
+```python
+CANDIDATE_FIELDS = [
+    ("data", "ip"),         # Cowrie nested format
+    ("data", "src_ip"),     # alternative Cowrie/Dionaea
+    ("src_ip",),            # flat format
+    ("ip",),                # minimal flat format
+    ("client_ip",),         # HTTP honeypot format
+    ("source_ip",),         # generic sensor format
+]
+```
+
+For each candidate:
+1. Extract the value from the dict (handling nested paths)
+2. Validate it is a syntactically valid IPv4 address
+3. Validate it is a public IP (not RFC1918, loopback, link-local, or reserved)
+4. If valid, return it
+
+If no candidate yields a valid public IP, return `None`. This is not a validation failure — events without a recoverable IP are accepted and stored with `src_ip=NULL`.
+
+**Important:** This function replaces the broken inline IP extraction in `stats.py` (which searched only top-level fields and returned `0` unique IPs for all real Cowrie events). It is the single canonical source of IP extraction logic.
+
+### `normalize_event_type(raw_type: str, source: str) -> str`
+
+Maps sensor-specific event type strings to canonical `event_types.id` values.
+
+```python
+TYPE_MAP = {
+    "cowrie": {
+        "cowrie.login.failed": "auth_failed",
+        "cowrie.login.success": "auth_success",
+        "cowrie.command.input": "command_exec",
+        "cowrie.session.file_upload": "malware_upload",
+    },
+    "dionaea": {
+        "dionaea.connection.free": "port_scan",
+    }
+}
+
+def normalize_event_type(raw_type: str, source: str) -> str:
+    return TYPE_MAP.get(source, {}).get(raw_type, raw_type.lower().replace(".", "_"))
+```
+
+If a type is not in the map, it is lowercased and dots replaced with underscores. Unknown types are stored as-is; they can always be re-mapped later by updating the `event_types` table.
+
+### `parse_timestamp(ts_value: Any) -> datetime | None`
+
+Parses timestamps in multiple formats (ISO8601 with and without timezone, Unix timestamps). Returns a timezone-aware UTC datetime or `None` if unparseable.
+
+```python
+def parse_timestamp(ts_value: Any) -> datetime | None:
+    if ts_value is None:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(ts_value).replace("Z", "+00:00"))
+        return dt.astimezone(timezone.utc)
+    except (ValueError, TypeError):
+        return None
+```
+
+---
+
+## Pydantic Models
+
+Full model definitions are in [DATABASE_SCHEMA.md](DATABASE_SCHEMA.md). The ingestion pipeline uses:
+
+### `RawEvent` — input validation boundary
+
+```python
+class RawEvent(BaseModel):
+    model_config = ConfigDict(extra="allow")  # accept any field from any sensor
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    ts: str                      # validated to parseable datetime in normalization
+    source: str
+    type: str
+    data: dict[str, Any] = Field(default_factory=dict)
+```
+
+`extra="allow"` — accept unknown fields without rejection. LegionTrap stores them in `raw_json` and ignores them during normalization. This is intentional: sensors evolve; the ingestion boundary must not break when a sensor adds a new field.
+
+### `HoneypotEvent` — post-normalization canonical form
+
+```python
+class HoneypotEvent(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    ts: datetime
+    ingested_at: datetime   # written to raw_events.ingested_at; not in the events table
+    source: str             # written to raw_events.source; not in the events table
+    event_type: str
+    src_ip: str | None = None
+    dst_port: int | None = None
+    protocol: str | None = None
+    service: str | None = None
+    schema_version: int = 1
+```
+
+`ingested_at` and `source` are carried on `HoneypotEvent` so the pipeline can populate `raw_events` from a single object, but `insert_event()` writes only the columns present in the `events` table (see DATABASE_SCHEMA.md). The Phase 3 `EnrichedEvent` extends this model with `country_code`, `country_name`, `city`, `asn`, and `asn_org` fields.
+
+### `IngestRequest` — request body wrapper
+
+```python
+class IngestRequest(BaseModel):
+    events: list[RawEvent] = Field(..., min_length=1, max_length=500)
+```
+
+### `IngestReceipt` — response
+
+```python
+class IngestReceipt(BaseModel):
+    batch_id: str
+    accepted: int
+    rejected: int
+    duplicate: int
+    errors: list[dict[str, Any]] = Field(default_factory=list)
+```
+
+---
+
+## Repository Interface
+
+`app/db/repository.py` will expose the storage methods the ingestion pipeline calls. No SQL appears outside this file.
+
+```python
+class EventRepository:
+
+    def insert_raw_event(self, raw: RawEvent) -> None:
+        """Insert into raw_events. Raises IntegrityError on duplicate id."""
+
+    def insert_event(self, event: HoneypotEvent | EnrichedEvent) -> None:
+        """Insert into events table."""
+
+    def upsert_source_ip(self, ip: str, ts: datetime, country_code: str | None,
+                         country_name: str | None, asn: int | None,
+                         asn_org: str | None) -> None:
+        """UPSERT into source_ips, incrementing event_count."""
+
+    def event_exists(self, event_id: str) -> bool:
+        """Return True if event_id already exists in raw_events."""
+
+    # Read methods (used by existing routers after Phase 1 migration to SQLite)
+
+    def get_stats(self) -> dict:
+        """Return total_events, unique_ips, last_24h counts."""
+
+    def list_events(self, limit: int = 100, offset: int = 0) -> list[dict]:
+        """Return most recent events, newest first."""
+
+    def get_unique_public_ips(self) -> list[str]:
+        """Return sorted list of unique public source IPs (for IOC export)."""
+```
+
+---
+
+## GeoIP Enrichment (Phase 3)
+
+GeoIP enrichment runs synchronously during ingestion. `GeoLite2-City.mmdb` is present in `storage/` and the `geoip2` library is already installed. `GeoLite2-ASN.mmdb` must be downloaded separately from MaxMind (free registration required) and placed in `storage/` before ASN enrichment will function.
+
+```python
+# app/utils/geoip.py
+
+import geoip2.database
+from pathlib import Path
+
+_city_reader = None
+_asn_reader = None
+
+def get_city_reader():
+    global _city_reader
+    if _city_reader is None:
+        _city_reader = geoip2.database.Reader("storage/GeoLite2-City.mmdb")
+    return _city_reader
+
+def enrich_ip(ip: str) -> dict:
+    """Return country_code, country_name, city, asn, asn_org for a public IP."""
+    result = {}
+    try:
+        city = get_city_reader().city(ip)
+        result["country_code"] = city.country.iso_code
+        result["country_name"] = city.country.name
+        result["city"] = city.city.name
+    except Exception:
+        pass
+    # ASN lookup omitted until GeoLite2-ASN.mmdb is confirmed present
+    return result
+```
+
+GeoIP lookup is a local file read — sub-millisecond, no network call, no privacy concern. It can run synchronously without meaningful performance impact.
+
+---
+
+## Deduplication
+
+Deduplication is based on the `id` field in `raw_events`. The check is a primary key lookup:
+
+```python
+def event_exists(self, event_id: str) -> bool:
+    row = self.conn.execute(
+        "SELECT 1 FROM raw_events WHERE id = ? LIMIT 1", (event_id,)
+    ).fetchone()
+    return row is not None
+```
+
+If an event with the same `id` arrives again (sensor retry, re-import of JSONL), it is silently skipped and counted in `duplicate` in the receipt. The batch continues processing remaining events.
+
+---
+
+## Error Handling
+
+### Validation failure
+A `RawEvent` that fails Pydantic validation is rejected. The index of the failing event in the request batch, plus the validation error message, are included in the `errors` array of the response. Processing continues with the next event.
+
+### IP extraction failure
+If `extract_src_ip()` finds no valid public IP, the event is accepted with `src_ip=NULL`. This is not a rejection — many valid events lack a source IP.
+
+### GeoIP failure
+If the GeoIP database lookup raises any exception (IP not in database, corrupted database), the enrichment is silently skipped. The event is accepted with `NULL` GeoIP fields. GeoIP failures must not cause ingestion failures.
+
+### Database error
+If the SQLite insert fails (disk full, I/O error, schema mismatch), the exception propagates to a 500 response for the entire batch. This is the only scenario that fails a whole batch. The JSONL append is not performed if the database write fails — the replica must not diverge from the database.
+
+### Timestamp failure
+If `parse_timestamp()` returns `None` (unparseable `ts` field), the event is rejected. Timestamp is a required field for the time-series queries the system depends on.
+
+---
+
+## Security Considerations
+
+### API key only — no JWT for ingestion
+
+Sensor processes (cron jobs, scripts, honeypot processes) must use API key authentication for `POST /api/ingest`. JWT tokens are short-lived (1 hour) and require a login flow — inappropriate for long-running sensor processes. API keys are persistent and suitable for machine-to-machine use.
+
+This is enforced at the route level:
+```python
+@router.post("/api/ingest", dependencies=[Depends(require_api_key)])
+```
+
+### `data.password` must not be extracted
+
+Real Cowrie events include attacker-submitted credentials in `data.password` and `data.username`. These fields:
+- Are stored verbatim in `raw_events.raw_json`
+- Must **not** be extracted to the `events` table
+- Must **not** appear in API responses
+- Must **not** appear in AI prompts
+- Are attacker-controlled strings and must be treated as untrusted content
+
+The normalization pipeline must explicitly exclude `data.password` from the fields it examines.
+
+### Prompt injection via event data
+
+Attacker-controlled strings in event data (usernames, passwords, User-Agent strings) could contain prompt injection content if they reach an AI prompt. Mitigation:
+
+- The normalization pipeline extracts only typed, structured fields (`src_ip`, `event_type`, `ts`, `dst_port`, `protocol`) — not free-text attacker content
+- The AI context builder (Phase 5) uses pre-aggregated SQL summaries, not raw event field values
+- `data.password` and `data.username` are never included in AI prompts under any circumstances
+
+### Rate limiting
+
+`slowapi` rate limiter is applied to `POST /api/ingest` at 1000 requests/minute per API key. This prevents a misconfigured sensor from overwhelming the ingestion endpoint. Rate limits on `/api/login` (5 req/min per IP) are separate and must be implemented simultaneously.
+
+---
+
+## JSONL Append Replica
+
+After every successful SQLite write, the normalized event is appended to `storage/events.jsonl`:
+
+```python
+def _append_to_jsonl_replica(event: HoneypotEvent) -> None:
+    with open("storage/events.jsonl", "a", encoding="utf-8") as f:
+        f.write(event.model_dump_json() + "\n")
+```
+
+This append is best-effort: if it fails (disk full, permissions error), it is logged but does not cause the ingest to fail. The database write is the authoritative action; the JSONL write is the safety net.
+
+---
+
+## Testing Requirements
+
+Before Phase 2 is considered complete, the following tests must pass:
+
+| Test | Assertion |
+|---|---|
+| `test_ingest_single_cowrie_event` | POST a real Cowrie event; assert 200, `accepted=1`, event in database |
+| `test_ingest_extracts_nested_ip` | POST `{"data": {"ip": "1.2.3.4"}}` event; assert `src_ip="1.2.3.4"` in events table |
+| `test_ingest_batch_partial_failure` | POST 5 events, 1 missing `ts`; assert `accepted=4, rejected=1, errors=[...]` |
+| `test_ingest_deduplication` | POST same event twice; assert `accepted=1, duplicate=1` on second call |
+| `test_ingest_oversized_batch` | POST 501 events; assert 422 or 413 |
+| `test_ingest_requires_api_key` | POST without `x-api-key`; assert 401 |
+| `test_ingest_jwt_rejected` | POST with Bearer JWT only; assert 401 |
+| `test_password_not_in_events_table` | POST Cowrie event with password; assert `data.password` not in events row |
+| `test_stats_after_ingest_shows_ip` | Ingest event with IP; assert `GET /api/stats` returns `unique_ips >= 1` |
+
+---
+
+*Cross-references: [DATABASE_SCHEMA.md](DATABASE_SCHEMA.md) · [MIGRATION_GUIDE.md](MIGRATION_GUIDE.md) · [AI_REASONING_ARCHITECTURE.md](AI_REASONING_ARCHITECTURE.md) · [ARCHITECTURE.md](ARCHITECTURE.md) · [ROADMAP.md](ROADMAP.md)*

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -1,0 +1,302 @@
+# LegionTrap TI — Migration Guide
+
+**Document type:** Implementation blueprint — JSONL-to-SQLite migration procedure
+**Audience:** Engineers, operators, autonomous agents performing Phase 1 work
+**Last reviewed:** 2026-05-23
+**Status:** Design-complete. Describes the migration that Phase 1 implements.
+
+---
+
+## Overview
+
+LegionTrap currently stores events in a JSONL flat file (`storage/events.jsonl`). This guide describes the migration from that storage to SQLite, covering:
+
+- Why the migration happens at this point in the roadmap
+- What happens to existing JSONL data
+- How the migration is executed safely
+- How to verify the migration succeeded
+- How to roll back if something goes wrong
+- What operators upgrading from a JSONL deployment need to do
+
+This migration is a **prerequisite** for all AI features, behavioral memory, campaign detection, and federation. It must be completed before Phase 2 (ingestion API) begins.
+
+---
+
+## Prerequisites
+
+Before running any migration step, verify:
+
+- [ ] Phase 0 security items are complete (bcrypt password, CORS restricted, no hardcoded defaults)
+- [ ] `DB_PATH` is set in `.env` (or defaults to `storage/legiontrap.db`)
+- [ ] `storage/` directory exists and is writable
+- [ ] `storage/events.jsonl` exists (may be empty or contain historical events)
+- [ ] Alembic is installed: `.venv/bin/alembic --version`
+- [ ] A backup of `storage/events.jsonl` exists before migration begins
+
+---
+
+## What Happens to the JSONL File
+
+**The JSONL file is never deleted.**
+
+After migration it transitions from the primary data store to two ongoing roles:
+
+1. **Append-only replica:** After every successful ingest via `POST /api/ingest`, the normalized event is also appended to `storage/events.jsonl`. The file remains a consistent recovery point. If the SQLite database is lost or corrupted, it can be fully reconstructed by re-importing the JSONL file.
+
+2. **Import/export format:** External tools (Cowrie, Dionaea, other sensors) that write directly to the JSONL file continue to work during the transition. A background JSONL watcher (Phase 2+) will pick up new lines and ingest them into SQLite.
+
+The file is the safety net. It must never be removed.
+
+---
+
+## Migration Architecture
+
+```
+BEFORE MIGRATION                    AFTER MIGRATION
+─────────────────────────────       ─────────────────────────────────────────
+storage/events.jsonl                storage/events.jsonl  (append-only replica)
+    │                                   │
+    │  read on every request             │  append on every ingest
+    ▼                                   ▼
+FastAPI routers                     storage/legiontrap.db  (primary store)
+(full file scan per call)               │
+                                        │  indexed SQL queries
+                                        ▼
+                                    FastAPI routers via EventRepository
+                                    (sub-millisecond queries with indexes)
+```
+
+---
+
+## Step-by-Step Migration Procedure
+
+### Step 1: Install Alembic and initialize migrations
+
+```bash
+# Alembic is added to requirements.txt during Phase 1
+pip install alembic
+
+# Initialize the Alembic environment in the project
+alembic init app/db/migrations
+
+# alembic.ini is created at project root
+# app/db/migrations/env.py is created — update it to point at legiontrap metadata
+```
+
+`alembic.ini` database URL:
+```ini
+sqlalchemy.url = sqlite:///storage/legiontrap.db
+```
+
+For test environments, read `DB_PATH` from the environment in `app/db/migrations/env.py`:
+```python
+import os
+db_path = os.environ.get("DB_PATH", "storage/legiontrap.db")
+config.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+```
+
+Set `DB_PATH=storage/legiontrap-test.db` before running `alembic upgrade head` in CI.
+
+### Step 2: Apply the initial schema migration
+
+```bash
+alembic upgrade head
+```
+
+This creates all Phase 1 tables: `event_types`, `raw_events`, `events`, `source_ips`, `audit_log`. It also seeds `event_types` with the initial taxonomy values.
+
+Verify the database was created:
+```bash
+sqlite3 storage/legiontrap.db ".tables"
+# Expected: audit_log  event_types  events  raw_events  source_ips
+```
+
+### Step 3: Import existing JSONL data
+
+```bash
+python -m app.tools.import_jsonl storage/events.jsonl
+```
+
+If additional archived JSONL files exist (e.g., `storage/events-20251028-183613.jsonl`), import each:
+```bash
+python -m app.tools.import_jsonl storage/events-20251028-183613.jsonl
+python -m app.tools.import_jsonl storage/events-20251028-181245.jsonl
+```
+
+The import tool:
+- Reads each line of the JSONL file
+- Validates against `RawEvent` Pydantic schema
+- Normalizes to `HoneypotEvent` (extracts `src_ip` from nested fields)
+- Inserts into `raw_events` and `events` (upserts by `id` — safe to re-run)
+- Upserts `source_ips` for each extracted IP
+- Writes failures to `storage/import_errors.jsonl` (not silently dropped)
+- Reports: events accepted, events skipped (duplicate), events failed
+
+**Expected output for a 8,000-event file:**
+```
+Importing: storage/events-20251028-183613.jsonl
+  Accepted:  8000
+  Duplicate: 0
+  Failed:    0
+Import complete. Database: storage/legiontrap.db
+```
+
+### Step 4: Verify import correctness
+
+Run the verification query:
+```bash
+python -m app.tools.verify_migration storage/events-20251028-183613.jsonl
+```
+
+The verify tool counts lines in the JSONL file and rows in SQLite and asserts they match. It also checks that `unique_ips` in SQLite matches the count from `iocs_pf.py`'s recursive IP extraction.
+
+### Step 5: Switch read endpoints to SQLite
+
+This is a code change, not a database change. The router implementations are updated to call `EventRepository` methods instead of reading the JSONL file. See [INGESTION_PIPELINE.md](INGESTION_PIPELINE.md) for the repository interface.
+
+The API response shapes do not change. Existing clients (dashboard, pfSense scripts) continue working without modification.
+
+### Step 6: Smoke test the migrated endpoints
+
+```bash
+# Stats endpoint — verify counts match pre-migration values
+curl -H "x-api-key: $API_KEY" http://localhost:8088/api/stats
+
+# Events endpoint — verify newest-first ordering preserved
+curl -H "x-api-key: $API_KEY" "http://localhost:8088/api/events?limit=5"
+
+# IOC export — verify IP list matches pre-migration output
+curl -H "x-api-key: $API_KEY" http://localhost:8088/api/iocs/pf.conf
+```
+
+Compare output against baseline captured before the migration.
+
+### Step 7: Enable JSONL append replica
+
+After confirming the migrated endpoints work correctly, enable the write-through replica in the ingestion pipeline. Every event written to SQLite is simultaneously appended to `storage/events.jsonl`.
+
+---
+
+## Import Tool Specification
+
+`app/tools/import_jsonl.py` is a command-line tool, not a library. It must not be imported by application code.
+
+```
+usage: python -m app.tools.import_jsonl <path> [--dry-run] [--batch-size N]
+
+positional arguments:
+  path              Path to JSONL file to import
+
+options:
+  --dry-run         Parse and validate without inserting (shows what would be imported)
+  --batch-size N    Rows per SQLite transaction (default: 500)
+  --errors-file F   Path for import error log (default: storage/import_errors.jsonl)
+```
+
+**Idempotency:** The import tool uses `INSERT OR IGNORE` on `raw_events` (primary key is the event `id`). Running the same file twice produces the same database state. This means JSONL files can be re-imported after schema changes without risk of duplication.
+
+**Error handling:** Events that fail Pydantic validation are not silently discarded. Each failure is written to the errors file with the original line and the validation error. The import continues — one bad event does not abort the batch.
+
+---
+
+## Handling the Existing Event Schema Mismatch
+
+The real Cowrie events in `storage/events-20251028-183613.jsonl` have this structure:
+
+```json
+{
+  "id": "48bd03ac-da86-4a4a-8f21-ec4fb0148b76",
+  "ts": "2025-10-28T18:31:08.354152+00:00",
+  "source": "cowrie",
+  "type": "auth_failed",
+  "data": {
+    "username": "root",
+    "password": "px1",
+    "ip": "203.0.113.2"
+  }
+}
+```
+
+The IP is nested inside `data.ip`. The import tool's `extract_src_ip()` function (in `app/utils/event_utils.py`) uses this priority order to find it:
+
+```
+data.ip → data.src_ip → src_ip → ip → client_ip → source_ip
+```
+
+The `data.password` field is intentionally **not** extracted to the `events` table. It remains in `raw_events.raw_json` (the verbatim JSON archive) and is never surfaced through any API endpoint. It is attacker-controlled content and must not appear in AI prompts, IOC exports, or dashboard responses.
+
+---
+
+## Rollback Plan
+
+SQLite is a single file. Rollback is:
+
+```bash
+# 1. Stop the application
+# 2. Rename or delete the database
+mv storage/legiontrap.db storage/legiontrap.db.bak
+
+# 3. Set STORAGE_BACKEND=jsonl in .env (if the env var is implemented)
+#    OR revert the router code to JSONL file reading
+# 4. Restart the application
+```
+
+The JSONL file was never modified during migration. It is the complete event history. Full rollback takes under 30 seconds.
+
+**The JSONL replica ensures the rollback path is always available.** As long as the replica write is working, no event that reached the SQLite database is unavailable in the JSONL file.
+
+---
+
+## Operator Upgrade Procedure (Existing Deployments)
+
+For operators upgrading from a JSONL-only deployment to the SQLite-backed version:
+
+1. **Stop the application**
+2. **Back up `storage/events.jsonl`** to a safe location
+3. **Update the application** (git pull or image pull)
+4. **Install new dependencies:** `pip install -r requirements.txt`
+5. **Run the migration:** `alembic upgrade head`
+6. **Import existing events:** `python -m app.tools.import_jsonl storage/events.jsonl`
+7. **Verify the import:** `python -m app.tools.verify_migration storage/events.jsonl`
+8. **Start the application**
+9. **Smoke test** the API endpoints
+10. **Monitor `storage/import_errors.jsonl`** for any events that failed validation
+
+The migration is additive. No data is destroyed. The original JSONL file is preserved.
+
+---
+
+## Post-Migration Verification Queries
+
+After migration, these queries can be run directly against the database to verify correctness:
+
+```sql
+-- Total event count (should match JSONL line count)
+SELECT COUNT(*) FROM events;
+
+-- Unique source IPs (should match iocs_pf.py output before migration)
+SELECT COUNT(DISTINCT src_ip) FROM events WHERE src_ip IS NOT NULL;
+
+-- Events by source (should show 'cowrie' for the test data)
+SELECT source, COUNT(*) FROM raw_events GROUP BY source;
+
+-- Events by type (should show 'auth_failed: 8000' for test data)
+SELECT event_type, COUNT(*) FROM events GROUP BY event_type ORDER BY COUNT(*) DESC;
+
+-- IP not extracted (events where normalization could not find an IP)
+SELECT COUNT(*) FROM events WHERE src_ip IS NULL;
+```
+
+The last query is particularly important. Before migration, `stats.py` returned `unique_ips: 0` for real Cowrie events because it searched only top-level fields. After migration with the corrected `extract_src_ip()` logic, `unique_ips` should reflect the actual number of distinct attacking IPs.
+
+---
+
+## Known Limitations
+
+**No concurrent write migration.** The import tool is a single-threaded sequential importer. It is not designed for live migration of a continuously-written JSONL file. The recommended procedure is to stop the application during import, then restart pointing at SQLite.
+
+**JSONL watcher not in Phase 1.** The file-watcher that picks up new lines appended by sensors directly to the JSONL file is a Phase 2 concern. During Phase 1, all event writes must go through `POST /api/ingest`. Sensors that write directly to the JSONL file will need to be reconfigured to use the HTTP API, or the watcher must be implemented before sensors are updated.
+
+---
+
+*Cross-references: [DATABASE_SCHEMA.md](DATABASE_SCHEMA.md) · [INGESTION_PIPELINE.md](INGESTION_PIPELINE.md) · [ARCHITECTURE.md](ARCHITECTURE.md) · [ROADMAP.md](ROADMAP.md)*

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 **Document type:** Documentation index and navigation guide
 **Audience:** Engineers, contributors, autonomous agents, new maintainers
-**Last reviewed:** 2026-05-22
+**Last reviewed:** 2026-05-23
 
 ---
 
@@ -61,6 +61,12 @@ Layer 2: Technical Architecture
   AI_ROADMAP.md      — AI integration stages and prerequisites
   FEDERATION_VISION.md — Federation protocol design
 
+Layer 2b: Implementation Blueprints (Phase 1–5)
+  DATABASE_SCHEMA.md         — Canonical SQL schema; all tables, indexes, seed data
+  MIGRATION_GUIDE.md         — JSONL→SQLite migration procedure; Alembic setup; import tool
+  INGESTION_PIPELINE.md      — POST /api/ingest specification; normalization; deduplication
+  AI_REASONING_ARCHITECTURE.md — Retrieval-then-reason pattern; SQL context queries; prompt design
+
 Layer 3: Operational and Conceptual Reference
   BEHAVIORAL_INTELLIGENCE.md — Core concept: behavioral fingerprinting and campaign memory
   SECURITY_AUDIT.md          — Known vulnerabilities, severity ratings, remediation plan
@@ -93,6 +99,10 @@ These documents define how the system is built and how it will evolve. They chan
 | `ROADMAP.md` | Technical | Phases 0–7 with exit criteria, sequencing rationale, and anti-patterns to avoid |
 | `AI_ROADMAP.md` | Technical | AI integration in 6 stages; backend options; privacy constraints; risk table |
 | `FEDERATION_VISION.md` | Technical | Privacy-preserving fingerprint federation; trust tiers; protocol design; privacy attack analysis |
+| `DATABASE_SCHEMA.md` | Blueprint | Canonical SQL schema; all tables, indexes, Alembic migration names, seed data, retention policy |
+| `MIGRATION_GUIDE.md` | Blueprint | Step-by-step JSONL→SQLite migration; import tool spec; Alembic env.py setup; rollback plan |
+| `INGESTION_PIPELINE.md` | Blueprint | `POST /api/ingest` spec; normalization functions; deduplication; Pydantic models; repository interface |
+| `AI_REASONING_ARCHITECTURE.md` | Blueprint | Retrieval-then-reason design; 7 context SQL queries; prompt structure; privacy rules; backend config |
 
 ### Operational and Conceptual Documents
 
@@ -143,11 +153,11 @@ Required: `SECURITY_AUDIT.md` → `ARCHITECTURE.md` → `AUTONOMOUS_OPERATIONS.m
 | Phase | Focus | Primary Document | Supporting Documents |
 |---|---|---|---|
 | Phase 0 | Security hygiene | `SECURITY_AUDIT.md` | `ARCHITECTURE.md` |
-| Phase 1 | SQLite storage | `ARCHITECTURE.md` | `ROADMAP.md` |
-| Phase 2 | Ingestion API | `ROADMAP.md` | `ARCHITECTURE.md` |
-| Phase 3 | GeoIP enrichment | `ROADMAP.md` | `ARCHITECTURE.md` |
-| Phase 4 | ATT&CK / standard exports | `ROADMAP.md` | `BEHAVIORAL_INTELLIGENCE.md` |
-| Phase 5 | First AI integration | `AI_ROADMAP.md` | `ROADMAP.md` |
+| Phase 1 | SQLite storage | `DATABASE_SCHEMA.md` | `MIGRATION_GUIDE.md`, `ARCHITECTURE.md` |
+| Phase 2 | Ingestion API | `INGESTION_PIPELINE.md` | `DATABASE_SCHEMA.md`, `ROADMAP.md` |
+| Phase 3 | GeoIP enrichment | `INGESTION_PIPELINE.md` | `DATABASE_SCHEMA.md` |
+| Phase 4 | ATT&CK / standard exports | `DATABASE_SCHEMA.md` | `BEHAVIORAL_INTELLIGENCE.md` |
+| Phase 5 | First AI integration | `AI_REASONING_ARCHITECTURE.md` | `AI_ROADMAP.md`, `ROADMAP.md` |
 | Phase 6 | Behavioral memory | `BEHAVIORAL_INTELLIGENCE.md` | `AI_ROADMAP.md` |
 | Phase 7 | Federation | `FEDERATION_VISION.md` | `BEHAVIORAL_INTELLIGENCE.md` |
 


### PR DESCRIPTION
## Summary

Four implementation blueprint documents covering the full Phase 1–5 design
surface of the LegionTrap TI intelligence platform. `docs/README.md` updated
with the new Layer 2b Blueprint tier, corrected Roadmap Phase→Document Map,
and a Blueprint classification in the document table.

No application code was modified. No tests were changed. No runtime files
were touched.

---

## Documents Added

### `DATABASE_SCHEMA.md`
Canonical SQL schema reference for all Phase 1–7 tables. Covers:
- Full DDL for `event_types`, `raw_events`, `events`, `source_ips`, `audit_log` (Phase 1)
- GeoIP fields added by Phase 3 migration
- Behavioral intelligence tables (`behavioral_fingerprints`, `campaigns`, `campaign_events`) — Phase 6
- AI analysis results table (`ai_analyses`) — Phase 5
- Federation fingerprint table (`federation_fingerprints`) — Phase 7
- Alembic migration naming convention; schema evolution policy with retention rules
- Design note: `campaign_id` FK omitted from Phase 1 DDL (campaigns table doesn't exist yet); added in Phase 6 via `ALTER TABLE` to maintain PostgreSQL compatibility

### `MIGRATION_GUIDE.md`
Step-by-step procedure for migrating from the current JSONL flat-file store to SQLite. Covers:
- 7-step migration procedure (Alembic init → schema apply → JSONL import → verify → router switch → smoke test → enable replica)
- Import tool specification (`app/tools/import_jsonl.py`) with `--dry-run`, `--batch-size`, `--errors-file` options
- Idempotent import via `INSERT OR IGNORE`; failures written to `import_errors.jsonl`, not silently dropped
- Rollback plan (single-file database; 30-second rollback)
- Operator upgrade procedure for existing JSONL deployments
- Alembic `env.py` pattern for reading `DB_PATH` from environment (corrected from misleading `alembic.ini` approach)

### `INGESTION_PIPELINE.md`
Full specification for `POST /api/ingest`. Covers:
- 7-stage pipeline diagram (auth → validation → normalization → deduplication → GeoIP → persistence → audit)
- Pydantic models: `RawEvent` (input, `extra="allow"`), `HoneypotEvent` (canonical), `IngestRequest`, `IngestReceipt`
- `extract_src_ip()` with priority order `data.ip → data.src_ip → src_ip → ip → client_ip → source_ip`; fixes the broken top-level-only extraction in `stats.py`
- `normalize_event_type()` TYPE_MAP for Cowrie and Dionaea sensor formats
- Repository interface for `EventRepository` with all read/write methods
- Security constraints: `data.password` never extracted; API-key-only auth for machine-to-machine ingestion; slowapi rate limiting (1000 req/min per key)
- GeoIP enrichment: `GeoLite2-City.mmdb` present; `GeoLite2-ASN.mmdb` must be downloaded from MaxMind separately
- 9 required tests with exact assertions

### `AI_REASONING_ARCHITECTURE.md`
Retrieval-then-reason AI architecture for Phase 5+. Covers:
- 11-step reasoning pipeline (intent parsing → SQL retrieval → context serialization → privacy filtering → prompt construction → AI call → parsing → citation grounding → persistence → response)
- 7 named context SQL queries (`ctx_event_summary`, `ctx_top_event_types`, `ctx_top_asns`, `ctx_top_countries`, `ctx_timing_distribution`, `ctx_new_vs_returning_ips`, `ctx_active_campaigns`)
- Prompt architecture: constant system prompt + structured context block + output schema
- `AI_BACKEND=claude|ollama|none` configuration; graceful degradation when `none`
- `AI_PRIVACY_MODE` defaulting to `PRIVACY_MODE` for independent control of AI prompt vs. IOC export privacy
- `POST /api/analyze` request/response specification
- Behavioral memory integration for Phase 6+ campaign context blocks
- Implementation file map (`app/routers/analyze.py`, `app/services/`, `app/models/`)
- 7 required tests; AI backend integration tests skipped in CI unless `AI_BACKEND` is set

---

## Architectural Goals

- Establish the single authoritative schema reference before Phase 1 implementation begins
- Prevent the `stats.py` IP extraction bug from being reproduced in the ingestion pipeline
- Define the `HoneypotEvent` canonical model before any code references it
- Lock in PostgreSQL-compatible DDL decisions before SQLite schemas accumulate tech debt
- Ground AI reasoning in SQL-aggregated context, not raw event content

---

## Consistency Review Summary

Two validation passes were performed:

**Pass 1** — Corrected 9 issues: date stamps, present-tense implementation claims,
`GeoLite2-ASN.mmdb` false presence claim, Alembic env var override approach,
AI_REASONING prerequisites incomplete, README missing new docs.

**Pass 2** — Corrected 5 issues against reference docs: migration file numbering
reversed (Phase 6 before Phase 5), `campaign_id` FK to non-existent `campaigns`
table in Phase 1 DDL (PostgreSQL incompatible), two instances of "Phase 4
migration" that should be "Phase 1 migration" (per ROADMAP.md), and
`HoneypotEvent` fields `ingested_at`/`source` not mapped to `events` table
without explanation.

---

## Risks

- None to existing functionality (documentation only)
- Blueprint documents make specific implementation commitments (schema, model names,
  endpoint signatures); future Phase 1 implementation must conform to these specifications

## Rollback Plan

If blueprints need revision before Phase 1 implementation: update docs on a new
`docs/` branch and merge. No code to roll back.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)