### PR TITLE
feat(ui): dashboard intelligence visibility panels (Phase 3 PR 5)

### DIFF
--- a/ui/dashboard/src/App.jsx
+++ b/ui/dashboard/src/App.jsx
@@ -2,6 +2,9 @@ import { useEffect, useRef, useState } from 'react';
 import { getStats, getPfConf } from './lib/api';
 import RecentEvents from "./components/RecentEvents";
 import EventTrends from "./components/EventTrends";
+import IntelligenceIPs from "./components/IntelligenceIPs";
+import TopCountries from "./components/TopCountries";
+import TopASNs from "./components/TopASNs";
 
 
 // keep <body> background in sync with dashboard theme
@@ -202,6 +205,22 @@ export default function App() {
         {/* 🧾 Recent Events table */}
         <div style={{ marginTop: 28 }}>
           <RecentEvents dark={dark} />
+        </div>
+
+        {/* 🔍 Intelligence: Top Source IPs */}
+        <div style={{ marginTop: 36 }}>
+          <IntelligenceIPs dark={dark} />
+        </div>
+
+        {/* 🌍 Top Countries + Top ASNs side by side */}
+        <div style={{
+          marginTop: 28,
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+          gap: 20,
+        }}>
+          <TopCountries dark={dark} />
+          <TopASNs dark={dark} />
         </div>
       </div>
     </div>

--- a/ui/dashboard/src/components/IntelligenceIPs.jsx
+++ b/ui/dashboard/src/components/IntelligenceIPs.jsx
@@ -1,0 +1,309 @@
+import { Fragment, useEffect, useState } from "react";
+import { getIntelligenceIPs, getIntelligenceIP } from "../lib/api";
+import { timeAgo } from "../utils/format";
+
+const REFRESH_MS = 30_000;
+
+function scoreColor(score) {
+  if (score == null) return "#9ca3af";
+  if (score >= 70) return "#ef4444";
+  if (score >= 40) return "#f97316";
+  return "#22c55e";
+}
+
+function Flag({ code }) {
+  if (!code || code.length !== 2) return <span style={{ opacity: 0.4 }}>—</span>;
+  const a = 0x1f1e6 - "A".charCodeAt(0);
+  return (
+    <span title={code}>
+      {String.fromCodePoint(code.charCodeAt(0) + a, code.charCodeAt(1) + a)}
+    </span>
+  );
+}
+
+function TagList({ tags, dark }) {
+  if (!tags || tags.length === 0) return <span style={{ opacity: 0.4 }}>—</span>;
+  return (
+    <span style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          style={{
+            padding: "1px 7px",
+            borderRadius: 9999,
+            fontSize: 11,
+            fontWeight: 600,
+            background: dark ? "rgba(239,68,68,0.2)" : "rgba(239,68,68,0.12)",
+            color: dark ? "#fca5a5" : "#b91c1c",
+          }}
+        >
+          {tag}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function IPProfile({ profile, dark }) {
+  const fg = dark ? "#d1d5db" : "#374151";
+  const chipBg = dark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.07)";
+  const entries = Object.entries(profile.event_type_breakdown ?? {});
+
+  return (
+    <div style={{ display: "flex", gap: 28, flexWrap: "wrap", fontSize: 13, color: fg }}>
+      <div>
+        <div style={{ fontSize: 11, textTransform: "uppercase", opacity: 0.55, marginBottom: 3 }}>
+          First Seen
+        </div>
+        <div style={{ fontFamily: "monospace" }}>
+          {profile.first_seen ? timeAgo(profile.first_seen) : "—"}
+        </div>
+      </div>
+      <div>
+        <div style={{ fontSize: 11, textTransform: "uppercase", opacity: 0.55, marginBottom: 3 }}>
+          Last Seen
+        </div>
+        <div style={{ fontFamily: "monospace" }}>
+          {profile.last_seen ? timeAgo(profile.last_seen) : "—"}
+        </div>
+      </div>
+      <div>
+        <div style={{ fontSize: 11, textTransform: "uppercase", opacity: 0.55, marginBottom: 3 }}>
+          Score
+        </div>
+        <div style={{ fontWeight: 700, color: scoreColor(profile.reputation_score) }}>
+          {profile.reputation_score ?? "—"}
+        </div>
+      </div>
+      {entries.length > 0 && (
+        <div>
+          <div style={{ fontSize: 11, textTransform: "uppercase", opacity: 0.55, marginBottom: 3 }}>
+            Event Breakdown
+          </div>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            {entries.map(([type, count]) => (
+              <span
+                key={type}
+                style={{
+                  padding: "2px 8px",
+                  borderRadius: 6,
+                  background: chipBg,
+                  fontSize: 12,
+                  fontFamily: "monospace",
+                }}
+              >
+                {type}: {count}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function IntelligenceIPs({ dark }) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [online, setOnline] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const [expandedIp, setExpandedIp] = useState(null);
+  const [profiles, setProfiles] = useState({});
+  const [profileLoading, setProfileLoading] = useState(null);
+
+  const cardBg = dark ? "#111827" : "#f9fafb";
+  const border = dark ? "#374151" : "#d1d5db";
+  const fg = dark ? "#e5e7eb" : "#111827";
+  const th = {
+    padding: "0.5rem 0.8rem",
+    textAlign: "left",
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: "uppercase",
+    letterSpacing: "0.05em",
+    whiteSpace: "nowrap",
+  };
+  const td = { padding: "0.55rem 0.8rem" };
+
+  async function fetchList() {
+    try {
+      const data = await getIntelligenceIPs(Date.now());
+      setItems(data.items ?? []);
+      setOnline(true);
+      setLastUpdated(new Date());
+    } catch (e) {
+      console.error("IntelligenceIPs fetch:", e);
+      setOnline(false);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function toggleRow(ip) {
+    if (expandedIp === ip) {
+      setExpandedIp(null);
+      return;
+    }
+    setExpandedIp(ip);
+    if (profiles[ip]) return;
+    setProfileLoading(ip);
+    try {
+      const profile = await getIntelligenceIP(ip);
+      setProfiles((prev) => ({ ...prev, [ip]: profile }));
+    } catch (e) {
+      console.error("IntelligenceIP profile fetch:", e);
+    } finally {
+      setProfileLoading(null);
+    }
+  }
+
+  useEffect(() => {
+    fetchList();
+    const t = setInterval(fetchList, REFRESH_MS);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <div style={{ color: fg }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 10,
+        }}
+      >
+        <h2 style={{ fontSize: 18, fontWeight: 600, margin: 0 }}>Top Source IPs</h2>
+        <span style={{ fontSize: 12, opacity: 0.6 }}>
+          {online
+            ? lastUpdated
+              ? `Updated ${timeAgo(lastUpdated)}`
+              : "Loading…"
+            : "Offline"}
+        </span>
+      </div>
+
+      <div
+        style={{
+          borderRadius: 12,
+          border: `1px solid ${border}`,
+          overflow: "hidden",
+          background: cardBg,
+        }}
+      >
+        <table style={{ width: "100%", fontSize: 13, borderCollapse: "collapse" }}>
+          <thead>
+            <tr
+              style={{
+                background: dark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.04)",
+              }}
+            >
+              <th style={th}>IP</th>
+              <th style={th}>Score</th>
+              <th style={th}>Events</th>
+              <th style={th}>Country</th>
+              <th style={th}>ASN / Org</th>
+              <th style={th}>Tags</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 && !loading && (
+              <tr>
+                <td colSpan={6} style={{ ...td, textAlign: "center", opacity: 0.5 }}>
+                  No intelligence data yet.
+                </td>
+              </tr>
+            )}
+            {items.map((item, idx) => {
+              const isExpanded = expandedIp === item.ip;
+              const evenBg = dark ? "rgba(255,255,255,0.03)" : "rgba(0,0,0,0.01)";
+              const oddBg = dark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.04)";
+              const rowBg = idx % 2 === 0 ? evenBg : oddBg;
+              const hoverBg = dark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.09)";
+              const profile = profiles[item.ip];
+
+              return (
+                <Fragment key={item.ip}>
+                  <tr
+                    onClick={() => toggleRow(item.ip)}
+                    style={{
+                      background: rowBg,
+                      cursor: "pointer",
+                      borderTop: idx > 0 ? `1px solid ${border}` : "none",
+                    }}
+                    onMouseEnter={(e) => (e.currentTarget.style.background = hoverBg)}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = rowBg)}
+                  >
+                    <td style={{ ...td, fontFamily: "monospace", fontWeight: 500 }}>
+                      {item.ip}
+                      <span style={{ marginLeft: 6, fontSize: 10, opacity: 0.45 }}>
+                        {isExpanded ? "▲" : "▼"}
+                      </span>
+                    </td>
+                    <td
+                      style={{
+                        ...td,
+                        fontWeight: 700,
+                        color: scoreColor(item.reputation_score),
+                      }}
+                    >
+                      {item.reputation_score ?? "—"}
+                    </td>
+                    <td style={td}>{item.event_count ?? "—"}</td>
+                    <td style={td}>
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                        <Flag code={item.country_code} />
+                        <span>{item.country_name ?? "—"}</span>
+                      </span>
+                    </td>
+                    <td style={{ ...td, fontFamily: "monospace", fontSize: 12 }}>
+                      {item.asn ? (
+                        <>
+                          <span style={{ opacity: 0.65 }}>AS{item.asn}</span>
+                          {item.asn_org && (
+                            <span style={{ marginLeft: 6 }}>{item.asn_org}</span>
+                          )}
+                        </>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                    <td style={td}>
+                      <TagList tags={item.tags} dark={dark} />
+                    </td>
+                  </tr>
+                  {isExpanded && (
+                    <tr style={{ borderTop: `1px solid ${border}` }}>
+                      <td
+                        colSpan={6}
+                        style={{
+                          padding: "12px 16px",
+                          background: dark
+                            ? "rgba(99,102,241,0.07)"
+                            : "rgba(99,102,241,0.04)",
+                          borderBottom: `1px solid ${border}`,
+                        }}
+                      >
+                        {profileLoading === item.ip ? (
+                          <span style={{ opacity: 0.5, fontSize: 13 }}>
+                            Loading profile…
+                          </span>
+                        ) : profile ? (
+                          <IPProfile profile={profile} dark={dark} />
+                        ) : (
+                          <span style={{ opacity: 0.5, fontSize: 13 }}>
+                            Profile unavailable.
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/ui/dashboard/src/components/TopASNs.jsx
+++ b/ui/dashboard/src/components/TopASNs.jsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import { getTopASNs } from "../lib/api";
+import { timeAgo } from "../utils/format";
+
+const REFRESH_MS = 30_000;
+
+export default function TopASNs({ dark }) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [online, setOnline] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState(null);
+
+  const cardBg = dark ? "#111827" : "#f9fafb";
+  const border = dark ? "#374151" : "#d1d5db";
+  const fg = dark ? "#e5e7eb" : "#111827";
+  const th = {
+    padding: "0.5rem 0.8rem",
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: "uppercase",
+    letterSpacing: "0.05em",
+  };
+  const td = { padding: "0.55rem 0.8rem" };
+
+  async function fetchData() {
+    try {
+      const data = await getTopASNs(Date.now());
+      setItems(data.items ?? []);
+      setOnline(true);
+      setLastUpdated(new Date());
+    } catch (e) {
+      console.error("TopASNs fetch:", e);
+      setOnline(false);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchData();
+    const t = setInterval(fetchData, REFRESH_MS);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <div style={{ color: fg }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 10,
+        }}
+      >
+        <h2 style={{ fontSize: 18, fontWeight: 600, margin: 0 }}>Top ASNs</h2>
+        <span style={{ fontSize: 12, opacity: 0.6 }}>
+          {online
+            ? lastUpdated
+              ? `Updated ${timeAgo(lastUpdated)}`
+              : "Loading…"
+            : "Offline"}
+        </span>
+      </div>
+
+      <div
+        style={{
+          borderRadius: 12,
+          border: `1px solid ${border}`,
+          overflow: "hidden",
+          background: cardBg,
+        }}
+      >
+        <table style={{ width: "100%", fontSize: 13, borderCollapse: "collapse" }}>
+          <thead>
+            <tr
+              style={{
+                background: dark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.04)",
+              }}
+            >
+              <th style={{ ...th, textAlign: "left" }}>ASN</th>
+              <th style={{ ...th, textAlign: "left" }}>Organization</th>
+              <th style={{ ...th, textAlign: "right" }}>Events</th>
+              <th style={{ ...th, textAlign: "right" }}>Unique IPs</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 && !loading && (
+              <tr>
+                <td colSpan={4} style={{ ...td, textAlign: "center", opacity: 0.5 }}>
+                  No ASN data yet.
+                </td>
+              </tr>
+            )}
+            {items.map((item, idx) => {
+              const evenBg = dark ? "rgba(255,255,255,0.03)" : "rgba(0,0,0,0.01)";
+              const oddBg = dark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.04)";
+              return (
+                <tr
+                  key={item.asn}
+                  style={{
+                    background: idx % 2 === 0 ? evenBg : oddBg,
+                    borderTop: idx > 0 ? `1px solid ${border}` : "none",
+                  }}
+                >
+                  <td style={{ ...td, fontFamily: "monospace", fontWeight: 600 }}>
+                    AS{item.asn}
+                  </td>
+                  <td style={td}>{item.asn_org ?? "—"}</td>
+                  <td style={{ ...td, textAlign: "right", fontWeight: 600 }}>
+                    {item.event_count ?? "—"}
+                  </td>
+                  <td style={{ ...td, textAlign: "right" }}>{item.unique_ips ?? "—"}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/ui/dashboard/src/components/TopCountries.jsx
+++ b/ui/dashboard/src/components/TopCountries.jsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import { getTopCountries } from "../lib/api";
+import { timeAgo } from "../utils/format";
+
+const REFRESH_MS = 30_000;
+
+function Flag({ code }) {
+  if (!code || code.length !== 2) return <span style={{ opacity: 0.4 }}>—</span>;
+  const a = 0x1f1e6 - "A".charCodeAt(0);
+  return (
+    <span title={code}>
+      {String.fromCodePoint(code.charCodeAt(0) + a, code.charCodeAt(1) + a)}
+    </span>
+  );
+}
+
+export default function TopCountries({ dark }) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [online, setOnline] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState(null);
+
+  const cardBg = dark ? "#111827" : "#f9fafb";
+  const border = dark ? "#374151" : "#d1d5db";
+  const fg = dark ? "#e5e7eb" : "#111827";
+  const th = {
+    padding: "0.5rem 0.8rem",
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: "uppercase",
+    letterSpacing: "0.05em",
+  };
+  const td = { padding: "0.55rem 0.8rem" };
+
+  async function fetchData() {
+    try {
+      const data = await getTopCountries(Date.now());
+      setItems(data.items ?? []);
+      setOnline(true);
+      setLastUpdated(new Date());
+    } catch (e) {
+      console.error("TopCountries fetch:", e);
+      setOnline(false);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchData();
+    const t = setInterval(fetchData, REFRESH_MS);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <div style={{ color: fg }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 10,
+        }}
+      >
+        <h2 style={{ fontSize: 18, fontWeight: 600, margin: 0 }}>Top Countries</h2>
+        <span style={{ fontSize: 12, opacity: 0.6 }}>
+          {online
+            ? lastUpdated
+              ? `Updated ${timeAgo(lastUpdated)}`
+              : "Loading…"
+            : "Offline"}
+        </span>
+      </div>
+
+      <div
+        style={{
+          borderRadius: 12,
+          border: `1px solid ${border}`,
+          overflow: "hidden",
+          background: cardBg,
+        }}
+      >
+        <table style={{ width: "100%", fontSize: 13, borderCollapse: "collapse" }}>
+          <thead>
+            <tr
+              style={{
+                background: dark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.04)",
+              }}
+            >
+              <th style={{ ...th, textAlign: "left" }}>Country</th>
+              <th style={{ ...th, textAlign: "right" }}>Events</th>
+              <th style={{ ...th, textAlign: "right" }}>Unique IPs</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 && !loading && (
+              <tr>
+                <td colSpan={3} style={{ ...td, textAlign: "center", opacity: 0.5 }}>
+                  No country data yet.
+                </td>
+              </tr>
+            )}
+            {items.map((item, idx) => {
+              const evenBg = dark ? "rgba(255,255,255,0.03)" : "rgba(0,0,0,0.01)";
+              const oddBg = dark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.04)";
+              return (
+                <tr
+                  key={item.country_code}
+                  style={{
+                    background: idx % 2 === 0 ? evenBg : oddBg,
+                    borderTop: idx > 0 ? `1px solid ${border}` : "none",
+                  }}
+                >
+                  <td style={td}>
+                    <span style={{ display: "inline-flex", alignItems: "center", gap: 7 }}>
+                      <Flag code={item.country_code} />
+                      <span>{item.country_name ?? item.country_code ?? "—"}</span>
+                    </span>
+                  </td>
+                  <td style={{ ...td, textAlign: "right", fontWeight: 600 }}>
+                    {item.event_count ?? "—"}
+                  </td>
+                  <td style={{ ...td, textAlign: "right" }}>{item.unique_ips ?? "—"}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/ui/dashboard/src/lib/api.js
+++ b/ui/dashboard/src/lib/api.js
@@ -9,3 +9,27 @@ export async function getPfConf(ts = Date.now()) {
   if (!r.ok) throw new Error(`pf.conf ${r.status}`);
   return r.text();
 }
+
+export async function getIntelligenceIPs(ts = Date.now()) {
+  const r = await fetch(`/api/intelligence/ips?limit=25&ts=${ts}`, { headers: { 'x-api-key': 'dev-123' } });
+  if (!r.ok) throw new Error(`intelligence/ips ${r.status}`);
+  return r.json();
+}
+
+export async function getIntelligenceIP(ip) {
+  const r = await fetch(`/api/intelligence/ips/${encodeURIComponent(ip)}`, { headers: { 'x-api-key': 'dev-123' } });
+  if (!r.ok) throw new Error(`intelligence/ips/${ip} ${r.status}`);
+  return r.json();
+}
+
+export async function getTopCountries(ts = Date.now()) {
+  const r = await fetch(`/api/intelligence/top-countries?ts=${ts}`, { headers: { 'x-api-key': 'dev-123' } });
+  if (!r.ok) throw new Error(`top-countries ${r.status}`);
+  return r.json();
+}
+
+export async function getTopASNs(ts = Date.now()) {
+  const r = await fetch(`/api/intelligence/top-asns?ts=${ts}`, { headers: { 'x-api-key': 'dev-123' } });
+  if (!r.ok) throw new Error(`top-asns ${r.status}`);
+  return r.json();
+}


### PR DESCRIPTION
## Summary

- Adds **IntelligenceIPs** component: top source IPs ranked by reputation score, with expandable row detail (event_type_breakdown, first/last seen, score chips)
- Adds **TopCountries** component: country breakdown table with flag emoji, event count, unique IP count
- Adds **TopASNs** component: ASN breakdown table with org name, event count, unique IPs
- Adds 4 fetch helpers to `api.js` (`getIntelligenceIPs`, `getIntelligenceIP`, `getTopCountries`, `getTopASNs`)
- Wires all three into `App.jsx` below RecentEvents: IntelligenceIPs full-width, TopCountries + TopASNs in a responsive 2-column grid

## Endpoints consumed

| Endpoint | Component |
|---|---|
| `GET /api/intelligence/ips?limit=25` | IntelligenceIPs list |
| `GET /api/intelligence/ips/{ip}` | IntelligenceIPs expandable row detail |
| `GET /api/intelligence/top-countries` | TopCountries |
| `GET /api/intelligence/top-asns` | TopASNs |

## Design notes

- Reputation score is color-coded: red (≥70), orange (≥40), green (<40)
- Tags rendered as small badge chips
- Expanded IP row fetches single-IP profile on demand; result is cached client-side for the session
- All panels poll every 30s (vs 10s for live events — intel data changes less frequently)
- Matches existing dark/light theme via `dark` prop; inline styles consistent with existing components

## What was NOT changed

- No backend changes
- No new API endpoints
- No schema migrations
- Pre-existing `RecentEvents.jsx` ESLint warning (`tick` unused var) not touched per PR scope

## Test plan

- [x] 245/245 backend tests pass (`pytest -q`)
- [x] Zero ESLint errors in all 5 changed/new files (`eslint src/components/IntelligenceIPs.jsx src/components/TopCountries.jsx src/components/TopASNs.jsx src/App.jsx src/lib/api.js`)
- [x] Pre-commit hooks pass