### PR TITLE
feat: Phase 2 PR 2 — source IP caching lifecycle, scoring, and tagging

### DIFF
--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -17,6 +17,7 @@ No FastAPI, router, or application imports belong in this module.
 
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -317,3 +318,79 @@ class EventRepository:
             {"cutoff": cutoff.isoformat()},
         )
         return deleted
+
+    # ------------------------------------------------------------------
+    # Phase 2 — intelligence enrichment cache and scoring
+    # ------------------------------------------------------------------
+
+    def get_source_ip_geo(self, ip: str) -> dict | None:
+        """
+        Return cached geo fields for ip if source_ips row exists and
+        country_code is populated. Returns None on cache miss (unknown IP
+        or NULL country_code). Keys: country_code, country_name, asn, asn_org.
+        Used by Stage 3.5 of ingest to skip the GeoIP file read for known IPs.
+        """
+        row = self._session.execute(
+            text("""
+                SELECT country_code, country_name, asn, asn_org
+                FROM source_ips
+                WHERE ip = :ip AND country_code IS NOT NULL
+                """),
+            {"ip": ip},
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "country_code": row[0],
+            "country_name": row[1],
+            "asn": row[2],
+            "asn_org": row[3],
+        }
+
+    def get_source_ip_event_types(self, ip: str) -> list[str]:
+        """Return distinct normalized event_type values seen from ip."""
+        rows = self._session.execute(
+            text("SELECT DISTINCT event_type FROM events WHERE src_ip = :ip"),
+            {"ip": ip},
+        ).fetchall()
+        return [row[0] for row in rows]
+
+    def get_source_ip_intelligence(self, ip: str) -> dict | None:
+        """
+        Return {tags: list[str], event_count: int} for ip from source_ips.
+        Used as scoring input after upsert_source_ip. Returns None if ip not found.
+        Malformed tags JSON is treated as an empty list.
+        """
+        row = self._session.execute(
+            text("SELECT event_count, tags FROM source_ips WHERE ip = :ip"),
+            {"ip": ip},
+        ).fetchone()
+        if row is None:
+            return None
+        event_count, tags_json = row
+        try:
+            tags: list[str] = json.loads(tags_json) if tags_json else []
+        except (ValueError, TypeError):
+            tags = []
+        return {"event_count": event_count, "tags": tags}
+
+    def update_source_ip_intelligence(
+        self,
+        ip: str,
+        tags: list[str],
+        reputation_score: float,
+    ) -> None:
+        """Update tags and reputation_score on an existing source_ips row.
+
+        tags is serialized as a sorted JSON array. No-op if ip is not in
+        source_ips (should not occur in normal operation — always called
+        after upsert_source_ip).
+        """
+        self._session.execute(
+            text("""
+                UPDATE source_ips
+                SET tags = :tags, reputation_score = :score
+                WHERE ip = :ip
+                """),
+            {"ip": ip, "tags": json.dumps(tags), "score": reputation_score},
+        )

--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -40,6 +40,7 @@ from app.schemas.models import (
 )
 from app.utils.event_utils import extract_src_ip, normalize_event_type, parse_timestamp
 from app.utils.geoip import enrich_ip
+from app.utils.scoring import compute_reputation_score, compute_tags
 
 router = APIRouter()
 
