### PR TITLE
feat: Phase 2 PR 3 — intelligence query endpoints

### DIFF
--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -394,3 +394,80 @@ class EventRepository:
                 """),
             {"ip": ip, "tags": json.dumps(tags), "score": reputation_score},
         )
+
+    # ------------------------------------------------------------------
+    # Phase 2D — intelligence query endpoints
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _source_ip_to_dict(row: Any) -> dict[str, Any]:
+        """Convert a source_ips SELECT row to the intelligence response dict.
+
+        city is always None — source_ips does not store city; it exists only
+        in the events table. The field is present in the response for forward
+        compatibility with a future schema update.
+        """
+        (
+            ip,
+            first_seen,
+            last_seen,
+            event_count,
+            country_code,
+            country_name,
+            asn,
+            asn_org,
+            reputation_score,
+            tags_json,
+        ) = row
+        try:
+            tags: list[str] = json.loads(tags_json) if tags_json else []
+        except (ValueError, TypeError):
+            tags = []
+        return {
+            "ip": ip,
+            "first_seen": first_seen,
+            "last_seen": last_seen,
+            "event_count": event_count,
+            "country_code": country_code,
+            "country_name": country_name,
+            "city": None,
+            "asn": asn,
+            "asn_org": asn_org,
+            "reputation_score": reputation_score,
+            "tags": tags,
+        }
+
+    def list_source_ips(self, limit: int = 100) -> list[dict[str, Any]]:
+        """
+        Return source IP intelligence records sorted by reputation_score DESC,
+        then event_count DESC. NULLs sort last (SQLite NULL < any non-NULL).
+        Used by GET /api/intelligence/ips.
+        """
+        rows = self._session.execute(
+            text("""
+                SELECT ip, first_seen, last_seen, event_count,
+                       country_code, country_name, asn, asn_org,
+                       reputation_score, tags
+                FROM source_ips
+                ORDER BY reputation_score DESC, event_count DESC
+                LIMIT :limit
+                """),
+            {"limit": limit},
+        ).fetchall()
+        return [self._source_ip_to_dict(row) for row in rows]
+
+    def get_source_ip(self, ip: str) -> dict[str, Any] | None:
+        """Return the intelligence profile for a single IP, or None if unknown."""
+        row = self._session.execute(
+            text("""
+                SELECT ip, first_seen, last_seen, event_count,
+                       country_code, country_name, asn, asn_org,
+                       reputation_score, tags
+                FROM source_ips
+                WHERE ip = :ip
+                """),
+            {"ip": ip},
+        ).fetchone()
+        if row is None:
+            return None
+        return self._source_ip_to_dict(row)

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ from app.routers import (
     events,  # Event listing endpoint
 )
 from app.routers.ingest import router as ingest_router  # POST /api/ingest
+from app.routers.intelligence import router as intelligence_router  # GET /api/intelligence/*
 from app.routers.iocs_pf import router as iocs_pf_router  # pf.conf generator
 from app.routers.stats import router as stats_router  # Stats & counters
 
@@ -53,6 +54,7 @@ app.add_middleware(
 # Prefixes help keep the API structure clean and RESTful.
 app.include_router(auth_router.router)  # /api/login
 app.include_router(ingest_router)  # /api/ingest
+app.include_router(intelligence_router)  # /api/intelligence/*
 app.include_router(iocs_pf_router, prefix="/api/iocs")  # pf.conf generator
 app.include_router(stats_router)  # /api/stats
 app.include_router(events.router)  # /api/events

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -1,0 +1,46 @@
+"""
+Intelligence query endpoints for LegionTrap TI.
+
+GET /api/intelligence/ips       — paginated source IP list, ranked by score
+GET /api/intelligence/ips/{ip}  — single IP intelligence profile
+
+All endpoints require API key or JWT authentication via require_jwt_or_api_key.
+No SQL belongs here — all queries go through EventRepository.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.db.connection import get_session
+from app.db.repository import EventRepository
+from app.utils.auth import require_jwt_or_api_key
+
+router = APIRouter(prefix="/api/intelligence", tags=["intelligence"])
+
+
+@router.get("/ips")
+def list_intelligence_ips(
+    limit: int = Query(default=100, ge=1, le=1000),
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return source IP intelligence records sorted by reputation_score DESC, event_count DESC."""
+    with get_session() as session:
+        items = EventRepository(session).list_source_ips(limit=limit)
+    return {"items": items, "count": len(items)}
+
+
+@router.get("/ips/{ip}")
+def get_intelligence_ip(
+    ip: str,
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return the intelligence profile for a single source IP. 404 if not found."""
+    with get_session() as session:
+        item = EventRepository(session).get_source_ip(ip)
+    if item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"IP {ip!r} not found",
+        )
+    return item

