### PR TITLE
feat(enrichment): add ASN enrichment via GeoLite2-ASN.mmdb

### DIFF
--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -38,6 +38,7 @@ from app.schemas.models import (
     IngestReceipt,
     IngestRequest,
 )
+from app.utils.asn import enrich_asn
 from app.utils.event_utils import extract_src_ip, normalize_event_type, parse_timestamp
 from app.utils.geoip import enrich_ip
 from app.utils.scoring import compute_reputation_score, compute_tags
@@ -113,12 +114,14 @@ def ingest_events(
             event_type = normalize_event_type(raw.type, raw.source)
             src_ip = extract_src_ip(raw.model_dump())
 
-            # Stage 3.5: GeoIP enrichment (cache-first; never blocks ingest)
+            # Stage 3.5: GeoIP + ASN enrichment (cache-first; never blocks ingest)
             geo: dict | None = None
             if src_ip:
-                geo = repo.get_source_ip_geo(src_ip)  # cache hit → skip file read
+                geo = repo.get_source_ip_geo(src_ip)  # cache hit → skip mmdb reads
                 if geo is None:
-                    geo = enrich_ip(src_ip)  # cache miss → local mmdb lookup
+                    city_geo = enrich_ip(src_ip)  # {country_code, country_name, city}
+                    asn_geo = enrich_asn(src_ip)  # {asn, asn_org}
+                    geo = {**city_geo, **asn_geo}
 
             # Construct canonical event object
             if geo is not None:
@@ -157,6 +160,8 @@ def ingest_events(
                         ts,
                         country_code=geo["country_code"] if geo else None,
                         country_name=geo["country_name"] if geo else None,
+                        asn=geo.get("asn") if geo else None,
+                        asn_org=geo.get("asn_org") if geo else None,
                     )
                 sp.commit()
             except IntegrityError:

--- a/app/utils/asn.py
+++ b/app/utils/asn.py
@@ -1,0 +1,79 @@
+"""
+ASN enrichment utility for LegionTrap TI.
+
+Provides ASN (Autonomous System Number) context for public IPv4 addresses
+using a local GeoLite2-ASN.mmdb file. The database file is never committed
+to the repository (storage/ is gitignored) and must be provisioned by each
+operator alongside GeoLite2-City.mmdb.
+
+Enrichment is best-effort: any failure (missing file, IP not in database,
+reader error) returns a dict of all-None values without raising. The ingest
+pipeline must never fail because of an enrichment error.
+
+No FastAPI, SQLAlchemy, or router imports belong in this module.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from pathlib import Path
+
+import geoip2.database
+
+ASN_DB_PATH = Path("storage/GeoLite2-ASN.mmdb")
+
+_asn_reader: geoip2.database.Reader | None = None
+_reader_lock = threading.Lock()
+
+
+def _get_reader() -> geoip2.database.Reader | None:
+    """Return the module-level singleton ASN reader, initializing on first call.
+
+    Returns None if the mmdb file is absent or fails to open. Subsequent calls
+    after a failed init re-check the file each time — the operator may provision
+    the file after startup without restarting the application.
+    """
+    global _asn_reader
+    if _asn_reader is not None:
+        return _asn_reader
+    with _reader_lock:
+        if _asn_reader is not None:
+            return _asn_reader
+        if not ASN_DB_PATH.exists():
+            return None
+        try:
+            _asn_reader = geoip2.database.Reader(str(ASN_DB_PATH))
+        except Exception:
+            return None
+    return _asn_reader
+
+
+def reset_asn_reader_for_testing() -> None:
+    """Close and clear the cached reader. Call from test fixtures only."""
+    global _asn_reader
+    with _reader_lock:
+        if _asn_reader is not None:
+            with contextlib.suppress(Exception):
+                _asn_reader.close()
+            _asn_reader = None
+
+
+def enrich_asn(ip: str) -> dict[str, int | str | None]:
+    """Return ASN context for a public IPv4 address.
+
+    Keys: asn (int or None), asn_org (str or None). All values are None when
+    the mmdb is absent, the IP is not in the database, or any error occurs.
+    Never raises.
+    """
+    reader = _get_reader()
+    if reader is None:
+        return {"asn": None, "asn_org": None}
+    try:
+        response = reader.asn(ip)
+        return {
+            "asn": response.autonomous_system_number,
+            "asn_org": response.autonomous_system_organization,
+        }
+    except Exception:
+        return {"asn": None, "asn_org": None}

--- a/tests/integration/test_asn_enrichment.py
+++ b/tests/integration/test_asn_enrichment.py
@@ -1,0 +1,117 @@
+"""Integration tests: ASN enrichment through the ingest pipeline.
+
+Tests verify that:
+- Ingest succeeds when GeoLite2-ASN.mmdb is absent (enrichment is best-effort)
+- events.asn and events.asn_org are NULL when the mmdb is absent
+- source_ips.asn and source_ips.asn_org are NULL when the mmdb is absent
+- When the mmdb is present, asn fields are populated on first insert
+  (guarded with skipif — requires operator to provision GeoLite2-ASN.mmdb)
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+import app.utils.asn as asn_module
+from app.db.connection import get_engine
+from app.main import app
+from app.utils.asn import reset_asn_reader_for_testing
+
+client = TestClient(app)
+API_KEY = "dev-123"
+HEADERS = {"x-api-key": API_KEY, "Content-Type": "application/json"}
+
+ASN_DB_AVAILABLE = asn_module.ASN_DB_PATH.exists()
+
+_PUBLIC_IP = "8.8.8.8"
+
+
+def _event(event_id: str, ip: str = _PUBLIC_IP) -> dict:
+    return {
+        "id": event_id,
+        "ts": "2025-10-28T18:31:08+00:00",
+        "source": "cowrie",
+        "type": "cowrie.login.failed",
+        "data": {"ip": ip},
+    }
+
+
+def _ingest(event_id: str, ip: str = _PUBLIC_IP):
+    return client.post(
+        "/api/ingest",
+        json={"events": [_event(event_id, ip)]},
+        headers=HEADERS,
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_asn_reader():
+    reset_asn_reader_for_testing()
+    yield
+    reset_asn_reader_for_testing()
+
+
+def test_ingest_succeeds_without_asn_mmdb(monkeypatch, tmp_path):
+    """Ingest must succeed even if GeoLite2-ASN.mmdb is absent."""
+    monkeypatch.setattr(asn_module, "ASN_DB_PATH", tmp_path / "absent.mmdb")
+    resp = _ingest("asn-no-mmdb-01")
+    assert resp.status_code == 200
+    assert resp.json()["accepted"] == 1
+
+
+def test_ingest_asn_null_in_events_without_mmdb(monkeypatch, tmp_path):
+    """events.asn and events.asn_org are NULL when ASN mmdb is absent."""
+    monkeypatch.setattr(asn_module, "ASN_DB_PATH", tmp_path / "absent.mmdb")
+    _ingest("asn-null-events-01")
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            text("SELECT asn, asn_org FROM events WHERE id = 'asn-null-events-01'")
+        ).fetchone()
+    assert row is not None
+    assert row[0] is None
+    assert row[1] is None
+
+
+def test_ingest_asn_null_in_source_ips_without_mmdb(monkeypatch, tmp_path):
+    """source_ips.asn and source_ips.asn_org are NULL when ASN mmdb is absent."""
+    monkeypatch.setattr(asn_module, "ASN_DB_PATH", tmp_path / "absent.mmdb")
+    _ingest("asn-null-source-01", ip=_PUBLIC_IP)
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            text("SELECT asn, asn_org FROM source_ips WHERE ip = :ip"),
+            {"ip": _PUBLIC_IP},
+        ).fetchone()
+    assert row is not None
+    assert row[0] is None
+    assert row[1] is None
+
+
+@pytest.mark.skipif(not ASN_DB_AVAILABLE, reason="GeoLite2-ASN.mmdb not provisioned")
+def test_ingest_populates_asn_in_events_when_mmdb_available():
+    """events.asn and events.asn_org are populated when GeoLite2-ASN.mmdb is present."""
+    _ingest("asn-live-events-01")
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            text("SELECT asn, asn_org FROM events WHERE id = 'asn-live-events-01'")
+        ).fetchone()
+    assert row is not None
+    assert row[0] is not None
+    assert isinstance(row[0], int)
+    assert row[1] is not None
+
+
+@pytest.mark.skipif(not ASN_DB_AVAILABLE, reason="GeoLite2-ASN.mmdb not provisioned")
+def test_ingest_populates_asn_in_source_ips_when_mmdb_available():
+    """source_ips.asn and source_ips.asn_org are populated on first insert."""
+    _ingest("asn-live-source-01", ip=_PUBLIC_IP)
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            text("SELECT asn, asn_org FROM source_ips WHERE ip = :ip"),
+            {"ip": _PUBLIC_IP},
+        ).fetchone()
+    assert row is not None
+    assert row[0] is not None
+    assert isinstance(row[0], int)
+    assert row[1] is not None

