### PR TITLE
docs: genericize autonomous agent references

### DIFF
--- a/docs/AUTONOMOUS_OPERATIONS.md
+++ b/docs/AUTONOMOUS_OPERATIONS.md
@@ -1,14 +1,14 @@
 # LegionTrap TI — Autonomous Operations
 
 **Document type:** Operational philosophy and AI-assisted engineering guide
-**Audience:** Engineers, autonomous agents, contributors, Claude Code
+**Audience:** Engineers, autonomous agents, contributors
 **Last reviewed:** 2026-05-22
 
 ---
 
 ## Purpose
 
-This document defines how autonomous AI agents — including Claude Code — should interact with this repository. It is not a policy document for human contributors (see `CLAUDE.md` for that). It is a reference for AI-assisted operations: what autonomous agents may do, what they must not do, what they should verify before acting, and how the repository is designed to be safe for automated work.
+This document defines how autonomous AI agents should interact with this repository. It is not a policy document for human contributors (see `CLAUDE.md` for that). It is a reference for AI-assisted operations: what autonomous agents may do, what they must not do, what they should verify before acting, and how the repository is designed to be safe for automated work.
 
 ---
 
@@ -195,7 +195,7 @@ The primary data store is `storage/events.jsonl`. Autonomous agents interacting 
 
 Autonomous agents operating in this repository use a persistent memory system at:
 
-`~/.claude/projects/-Users-stecrin-Projects-gitrepo-legiontrap-ti/memory/`
+`<agent-specific memory path>`
 
 This memory captures:
 - User preferences and working style

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ New contributors and autonomous agents must read the relevant documents in this 
 
 ## How Autonomous Agents Should Use These Documents
 
-Autonomous agents operating in this repository (including Claude Code) should follow this reading protocol:
+Autonomous agents operating in this repository should follow this reading protocol:
 
 ### Before any task
 

--- a/docs/strategy/README.md
+++ b/docs/strategy/README.md
@@ -117,7 +117,7 @@ The founder's observations and intuitions are inputs to strategy, not outputs. T
 
 ### The strategy layer is maintained by maintainers, not by autonomous agents
 
-Autonomous agents (including Claude Code) may read this layer for context and may propose additions or modifications through the standard PR process. They may not directly update `STRATEGIC_DECISIONS.md`, `REJECTED_IDEAS.md`, or `STRATEGY_CHANGELOG.md` without explicit maintainer instruction. These are the project's strategic memory; they require human judgment for updates.
+Autonomous agents may read this layer for context and may propose additions or modifications through the standard PR process. They may not directly update `STRATEGIC_DECISIONS.md`, `REJECTED_IDEAS.md`, or `STRATEGY_CHANGELOG.md` without explicit maintainer instruction. These are the project's strategic memory; they require human judgment for updates.
 
 Autonomous agents may update working documents (`COMPETITOR_ANALYSIS.md`, `AI_THREAT_FORECASTS.md`) with clearly tagged `[hypothesis]` additions when instructed to research and document strategic questions.
 


### PR DESCRIPTION
## Summary

- Removes explicit tool-specific references from public documentation
- Replaces with neutral wording: `autonomous agents`, `<agent-specific memory path>`
- Files changed: `docs/AUTONOMOUS_OPERATIONS.md`, `docs/README.md`, `docs/strategy/README.md`

## Context

Follow-up to PR #25 (Phase 2 schema readiness audit). A pre-merge attribution audit identified five lines across three docs that named the specific AI development tool used. These have been genericized so the public docs describe the workflow pattern rather than any particular tool.

## Files changed

- `docs/AUTONOMOUS_OPERATIONS.md` — removed tool name from Audience field, Purpose paragraph, and memory path
- `docs/README.md` — removed tool name from agent reading protocol line
- `docs/strategy/README.md` — removed tool name from governance section

## Test plan

- [x] pre-commit clean (black, ruff, trim)
- [x] No application logic touched