--- a/tests/integration/test_intelligence_endpoints.py
+++ b/tests/integration/test_intelligence_endpoints.py
@@ -1,0 +1,252 @@
+"""
+Integration tests for GET /api/intelligence/ips and GET /api/intelligence/ips/{ip}.
+
+Tests hit the full HTTP → router → repository → in-memory SQLite stack.
+Schema is bootstrapped by tests/conftest.py; rows are reset per test by
+tests/integration/conftest.py (reset_db_rows fixture).
+
+All tests insert source_ips rows directly for deterministic control over
+reputation_score, event_count, and tags without depending on GeoIP MMDB.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.db.connection import get_engine
+from app.main import app
+
+client = TestClient(app)
+API_KEY = "dev-123"
+HEADERS = {"x-api-key": API_KEY}
+
+_REQUIRED_FIELDS = {
+    "ip",
+    "first_seen",
+    "last_seen",
+    "event_count",
+    "country_code",
+    "country_name",
+    "city",
+    "asn",
+    "asn_org",
+    "tags",
+    "reputation_score",
+}
+
+_TS = "2025-10-28T18:31:08+00:00"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_source_ip(
+    ip: str,
+    event_count: int = 1,
+    reputation_score: float | None = None,
+    tags: list[str] | None = None,
+    country_code: str | None = None,
+    country_name: str | None = None,
+) -> None:
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO source_ips
+                    (ip, first_seen, last_seen, event_count,
+                     reputation_score, tags, country_code, country_name)
+                VALUES
+                    (:ip, :ts, :ts, :ec, :score, :tags, :cc, :cn)
+                """),
+            {
+                "ip": ip,
+                "ts": _TS,
+                "ec": event_count,
+                "score": reputation_score,
+                "tags": json.dumps(tags) if tags is not None else None,
+                "cc": country_code,
+                "cn": country_name,
+            },
+        )
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/intelligence/ips — list
+# ---------------------------------------------------------------------------
+
+
+def test_list_ips_empty_db():
+    resp = client.get("/api/intelligence/ips", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["count"] == 0
+
+
+def test_list_ips_returns_required_fields():
+    _insert_source_ip("1.2.3.4")
+    resp = client.get("/api/intelligence/ips", headers=HEADERS)
+    assert resp.status_code == 200
+    item = resp.json()["items"][0]
+    assert _REQUIRED_FIELDS.issubset(item.keys())
+
+
+def test_list_ips_city_is_null():
+    """city is not stored in source_ips — must be present but null."""
+    _insert_source_ip("1.2.3.4")
+    resp = client.get("/api/intelligence/ips", headers=HEADERS)
+    item = resp.json()["items"][0]
+    assert "city" in item
+    assert item["city"] is None
+
+
+def test_list_ips_tags_returned_as_list():
+    _insert_source_ip("1.2.3.4", tags=["brute-force", "scanner"])
+    resp = client.get("/api/intelligence/ips", headers=HEADERS)
+    item = resp.json()["items"][0]
+    assert isinstance(item["tags"], list)
+    assert "brute-force" in item["tags"]
+    assert "scanner" in item["tags"]
+
+
+def test_list_ips_null_tags_returned_as_empty_list():
+    _insert_source_ip("1.2.3.4", tags=None)
+    resp = client.get("/api/intelligence/ips", headers=HEADERS)
+    item = resp.json()["items"][0]
+    assert item["tags"] == []
+
+
+def test_list_ips_sorted_by_reputation_score_desc():
+    _insert_source_ip("10.0.0.1", reputation_score=0.2)
+    _insert_source_ip("10.0.0.2", reputation_score=0.9)
+    _insert_source_ip("10.0.0.3", reputation_score=0.5)
+    resp = client.get("/api/intelligence/ips", headers=HEADERS)
+    scores = [item["reputation_score"] for item in resp.json()["items"]]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_list_ips_sorted_by_event_count_when_scores_equal():
+    """When reputation_score is tied (or both NULL), higher event_count ranks first."""
+    _insert_source_ip("20.0.0.1", event_count=10, reputation_score=0.3)
+    _insert_source_ip("20.0.0.2", event_count=50, reputation_score=0.3)
+    _insert_source_ip("20.0.0.3", event_count=1, reputation_score=0.3)
+    resp = client.get("/api/intelligence/ips", headers=HEADERS)
+    items = resp.json()["items"]
+    counts = [i["event_count"] for i in items]
+    assert counts == sorted(counts, reverse=True)
+
+
+def test_list_ips_null_score_sorts_last():
+    _insert_source_ip("30.0.0.1", reputation_score=0.5)
+    _insert_source_ip("30.0.0.2", reputation_score=None)
+    resp = client.get("/api/intelligence/ips", headers=HEADERS)
+    items = resp.json()["items"]
+    scored = [i for i in items if i["reputation_score"] is not None]
+    unscored = [i for i in items if i["reputation_score"] is None]
+    # All scored IPs must appear before unscored ones
+    assert items.index(scored[-1]) < items.index(unscored[0])
+
+
+def test_list_ips_limit_respected():
+    for i in range(5):
+        _insert_source_ip(f"40.0.0.{i + 1}")
+    resp = client.get("/api/intelligence/ips?limit=3", headers=HEADERS)
+    data = resp.json()
+    assert len(data["items"]) == 3
+    assert data["count"] == 3
+
+
+def test_list_ips_limit_default_is_100():
+    resp = client.get("/api/intelligence/ips", headers=HEADERS)
+    assert resp.status_code == 200  # default limit accepted
+
+
+def test_list_ips_limit_below_minimum_returns_422():
+    resp = client.get("/api/intelligence/ips?limit=0", headers=HEADERS)
+    assert resp.status_code == 422
+
+
+def test_list_ips_limit_above_maximum_returns_422():
+    resp = client.get("/api/intelligence/ips?limit=1001", headers=HEADERS)
+    assert resp.status_code == 422
+
+
+def test_list_ips_count_matches_items_length():
+    _insert_source_ip("50.0.0.1")
+    _insert_source_ip("50.0.0.2")
+    resp = client.get("/api/intelligence/ips", headers=HEADERS)
+    data = resp.json()
+    assert data["count"] == len(data["items"])
+
+
+# ---------------------------------------------------------------------------
+# GET /api/intelligence/ips/{ip} — single IP profile
+# ---------------------------------------------------------------------------
+
+
+def test_get_ip_returns_profile():
+    _insert_source_ip("60.0.0.1", event_count=42, reputation_score=0.7, tags=["brute-force"])
+    resp = client.get("/api/intelligence/ips/60.0.0.1", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ip"] == "60.0.0.1"
+    assert data["event_count"] == 42
+    assert data["reputation_score"] == pytest.approx(0.7)
+    assert "brute-force" in data["tags"]
+
+
+def test_get_ip_returns_all_required_fields():
+    _insert_source_ip("60.0.0.2")
+    resp = client.get("/api/intelligence/ips/60.0.0.2", headers=HEADERS)
+    assert resp.status_code == 200
+    assert _REQUIRED_FIELDS.issubset(resp.json().keys())
+
+
+def test_get_ip_404_for_unknown():
+    resp = client.get("/api/intelligence/ips/99.99.99.99", headers=HEADERS)
+    assert resp.status_code == 404
+
+
+def test_get_ip_city_is_null():
+    _insert_source_ip("60.0.0.3", country_code="US")
+    resp = client.get("/api/intelligence/ips/60.0.0.3", headers=HEADERS)
+    assert resp.json()["city"] is None
+
+
+def test_get_ip_country_fields_populated():
+    _insert_source_ip("60.0.0.4", country_code="DE", country_name="Germany")
+    resp = client.get("/api/intelligence/ips/60.0.0.4", headers=HEADERS)
+    data = resp.json()
+    assert data["country_code"] == "DE"
+    assert data["country_name"] == "Germany"
+
+
+# ---------------------------------------------------------------------------
+# Auth tests — both endpoints must reject missing/wrong credentials
+# ---------------------------------------------------------------------------
+
+
+def test_list_ips_no_auth_returns_401():
+    resp = client.get("/api/intelligence/ips")
+    assert resp.status_code == 401
+
+
+def test_list_ips_wrong_api_key_returns_401():
+    resp = client.get("/api/intelligence/ips", headers={"x-api-key": "wrong-key"})
+    assert resp.status_code == 401
+
+
+def test_get_ip_no_auth_returns_401():
+    resp = client.get("/api/intelligence/ips/1.2.3.4")
+    assert resp.status_code == 401
+
+
+def test_get_ip_wrong_api_key_returns_401():
+    resp = client.get("/api/intelligence/ips/1.2.3.4", headers={"x-api-key": "bad"})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

- Adds `app/routers/intelligence.py` with two read-only endpoints protected by `require_jwt_or_api_key`
- Adds `list_source_ips`, `get_source_ip`, and `_source_ip_to_dict` to `EventRepository`
- Registers the router in `app/main.py`

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/intelligence/ips` | Paginated source IP list sorted by `reputation_score DESC`, `event_count DESC`. Query param: `limit` (1–1000, default 100) |
| `GET` | `/api/intelligence/ips/{ip}` | Single IP intelligence profile. 404 if not found |

**Response fields:** `ip`, `first_seen`, `last_seen`, `event_count`, `country_code`, `country_name`, `city` (always `null` — not stored in `source_ips`), `asn`, `asn_org`, `tags` (list), `reputation_score`

## Scope

Read-only intelligence queries only. No top-countries, no top-ASNs, no dashboard, no schema migration.

## Test plan

- [ ] `python -m pytest --tb=short -q` — 201 passed locally
- [ ] `test_list_ips_sorted_by_reputation_score_desc` — score order verified
- [ ] `test_list_ips_sorted_by_event_count_when_scores_equal` — tiebreak order verified
- [ ] `test_list_ips_null_score_sorts_last` — unscored IPs appear after scored
- [ ] `test_list_ips_limit_below_minimum_returns_422` and `test_list_ips_limit_above_maximum_returns_422`
- [ ] `test_get_ip_404_for_unknown`
- [ ] Auth rejection on both endpoints (no key, wrong key)