--- a/tests/unit/test_asn.py
+++ b/tests/unit/test_asn.py
@@ -1,0 +1,44 @@
+"""Unit tests for app/utils/asn.py."""
+
+import pytest
+
+import app.utils.asn as asn_module
+from app.utils.asn import enrich_asn, reset_asn_reader_for_testing
+
+ASN_DB_AVAILABLE = asn_module.ASN_DB_PATH.exists()
+
+_EXPECTED_KEYS = {"asn", "asn_org"}
+
+
+@pytest.fixture(autouse=True)
+def reset_reader():
+    reset_asn_reader_for_testing()
+    yield
+    reset_asn_reader_for_testing()
+
+
+def test_enrich_asn_missing_mmdb_returns_all_none(monkeypatch, tmp_path):
+    monkeypatch.setattr(asn_module, "ASN_DB_PATH", tmp_path / "absent.mmdb")
+    result = enrich_asn("1.2.3.4")
+    assert result == {"asn": None, "asn_org": None}
+
+
+def test_enrich_asn_returns_dict_with_expected_keys(monkeypatch, tmp_path):
+    monkeypatch.setattr(asn_module, "ASN_DB_PATH", tmp_path / "absent.mmdb")
+    result = enrich_asn("1.2.3.4")
+    assert set(result.keys()) == _EXPECTED_KEYS
+
+
+def test_enrich_asn_never_raises_on_invalid_ip_strings(monkeypatch, tmp_path):
+    monkeypatch.setattr(asn_module, "ASN_DB_PATH", tmp_path / "absent.mmdb")
+    for bad in ("", "not-an-ip", "999.999.999.999", "::1", "0.0.0.0"):
+        result = enrich_asn(bad)
+        assert set(result.keys()) == _EXPECTED_KEYS
+
+
+@pytest.mark.skipif(not ASN_DB_AVAILABLE, reason="GeoLite2-ASN.mmdb not provisioned")
+def test_enrich_asn_returns_asn_number_for_public_ip():
+    result = enrich_asn("8.8.8.8")
+    assert result["asn"] is not None
+    assert isinstance(result["asn"], int)
+    assert result["asn_org"] is not None


