### PR TITLE
docs: close Phase 2 with schema readiness audit

### DIFF
--- a/app/db/migrations/versions/0002_phase2_intelligence_indexes.py
+++ b/app/db/migrations/versions/0002_phase2_intelligence_indexes.py
@@ -1,0 +1,46 @@
+"""Phase 2E intelligence query indexes
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-05-25
+
+Adds two indexes identified by the Phase 2E schema readiness audit:
+
+  idx_source_ips_reputation — supports list_source_ips ORDER BY reputation_score DESC
+  idx_events_src_ip_type    — covering index for get_source_ip_event_types
+                              (SELECT DISTINCT event_type FROM events WHERE src_ip = :ip)
+
+The source_ips(tags) partial JSON index is deferred: SQLite json_each expression
+indexes require careful quoting and offer diminishing returns until tag-filtered
+queries are confirmed in production workloads.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_source_ips_reputation",
+        "source_ips",
+        [sa.text("reputation_score DESC")],
+    )
+    op.create_index(
+        "idx_events_src_ip_type",
+        "events",
+        ["src_ip", "event_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_events_src_ip_type", table_name="events")
+    op.drop_index("idx_source_ips_reputation", table_name="source_ips")

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -2,8 +2,8 @@
 
 **Document type:** Implementation blueprint — canonical SQL schema reference
 **Audience:** Engineers, autonomous agents, Alembic migration authors
-**Last reviewed:** 2026-05-23
-**Status:** Implemented. All Phase 1 tables and indexes are live. Run `alembic upgrade head` for new deployments.
+**Last reviewed:** 2026-05-25
+**Status:** Implemented. Phase 1 tables and indexes are live. Phase 2E intelligence indexes are live. Run `alembic upgrade head` for new deployments.
 
 ---
 
@@ -365,11 +365,11 @@ Alembic manages all schema changes. The migration version table is created by Al
 
 ```
 app/db/migrations/versions/
-  0001_initial_schema.py        -- creates all Phase 1 tables
-  0002_add_geoip_fields.py      -- Phase 3: adds country/ASN fields to events
-  0003_ai_analysis_table.py     -- Phase 5: adds ai_analyses
-  0004_behavioral_tables.py     -- Phase 6: adds fingerprints, campaigns, campaign_id FK
-  0005_federation_table.py      -- Phase 7: adds federation_fingerprints
+  0001_initial_schema.py                 -- creates all Phase 1 tables (live)
+  0002_phase2_intelligence_indexes.py    -- Phase 2E: intelligence query indexes (live)
+  0003_ai_analysis_table.py             -- Phase 5: adds ai_analyses (future)
+  0004_behavioral_tables.py             -- Phase 6: adds fingerprints, campaigns, campaign_id FK (future)
+  0005_federation_table.py              -- Phase 7: adds federation_fingerprints (future)
 ```
 
 **Rule:** Never manually ALTER a table that Alembic manages. All schema changes go through a new migration file.
@@ -390,6 +390,63 @@ app/db/migrations/versions/
 | `ai_analyses` | Phase 5 | Separate (90d default) | Yes |
 | `federation_fingerprints` | Phase 7 | Separate configurable | Yes |
 | `audit_log` | Phase 1 | Separate (90d default) | Yes |
+
+---
+
+---
+
+## Phase 2E Index Readiness Audit
+
+**Audit date:** 2026-05-25
+**Auditor:** Phase 2 close-out PR (schema readiness step)
+**Status:** Complete. Migration `0002_phase2_intelligence_indexes.py` created and merged.
+
+### Methodology
+
+Each Phase 2D/2E query pattern was mapped against existing indexes from `0001_initial_schema.py`.
+Gaps were defined as: query shapes for which SQLite would perform a full table scan or an index scan
+followed by a separate sort pass at 100k+ row scale.
+
+### Query patterns audited
+
+| Query | Repository method | Existing index | Gap? |
+|---|---|---|---|
+| `SELECT … FROM source_ips ORDER BY reputation_score DESC, event_count DESC LIMIT :n` | `list_source_ips` | `idx_source_ips_count` (event_count only) | **Yes** — no index on reputation_score |
+| `SELECT DISTINCT event_type FROM events WHERE src_ip = :ip` | `get_source_ip_event_types` | `idx_events_src_ip` (single-column) | **Yes** — composite covering index needed |
+| `SELECT country_code, … FROM source_ips WHERE country_code IS NOT NULL GROUP BY country_code ORDER BY event_count DESC` | `get_top_countries` | `idx_source_ips_country` | No — filter + group on country_code is served |
+| `SELECT asn, … FROM source_ips WHERE asn IS NOT NULL GROUP BY asn ORDER BY event_count DESC` | `get_top_asns` | `idx_source_ips_asn` | No — filter + group on asn is served |
+| `SELECT … FROM source_ips WHERE ip = :ip` | `get_source_ip` | PRIMARY KEY on `ip` | No |
+| `SELECT … FROM source_ips WHERE country_code IS NOT NULL AND event_count IS NOT NULL` | cache read (`get_source_ip_geo`) | `idx_source_ips_country` | No |
+
+### Gaps addressed in migration 0002
+
+**`idx_source_ips_reputation` on `source_ips(reputation_score DESC)`**
+
+`list_source_ips` orders by `reputation_score DESC, event_count DESC`. Without this index,
+SQLite performs a full table scan plus an in-memory sort on every call to `GET /api/intelligence/ips`.
+At 100k unique IPs this is a measurable overhead. The index eliminates the sort pass for the
+primary ordering key.
+
+**`idx_events_src_ip_type` on `events(src_ip, event_type)`**
+
+`get_source_ip_event_types` runs `SELECT DISTINCT event_type FROM events WHERE src_ip = :ip`.
+The single-column `idx_events_src_ip` already handles the `WHERE` filter, but SQLite must
+then load each matching row to extract `event_type`. A composite covering index lets SQLite
+satisfy the entire query from the index without touching the table.
+
+### Deferred items
+
+| Index | Reason deferred |
+|---|---|
+| `source_ips(tags)` JSON partial index using `json_each` | SQLite expression indexes on JSON require careful quoting syntax; benefit is limited until tag-filtered queries are confirmed in production. Revisit in Phase 4 when tag-filtered IOC exports are implemented. |
+
+### Validator update
+
+`scripts/validate_migration.py` was updated in the same PR:
+- `EXPECTED_INDEXES` extended with `idx_source_ips_reputation` and `idx_events_src_ip_type`
+- `EXPECTED_ALEMBIC_REVISION` bumped from `"0001"` to `"0002"`
+
+`make db-validate` passes against a database at revision 0002.
 
 ---
 

--- a/docs/PHASE_2_BLUEPRINT.md
+++ b/docs/PHASE_2_BLUEPRINT.md
@@ -3,7 +3,7 @@
 **Document type:** Implementation blueprint — Phase 2 architectural plan
 **Audience:** Engineers and autonomous agents performing Phase 2 work
 **Last reviewed:** 2026-05-25
-**Status:** Pre-implementation. Phase 2 has not started. Read this before writing any Phase 2 code.
+**Status:** Complete. All Phase 2 sub-phases (2A–2E) are implemented and merged to `main`.
 **Prerequisites:** Phases 0, 1A, and 1B are complete and merged to `main`.
 
 ---

--- a/scripts/validate_migration.py
+++ b/scripts/validate_migration.py
@@ -31,10 +31,11 @@ EXPECTED_TABLES: list[str] = [
     "audit_log",
 ]
 
-# All indexes created by 0001_initial_schema.py.
+# All indexes created by Alembic migrations up to the current head.
 # create_all_tables() does NOT create these — their absence indicates the DB
 # was not set up via 'alembic upgrade head'.
 EXPECTED_INDEXES: list[str] = [
+    # 0001_initial_schema
     "idx_raw_events_ts",
     "idx_raw_events_source",
     "idx_raw_events_ingested",
@@ -53,9 +54,12 @@ EXPECTED_INDEXES: list[str] = [
     "idx_audit_ts",
     "idx_audit_event_type",
     "idx_audit_source_ip",
+    # 0002_phase2_intelligence_indexes
+    "idx_source_ips_reputation",
+    "idx_events_src_ip_type",
 ]
 
-EXPECTED_ALEMBIC_REVISION = "0001"
+EXPECTED_ALEMBIC_REVISION = "0002"
 
 
 @dataclass

--- a/tests/unit/test_validate_migration.py
+++ b/tests/unit/test_validate_migration.py
@@ -65,6 +65,12 @@ def _add_full_indexes_and_revision(engine) -> None:
         conn.execute(text("CREATE INDEX idx_audit_event_type ON audit_log(event_type)"))
         conn.execute(text("CREATE INDEX idx_audit_source_ip ON audit_log(source_ip)"))
 
+        # 0002_phase2_intelligence_indexes
+        conn.execute(
+            text("CREATE INDEX idx_source_ips_reputation ON source_ips(reputation_score DESC)")
+        )
+        conn.execute(text("CREATE INDEX idx_events_src_ip_type ON events(src_ip, event_type)"))
+
         # Alembic version table (mirrors what Alembic creates)
         conn.execute(
             text(
@@ -188,6 +194,11 @@ def test_validate_missing_alembic_version_is_invalid(tmp_path):
         conn.execute(text("CREATE INDEX idx_audit_ts ON audit_log(ts)"))
         conn.execute(text("CREATE INDEX idx_audit_event_type ON audit_log(event_type)"))
         conn.execute(text("CREATE INDEX idx_audit_source_ip ON audit_log(source_ip)"))
+        # 0002_phase2_intelligence_indexes
+        conn.execute(
+            text("CREATE INDEX idx_source_ips_reputation ON source_ips(reputation_score DESC)")
+        )
+        conn.execute(text("CREATE INDEX idx_events_src_ip_type ON events(src_ip, event_type)"))
         conn.commit()
 
     result = validate_database(engine)


### PR DESCRIPTION
## Summary

- Alembic migration `0002_phase2_intelligence_indexes.py` adds two indexes identified by the Phase 2E audit: `idx_source_ips_reputation` (`source_ips(reputation_score DESC)`) and `idx_events_src_ip_type` (`events(src_ip, event_type)`)
- `scripts/validate_migration.py` updated: two new indexes added to `EXPECTED_INDEXES`, `EXPECTED_ALEMBIC_REVISION` bumped to `"0002"`
- `docs/DATABASE_SCHEMA.md`: migration naming table corrected, full Phase 2E audit section added with query-to-index mapping, gap analysis, rationale, and deferred items
- `docs/PHASE_2_BLUEPRINT.md`: status updated from "Pre-implementation" to "Complete"

## Test plan

- [x] 232/232 tests pass (`pytest -q`)
- [x] pre-commit clean (black, ruff)
- [x] `alembic upgrade head` applies both migrations cleanly (0001 → 0002)
- [x] `make db-validate` → VALID (revision 0002, all 20 indexes present)
- [x] `tests/unit/test_validate_migration.py` updated to include new indexes in full-schema helper