@@ -112,8 +113,12 @@ def ingest_events(
             event_type = normalize_event_type(raw.type, raw.source)
             src_ip = extract_src_ip(raw.model_dump())
 
-            # Stage 3.5: GeoIP enrichment (best-effort; never blocks ingest)
-            geo = enrich_ip(src_ip) if src_ip else None
+            # Stage 3.5: GeoIP enrichment (cache-first; never blocks ingest)
+            geo: dict | None = None
+            if src_ip:
+                geo = repo.get_source_ip_geo(src_ip)  # cache hit → skip file read
+                if geo is None:
+                    geo = enrich_ip(src_ip)  # cache miss → local mmdb lookup
 
             # Construct canonical event object
             if geo is not None:
@@ -159,6 +164,20 @@ def ingest_events(
                 sp.rollback()
                 duplicate += 1
                 continue
+
+            # Stage 5.5: intelligence scoring (best-effort; isolated via SAVEPOINT)
+            # Failure here must never block ingest — the event is already committed.
+            if src_ip:
+                score_sp = session.begin_nested()
+                try:
+                    intel = repo.get_source_ip_intelligence(src_ip)
+                    if intel is not None:
+                        new_tags = compute_tags(intel["tags"], event_type)
+                        new_score = compute_reputation_score(new_tags, intel["event_count"])
+                        repo.update_source_ip_intelligence(src_ip, new_tags, new_score)
+                    score_sp.commit()
+                except Exception:
+                    score_sp.rollback()
 
             # Stage 6: JSONL replica (best-effort; only after DB commit)
             # TODO: remove _append_jsonl() once all consumers migrate to the SQLite API.

--- a/app/utils/scoring.py
+++ b/app/utils/scoring.py
@@ -1,0 +1,74 @@
+"""
+Intelligence scoring and tagging for LegionTrap TI.
+
+Pure functions — no database imports, no FastAPI, no external I/O.
+Rules sourced from docs/PHASE_2_BLUEPRINT.md sections 10 and 11.
+Thresholds and tag mappings are defined as module-level constants so they
+can be adjusted without touching the calling code.
+"""
+
+from __future__ import annotations
+
+# Maps normalized event_type → intelligence tag.
+# Multiple event_types may map to the same tag (e.g., port_scan and http_probe → scanner).
+_EVENT_TYPE_TO_TAG: dict[str, str] = {
+    "auth_failed": "brute-force",
+    "auth_success": "auth-success",
+    "port_scan": "scanner",
+    "http_probe": "scanner",
+    "command_exec": "command-exec",
+    "malware_upload": "malware",
+}
+
+# Scoring weight for each tag (additive, capped at 1.0).
+_TAG_WEIGHTS: dict[str, float] = {
+    "brute-force": 0.3,
+    "scanner": 0.2,
+    "command-exec": 0.3,
+    "malware": 0.3,
+}
+
+# Event-count thresholds contribute to the base score independent of tags.
+_COUNT_HIGH = 100
+_COUNT_HIGH_WEIGHT = 0.3
+_COUNT_MED = 10
+_COUNT_MED_WEIGHT = 0.1
+
+
+def compute_tags(current_tags: list[str], new_event_type: str) -> list[str]:
+    """Return updated tag list after observing new_event_type.
+
+    Tags are additive — existing tags are never removed.
+    Returns a sorted list for deterministic output.
+    If new_event_type maps to no tag, or the tag is already present,
+    the original list is returned unchanged.
+    """
+    new_tag = _EVENT_TYPE_TO_TAG.get(new_event_type)
+    if new_tag is None or new_tag in current_tags:
+        return current_tags
+    return sorted({*current_tags, new_tag})
+
+
+def compute_reputation_score(tags: list[str], event_count: int) -> float:
+    """Return heuristic reputation score in [0.0, 1.0].
+
+    Scoring rules (from PHASE_2_BLUEPRINT.md section 10):
+      - event_count >= 100  → +0.3
+      - event_count >= 10   → +0.1
+      - brute-force tag     → +0.3
+      - scanner tag         → +0.2
+      - command-exec tag    → +0.3
+      - malware tag         → +0.3
+
+    Score is capped at 1.0. Rules are additive; all matching conditions
+    contribute. auth-success has no score contribution.
+    """
+    score = 0.0
+    if event_count >= _COUNT_HIGH:
+        score += _COUNT_HIGH_WEIGHT
+    elif event_count >= _COUNT_MED:
+        score += _COUNT_MED_WEIGHT
+    for tag, weight in _TAG_WEIGHTS.items():
+        if tag in tags:
+            score += weight
+    return min(score, 1.0)

--- a/tests/integration/test_intelligence_scoring.py
+++ b/tests/integration/test_intelligence_scoring.py
@@ -1,0 +1,281 @@
+"""
+Integration tests: source IP caching lifecycle and intelligence scoring/tagging.
+
+Tests hit the full HTTP → router → repository → in-memory SQLite stack.
+Schema is bootstrapped by tests/conftest.py; rows are reset per test by
+tests/integration/conftest.py (reset_db_rows fixture).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+import app.routers.ingest as ingest_module
+import app.utils.geoip as geoip_module
+from app.db.connection import get_engine
+from app.main import app
+from app.utils.geoip import reset_reader_for_testing
+
+client = TestClient(app)
+API_KEY = "dev-123"
+HEADERS = {"x-api-key": API_KEY, "Content-Type": "application/json"}
+
+PUBLIC_IP = "8.8.8.8"
+OTHER_PUBLIC_IP = "1.1.1.1"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _event(
+    event_id: str | None = None,
+    raw_type: str = "cowrie.login.failed",
+    source: str = "cowrie",
+    ip: str = PUBLIC_IP,
+) -> dict:
+    return {
+        "id": event_id or str(uuid.uuid4()),
+        "ts": "2025-10-28T18:31:08+00:00",
+        "source": source,
+        "type": raw_type,
+        "data": {"ip": ip},
+    }
+
+
+def _ingest(*events):
+    return client.post("/api/ingest", json={"events": list(events)}, headers=HEADERS)
+
+
+def _get_source_ip_row(ip: str) -> dict | None:
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            text(
+                "SELECT event_count, tags, reputation_score, country_code "
+                "FROM source_ips WHERE ip = :ip"
+            ),
+            {"ip": ip},
+        ).fetchone()
+    if row is None:
+        return None
+    return {
+        "event_count": row[0],
+        "tags": json.loads(row[1]) if row[1] else [],
+        "reputation_score": row[2],
+        "country_code": row[3],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_geoip_reader():
+    reset_reader_for_testing()
+    yield
+    reset_reader_for_testing()
+
+
+@pytest.fixture()
+def no_mmdb(monkeypatch, tmp_path):
+    """Ensure mmdb is absent and enrich_ip returns all-None for every test."""
+    monkeypatch.setattr(geoip_module, "CITY_DB_PATH", tmp_path / "absent.mmdb")
+
+
+# ---------------------------------------------------------------------------
+# Caching lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+def test_cache_miss_calls_enrich_ip_once(no_mmdb, monkeypatch):
+    """First event from an unknown IP must call enrich_ip exactly once."""
+    call_count = [0]
+
+    def counting_enrich(ip):
+        call_count[0] += 1
+        return {"country_code": None, "country_name": None, "city": None}
+
+    monkeypatch.setattr(ingest_module, "enrich_ip", counting_enrich)
+
+    resp = _ingest(_event("cache-miss-1"))
+    assert resp.status_code == 200
+    assert resp.json()["accepted"] == 1
+    assert call_count[0] == 1
+
+
+def test_cache_hit_skips_enrich_ip(no_mmdb, monkeypatch):
+    """Second event from the same IP must NOT call enrich_ip.
+
+    The counting stub returns a real country_code so that the source_ips row is
+    populated on first insert. The second event then finds it via get_source_ip_geo
+    (which requires country_code IS NOT NULL) and skips the file lookup entirely.
+    """
+    call_count = [0]
+
+    def counting_enrich(ip):
+        call_count[0] += 1
+        return {"country_code": "US", "country_name": "United States", "city": "Mountain View"}
+
+    monkeypatch.setattr(ingest_module, "enrich_ip", counting_enrich)
+
+    _ingest(_event("cache-hit-first"))
+    assert call_count[0] == 1  # cache miss on first event
+
+    _ingest(_event("cache-hit-second"))
+    assert call_count[0] == 1  # cache hit on second event — no additional call
+
+
+def test_different_ips_each_call_enrich_ip(no_mmdb, monkeypatch):
+    """Each distinct IP gets its own enrich_ip call."""
+    call_count = [0]
+
+    def counting_enrich(ip):
+        call_count[0] += 1
+        return {"country_code": None, "country_name": None, "city": None}
+
+    monkeypatch.setattr(ingest_module, "enrich_ip", counting_enrich)
+
+    _ingest(
+        _event("diff-ip-1", ip=PUBLIC_IP),
+        _event("diff-ip-2", ip=OTHER_PUBLIC_IP),
+    )
+    assert call_count[0] == 2
+
+
+def test_get_source_ip_geo_returns_none_for_unknown_ip():
+    """get_source_ip_geo returns None when IP has no source_ips row."""
+    from app.db.connection import get_session
+    from app.db.repository import EventRepository
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        result = repo.get_source_ip_geo("203.0.113.99")
+    assert result is None
+
+
+def test_get_source_ip_geo_returns_none_if_country_null(no_mmdb):
+    """get_source_ip_geo returns None for a known IP with NULL country_code."""
+    _ingest(_event("geo-null-test"))
+    from app.db.connection import get_session
+    from app.db.repository import EventRepository
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        result = repo.get_source_ip_geo(PUBLIC_IP)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tagging tests
+# ---------------------------------------------------------------------------
+
+
+def test_brute_force_tag_applied_after_auth_failed(no_mmdb):
+    _ingest(_event("tag-bf-1", raw_type="cowrie.login.failed"))
+    row = _get_source_ip_row(PUBLIC_IP)
+    assert row is not None
+    assert "brute-force" in row["tags"]
+
+
+def test_auth_success_tag_applied(no_mmdb):
+    _ingest(_event("tag-as-1", raw_type="cowrie.login.success"))
+    row = _get_source_ip_row(PUBLIC_IP)
+    assert row is not None
+    assert "auth-success" in row["tags"]
+
+
+def test_scanner_tag_applied_after_port_scan(no_mmdb):
+    _ingest(_event("tag-scan-1", raw_type="dionaea.connection.free", source="dionaea"))
+    row = _get_source_ip_row(PUBLIC_IP)
+    assert row is not None
+    assert "scanner" in row["tags"]
+
+
+def test_command_exec_tag_applied(no_mmdb):
+    _ingest(_event("tag-cmd-1", raw_type="cowrie.command.input"))
+    row = _get_source_ip_row(PUBLIC_IP)
+    assert row is not None
+    assert "command-exec" in row["tags"]
+
+
+def test_malware_tag_applied(no_mmdb):
+    _ingest(_event("tag-mal-1", raw_type="cowrie.session.file_upload"))
+    row = _get_source_ip_row(PUBLIC_IP)
+    assert row is not None
+    assert "malware" in row["tags"]
+
+
+def test_tags_are_additive_across_events(no_mmdb):
+    """Tags accumulated over multiple events are never removed."""
+    _ingest(_event("additive-1", raw_type="cowrie.login.failed"))
+    _ingest(_event("additive-2", raw_type="dionaea.connection.free", source="dionaea"))
+    row = _get_source_ip_row(PUBLIC_IP)
+    assert row is not None
+    assert "brute-force" in row["tags"]
+    assert "scanner" in row["tags"]
+
+
+def test_unknown_event_type_does_not_add_tag(no_mmdb):
+    _ingest(_event("unknown-type-1", raw_type="some.unknown.type", source="custom"))
+    row = _get_source_ip_row(PUBLIC_IP)
+    assert row is not None
+    assert row["tags"] == []
+
+
+# ---------------------------------------------------------------------------
+# Scoring tests
+# ---------------------------------------------------------------------------
+
+
+def test_reputation_score_set_after_auth_failed(no_mmdb):
+    _ingest(_event("score-bf-1", raw_type="cowrie.login.failed"))
+    row = _get_source_ip_row(PUBLIC_IP)
+    assert row is not None
+    assert row["reputation_score"] is not None
+    assert row["reputation_score"] > 0.0
+
+
+def test_reputation_score_meets_exit_criterion(no_mmdb):
+    """Blueprint exit criterion: 100+ auth_failed events → reputation_score >= 0.4."""
+    events = [_event(f"exit-criterion-{i}", raw_type="cowrie.login.failed") for i in range(100)]
+    _ingest(*events)
+    row = _get_source_ip_row(PUBLIC_IP)
+    assert row is not None
+    assert "brute-force" in row["tags"]
+    assert row["reputation_score"] >= 0.4
+
+
+def test_reputation_score_increases_with_event_count(no_mmdb):
+    """Score after 100 events must be higher than score after 1 event."""
+    _ingest(_event("score-low-1", raw_type="cowrie.login.failed"))
+    row_low = _get_source_ip_row(PUBLIC_IP)
+
+    for i in range(99):
+        _ingest(_event(f"score-high-{i}", raw_type="cowrie.login.failed", ip=OTHER_PUBLIC_IP))
+
+    row_high = _get_source_ip_row(OTHER_PUBLIC_IP)
+    assert row_high["reputation_score"] > row_low["reputation_score"]
+
+
+def test_scoring_failure_does_not_block_ingest(no_mmdb, monkeypatch):
+    """A scoring error must not cause ingest to return non-200."""
+    from app.db import repository as repo_module
+
+    def exploding_update(self, ip, tags, score):
+        raise RuntimeError("simulated scoring failure")
+
+    monkeypatch.setattr(
+        repo_module.EventRepository, "update_source_ip_intelligence", exploding_update
+    )
+
+    resp = _ingest(_event("score-fail-1", raw_type="cowrie.login.failed"))
+    assert resp.status_code == 200
+    assert resp.json()["accepted"] == 1

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -1,0 +1,101 @@
+"""Unit tests for app/utils/scoring.py — pure functions, no database required."""
+
+import pytest
+
+from app.utils.scoring import compute_reputation_score, compute_tags
+
+
+class TestComputeTags:
+    def test_auth_failed_adds_brute_force(self):
+        assert "brute-force" in compute_tags([], "auth_failed")
+
+    def test_auth_success_adds_auth_success(self):
+        assert "auth-success" in compute_tags([], "auth_success")
+
+    def test_port_scan_adds_scanner(self):
+        assert "scanner" in compute_tags([], "port_scan")
+
+    def test_http_probe_adds_scanner(self):
+        assert "scanner" in compute_tags([], "http_probe")
+
+    def test_command_exec_adds_command_exec(self):
+        assert "command-exec" in compute_tags([], "command_exec")
+
+    def test_malware_upload_adds_malware(self):
+        assert "malware" in compute_tags([], "malware_upload")
+
+    def test_unknown_event_type_returns_unchanged(self):
+        current = ["brute-force"]
+        result = compute_tags(current, "unknown")
+        assert result == current
+
+    def test_unmapped_normalized_type_returns_unchanged(self):
+        current = ["scanner"]
+        result = compute_tags(current, "some_custom_sensor_type")
+        assert result == current
+
+    def test_existing_tag_not_duplicated(self):
+        result = compute_tags(["brute-force"], "auth_failed")
+        assert result.count("brute-force") == 1
+
+    def test_tags_are_additive_existing_preserved(self):
+        result = compute_tags(["brute-force"], "port_scan")
+        assert "brute-force" in result
+        assert "scanner" in result
+
+    def test_result_is_sorted(self):
+        result = compute_tags([], "port_scan")
+        assert result == sorted(result)
+
+    def test_multi_type_same_tag_no_duplicate(self):
+        tags_after_scan = compute_tags([], "port_scan")
+        tags_after_probe = compute_tags(tags_after_scan, "http_probe")
+        assert tags_after_probe.count("scanner") == 1
+
+
+class TestComputeReputationScore:
+    def test_zero_for_no_events_no_tags(self):
+        assert compute_reputation_score([], 0) == pytest.approx(0.0)
+
+    def test_zero_for_single_event_no_tags(self):
+        assert compute_reputation_score([], 1) == pytest.approx(0.0)
+
+    def test_low_event_count_adds_point_one(self):
+        assert compute_reputation_score([], 10) == pytest.approx(0.1)
+
+    def test_high_event_count_adds_point_three(self):
+        assert compute_reputation_score([], 100) == pytest.approx(0.3)
+
+    def test_brute_force_tag_weight(self):
+        assert compute_reputation_score(["brute-force"], 0) == pytest.approx(0.3)
+
+    def test_scanner_tag_weight(self):
+        assert compute_reputation_score(["scanner"], 0) == pytest.approx(0.2)
+
+    def test_command_exec_tag_weight(self):
+        assert compute_reputation_score(["command-exec"], 0) == pytest.approx(0.3)
+
+    def test_malware_tag_weight(self):
+        assert compute_reputation_score(["malware"], 0) == pytest.approx(0.3)
+
+    def test_auth_success_tag_no_contribution(self):
+        assert compute_reputation_score(["auth-success"], 0) == pytest.approx(0.0)
+
+    def test_brute_force_and_high_count(self):
+        score = compute_reputation_score(["brute-force"], 100)
+        assert score == pytest.approx(0.6)
+
+    def test_score_meets_exit_criterion(self):
+        # Blueprint exit criterion: 100+ auth_failed events → score >= 0.4
+        tags = compute_tags([], "auth_failed")
+        score = compute_reputation_score(tags, 100)
+        assert score >= 0.4
+
+    def test_score_capped_at_1(self):
+        all_tags = ["brute-force", "scanner", "command-exec", "malware"]
+        score = compute_reputation_score(all_tags, 100)
+        assert score == pytest.approx(1.0)
+
+    def test_score_below_1_without_all_tags(self):
+        score = compute_reputation_score(["brute-force"], 5)
+        assert 0.0 < score < 1.0


### PR DESCRIPTION
## Summary

- Adds `app/utils/scoring.py`: pure-function `compute_tags` and `compute_reputation_score` — no DB imports, fully unit-testable
- Adds 4 repository methods: `get_source_ip_geo` (cache check), `get_source_ip_event_types`, `get_source_ip_intelligence`, `update_source_ip_intelligence`
- Updates `app/routers/ingest.py`: Stage 3.5 now checks the `source_ips` cache before calling `enrich_ip` (skips file read for known IPs); Stage 5.5 computes and writes tags + reputation score after each committed event via an isolated SAVEPOINT

## Scope

Caching lifecycle + deterministic scoring and rule-based tagging only. No ML, no external APIs, no campaign logic, no async workers, no schema changes.

## Architectural decisions

**Cache check requires `country_code IS NOT NULL`** — if a previous event stored an IP with NULL geo (mmdb absent), the cache miss path retries enrichment. This allows retroactive geo population without a backfill script.

**Stage 5.5 runs after the event SAVEPOINT commits** — scoring failure cannot roll back an accepted event. The scoring update runs in its own nested SAVEPOINT; any exception triggers `score_sp.rollback()` and ingest continues normally.

**`compute_tags` is additive** — tags are never removed once set. Output is sorted for deterministic JSON serialization and test assertions.

## Test plan

- [ ] `python -m pytest --tb=short -q` — 179 passed locally
- [ ] `test_cache_hit_skips_enrich_ip` — second event from same IP (with geo populated) does not call `enrich_ip`
- [ ] `test_reputation_score_meets_exit_criterion` — 100 `auth_failed` events produce `brute-force` tag and `reputation_score >= 0.4`
- [ ] `test_tags_are_additive_across_events` — `brute-force` + `scanner` both present after events of each type
- [ ] `test_scoring_failure_does_not_block_ingest` — monkeypatched exploding `update_source_ip_intelligence` returns HTTP 200 with `accepted=1`