### PR DESCRIPTION
## Summary

- Creates `app/utils/asn.py` — lazy-loaded singleton ASN reader (same pattern as `geoip.py`): thread-safe double-checked locking, no startup failure if mmdb absent, best-effort with all-None fallback
- Wires `enrich_asn()` into ingest Stage 3.5: on cache miss, calls `enrich_ip()` (city/country) and `enrich_asn()` (ASN/org) and merges before constructing `EnrichedEvent`
- Updates `upsert_source_ip()` call to pass `asn` and `asn_org` — these fields were in the schema and `WriteRepository` signature but were never populated from enrichment

## Changes

| File | Change |
|---|---|
| `app/utils/asn.py` | New ASN enrichment utility |
| `app/routers/ingest.py` | Stage 3.5: call `enrich_asn()` on cache miss; pass `asn`/`asn_org` to `upsert_source_ip()` |
| `tests/unit/test_asn.py` | 3 always-on unit tests + 1 skipif-guarded live test |
| `tests/integration/test_asn_enrichment.py` | 3 always-on integration tests + 2 skipif-guarded live tests |

## JSONL removal — deferred

`_append_jsonl()` assessed and left in place. `MIGRATION_GUIDE.md` documents `events.jsonl` as the disaster-recovery source of truth; removing the write would silently break that guarantee. Removal belongs in a dedicated PR that also replaces the recovery guarantee with a DB-snapshot strategy and deletes `scripts/import_jsonl.py` and its tests together.

## Provisioning

To activate live ASN enrichment, provision `storage/GeoLite2-ASN.mmdb` from MaxMind (same download as `GeoLite2-City.mmdb`). No restart required — the reader initializes lazily on first use.

## Test plan

- [ ] 245/245 tests pass, 3 skipped (`GeoLite2-ASN.mmdb not provisioned` guard — expected)
- [ ] Pre-commit hooks clean (black, ruff, fix end of files, trim trailing whitespace)
- [ ] Ingest succeeds without ASN mmdb — no startup or runtime failures
- [ ] `events.asn` and `events.asn_org` are NULL when mmdb absent, populated when present
- [ ] `source_ips.asn` and `source_ips.asn_org` are NULL when mmdb absent, populated on first insert
- [ ] City/country enrichment (`geoip.py`) is unchanged