### PR TITLE
docs: Phase 3 close-out and Phase 4 direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 | **Phase 0** | Security & Infrastructure Hygiene | ✅ Complete |
 | **Phase 1** | SQLite Storage Foundation | ✅ Complete |
 | **Phase 2** | HTTP Ingestion API | ✅ Complete |
-| **Phase 3** | GeoIP Enrichment | ⏳ Next |
-| **Phase 4** | ATT&CK Mapping & Standard Exports | ⏳ Planned |
+| **Phase 3** | GeoIP Enrichment & Intelligence Exports | ✅ Complete |
+| **Phase 4** | Campaign Intelligence & Export Maturity | ⏳ Next |
 | **Phase 5** | AI Integration | ⏳ Planned |
 | **Phase 6** | Behavioral Memory & Campaign Tracking | ⏳ Planned |
 | **Phase 7** | Privacy-Preserving Federation | ⏳ Planned |
@@ -73,6 +73,7 @@ Honeypot sensors (Cowrie, Dionaea, ...)
          ▼
     FastAPI Backend (app/)
          │  Pydantic validation → normalization → deduplication
+         │  GeoIP enrichment (country, city, ASN) via geoip2
          ▼
     storage/legiontrap.db  (SQLite, primary store)
          │  INSERT raw_events + events + UPSERT source_ips
@@ -80,11 +81,10 @@ Honeypot sensors (Cowrie, Dionaea, ...)
          │
     Read path: SQL queries via EventRepository
          │
-         ▼
-    GET /api/stats, /api/events, /api/iocs/pf.conf, /api/iocs/ufw.txt
-         │
-         ▼
-    Browser dashboard / firewall scripts
+         ├── GET /api/stats, /api/events         → Browser dashboard
+         ├── GET /api/iocs/pf.conf, /ufw.txt     → Firewall scripts
+         ├── GET /api/intelligence/*             → Intelligence panels
+         └── GET /api/exports/*                 → External TI tools
 ```
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full component map.
@@ -126,15 +126,21 @@ curl -s -H "$H" http://127.0.0.1:8088/api/iocs/pf.conf
 
 ## API Endpoints
 
-| Method | Path                    | Auth | Description                           |
-|-------:|-------------------------|:----:|---------------------------------------|
-| GET    | `/api/health`           |  No  | Liveness check                        |
-| POST   | `/api/login`            |  No  | Dashboard login → JWT token           |
-| POST   | `/api/ingest`           | API key | Batch event ingest (up to 500)     |
-| GET    | `/api/stats`            | Yes  | Total events, unique IPs, last-24h    |
-| GET    | `/api/events`           | Yes  | Recent events (newest first)          |
-| GET    | `/api/iocs/ufw.txt`     | Yes  | UFW deny list (privacy-aware)         |
-| GET    | `/api/iocs/pf.conf`     | Yes  | PF table config (privacy-aware)       |
+| Method | Path                              | Auth    | Description                              |
+|-------:|-----------------------------------|:-------:|------------------------------------------|
+| GET    | `/api/health`                     | No      | Liveness check                           |
+| POST   | `/api/login`                      | No      | Dashboard login → JWT token              |
+| POST   | `/api/ingest`                     | API key | Batch event ingest (up to 500)           |
+| GET    | `/api/stats`                      | Yes     | Total events, unique IPs, last-24h       |
+| GET    | `/api/events`                     | Yes     | Recent events (newest first)             |
+| GET    | `/api/iocs/ufw.txt`               | Yes     | UFW deny list (privacy-aware)            |
+| GET    | `/api/iocs/pf.conf`               | Yes     | PF table config (privacy-aware)          |
+| GET    | `/api/intelligence/ips`           | Yes     | Top source IPs with reputation scores    |
+| GET    | `/api/intelligence/ips/{ip}`      | Yes     | Detail record for a single IP            |
+| GET    | `/api/intelligence/top-countries` | Yes     | Top countries by event count             |
+| GET    | `/api/intelligence/top-asns`      | Yes     | Top ASNs by event count                  |
+| GET    | `/api/exports/attack-navigator`   | Yes     | ATT&CK Navigator layer JSON              |
+| GET    | `/api/exports/stix`               | Yes     | STIX 2.1 Indicator bundle (blocked when `PRIVACY_MODE=on`) |
 
 **Auth options:**
 - API key header: `x-api-key: <API_KEY>`
@@ -177,7 +183,7 @@ make db-validate
 | `FEED_SALT`        | Yes      | HMAC salt for privacy-mode IP hashing.                           |
 | `DASH_USER`        | Yes      | Dashboard login username.                                        |
 | `DASH_PASS`        | Yes      | Dashboard password as a bcrypt hash.                             |
-| `PRIVACY_MODE`     | No       | Set `on` to enable privacy masking on IOC exports (default off). |
+| `PRIVACY_MODE`     | No       | Set `on` to enable privacy masking on IOC exports and block STIX export (default off). |
 | `CORS_ORIGINS`     | No       | Comma-separated allowed origins (default: localhost variants).   |
 | `DB_PATH`          | No       | SQLite file path (default: `storage/legiontrap.db`).             |
 | `LOGIN_RATE_LIMIT` | No       | Rate limit for `/api/login` (default: `5/minute`).               |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,27 +19,39 @@ Browser (React 19 + Vite)
   │     └── POST /api/login → JWT token stored in localStorage
   │
   ├── Dashboard (authenticated)
-  │     ├── GET /api/stats          → KPI counters
-  │     ├── GET /api/iocs/pf.conf   → Firewall block table preview
-  │     ├── GET /api/events         → Recent events table
-  │     └── GET /api/events         → Event trends chart
+  │     ├── GET /api/stats                      → KPI counters
+  │     ├── GET /api/iocs/pf.conf               → Firewall block table preview
+  │     ├── GET /api/events                     → Recent events table + trends chart
+  │     ├── GET /api/intelligence/ips           → Top Source IPs panel
+  │     ├── GET /api/intelligence/top-countries → Top Countries panel
+  │     └── GET /api/intelligence/top-asns      → Top ASNs panel
   │
-  └── Auto-refresh: 10s interval
+  └── Auto-refresh: 10–30s interval per component
 
 FastAPI Backend (app/)
   │
   ├── app/main.py               FastAPI instance, CORS, router registration
   ├── app/routers/
   │     ├── auth_router.py      POST /api/login → JWT
-  │     ├── ingest.py           POST /api/ingest (batch ingest, audit log)
+  │     ├── ingest.py           POST /api/ingest (batch ingest, GeoIP enrichment, audit log)
   │     ├── stats.py            GET /api/stats
   │     ├── events.py           GET /api/events
-  │     └── iocs_pf.py          GET /api/iocs/pf.conf, /api/iocs/ufw.txt
+  │     ├── iocs_pf.py          GET /api/iocs/pf.conf, /api/iocs/ufw.txt
+  │     ├── intelligence.py     GET /api/intelligence/* (top IPs, countries, ASNs, IP detail)
+  │     └── exports.py          GET /api/exports/attack-navigator, /api/exports/stix
+  ├── app/exports/
+  │     ├── attack_navigator.py  Pure transform: technique counts → Navigator layer dict
+  │     └── stix.py              Pure transform: IP records → STIX 2.1 bundle dict
   ├── app/db/
-  │     ├── connection.py       SQLAlchemy engine, session factory, create_all_tables()
-  │     └── repository.py       EventRepository — all SQL lives here
+  │     ├── connection.py        SQLAlchemy engine, session factory, create_all_tables()
+  │     ├── repository.py        EventRepository public facade (re-exports mixin composition)
+  │     └── repositories/
+  │           ├── _base.py       BaseRepository (session holder)
+  │           ├── read.py        ReadRepository — event and source_ip queries
+  │           ├── write.py       WriteRepository — ingest, audit_log
+  │           └── intelligence.py  IntelligenceRepository — top IPs, countries, ASNs, STIX/ATT&CK queries
   ├── app/schemas/
-  │     └── ingest.py           RawEvent, HoneypotEvent, IngestRequest, IngestReceipt
+  │     └── models.py           RawEvent, HoneypotEvent, IngestRequest, IngestReceipt
   ├── app/utils/
   │     ├── auth.py             JWT helpers, require_jwt_or_api_key dependency
   │     └── event_utils.py      extract_src_ip(), normalize_event_type(), parse_timestamp()
@@ -50,7 +62,7 @@ Storage
   └── storage/
         ├── legiontrap.db        SQLite database (primary data store)
         ├── backups/             DB snapshot backups (see JSONL_RETIREMENT.md for schedule)
-        └── GeoLite2-City.mmdb   IP geolocation database (installed; used in Phase 3)
+        └── GeoLite2-City.mmdb   IP geolocation database (active — used by ingest enrichment)
 
 Deployment
   └── docker/
@@ -84,17 +96,18 @@ External honeypot (Cowrie, Dionaea, etc.)
     ▼
 FastAPI ingest.py
     │  Pydantic validation → normalization → deduplication
+    │  GeoIP enrichment: geoip2.database.Reader → country, city, ASN
     ▼
 storage/legiontrap.db (SQLite, primary store)
-    │  INSERT raw_events + events + UPSERT source_ips
+    │  INSERT raw_events + events + UPSERT source_ips (with geo fields)
     │  INSERT audit_log (separate session)
     │
-    │  indexed SQL queries
-    ▼
-FastAPI (stats.py / events.py / iocs_pf.py)
+    │  indexed SQL queries via EventRepository
     │
-    ▼
-API response → Browser / Script / Firewall
+    ├── stats.py / events.py        → API response → Browser dashboard
+    ├── iocs_pf.py                  → API response → Firewall scripts
+    ├── intelligence.py             → API response → Intelligence panels
+    └── exports.py + app/exports/   → API response → External TI tools
 ```
 
 **Read path:** All dashboard and IOC queries run SQL against `legiontrap.db` via `EventRepository`. No file scans.
@@ -113,6 +126,8 @@ The privacy system operates at the IOC export layer, not at the storage layer. E
 
 The privacy transformation is applied in `iocs_pf.py` after calling `EventRepository.get_unique_public_ips()` to retrieve IPs from SQLite.
 
+**STIX export and PRIVACY_MODE:** The `GET /api/exports/stix` endpoint returns HTTP 422 when `PRIVACY_MODE=on`. STIX Indicator patterns require embedding raw IP addresses (`[ipv4-addr:value = '1.2.3.4']`), which is incompatible with privacy mode's intent. The ATT&CK Navigator export is unaffected because it contains no IP data.
+
 ---
 
 ## Frontend Structure
@@ -126,8 +141,11 @@ ui/dashboard/
     components/
       EventTrends.jsx    Recharts line chart of events over time
       RecentEvents.jsx   Tabular view of most recent events
+      IntelligenceIPs.jsx  Top Source IPs table with expandable IP detail rows
+      TopCountries.jsx   Top Countries panel (country, event count, unique IPs)
+      TopASNs.jsx        Top ASNs panel (ASN, organization, event count, unique IPs)
     lib/
-      api.js             Authenticated fetch helpers (getStats, getPfConf)
+      api.js             Authenticated fetch helpers (stats, events, intelligence, exports)
     utils/
       format.js          Date/time formatting utilities
     index.css            Global styles + dark/light mode variables

--- a/docs/PHASE_3_CLOSEOUT.md
+++ b/docs/PHASE_3_CLOSEOUT.md
@@ -1,0 +1,146 @@
+# Phase 3 Close-Out — GeoIP Enrichment and Intelligence Exports
+
+**Document type:** Phase completion record and architectural handoff
+**Audience:** Engineers, contributors
+**Date:** 2026-05-25
+
+---
+
+## What Phase 3 Delivered
+
+Phase 3 exceeded its original scope. It was specified as a GeoIP enrichment phase; it shipped a complete intelligence layer and standard TI export capability.
+
+### Pull Requests
+
+| PR | Branch | Title |
+|----|--------|-------|
+| PR 1 | `feat/phase3-geoip-enrichment` | GeoIP enrichment on ingestion |
+| PR 2 | `feat/phase3-intelligence-api` | Intelligence API (top IPs, countries, ASNs, reputation) |
+| PR 3 | `feat/phase3-source-ip-reputation` | Source IP reputation scoring |
+| PR 4 | `refactor/remove-jsonl-replica` | Remove JSONL replica write from ingest path |
+| PR 5 | `feat/phase3-dashboard-intelligence` | Dashboard intelligence visibility panels |
+| PR 6 | `feat/phase3-exports` | ATT&CK Navigator and STIX 2.1 export endpoints |
+
+### Functional Capabilities Added
+
+**GeoIP enrichment**
+- Every ingested event with a routable source IP is enriched at ingest time with `country_code`, `country_name`, `city`, `asn`, and `asn_org`.
+- Enrichment uses `geoip2.database.Reader` against the bundled `GeoLite2-City.mmdb`.
+- Private, loopback, and reserved IPs are not enriched; `src_ip` is stored as NULL.
+
+**Intelligence API (`GET /api/intelligence/*`)**
+- `GET /api/intelligence/ips` — paginated list of source IPs ordered by reputation score
+- `GET /api/intelligence/ips/{ip}` — full detail record for a single observed IP
+- `GET /api/intelligence/top-countries` — top countries by event count with unique IP counts
+- `GET /api/intelligence/top-asns` — top ASNs by event count with unique IP counts
+
+**Reputation scoring**
+- Heuristic reputation score (0.0–1.0) assigned to each `source_ips` row.
+- Score computed from event count, event type diversity, and presence of high-severity event types (brute force, command execution, auth success on honeypot).
+
+**Dashboard panels**
+- IntelligenceIPs: top source IPs table with expandable detail rows showing full IP intelligence record.
+- TopCountries: country breakdown with flag, event count, unique IP count.
+- TopASNs: ASN breakdown with organization name, event count, unique IP count.
+
+**ATT&CK Navigator export (`GET /api/exports/attack-navigator`)**
+- Returns a full ATT&CK Navigator layer JSON.
+- Technique IDs and tactic mappings come exclusively from the `event_types` table; no technique IDs are hardcoded in application code.
+- Gradient `maxValue` scales dynamically to the highest observed event count.
+- PRIVACY_MODE does not affect this endpoint (no IP data is exported).
+
+**STIX 2.1 export (`GET /api/exports/stix`)**
+- Returns a STIX 2.1 Bundle containing one `ipv4-addr` SCO and one `indicator` SDO per qualifying IP.
+- Deterministic IDs: `uuid5` over a project namespace ensures the same IP always produces the same object IDs across exports.
+- Object IDs are stable; re-exporting after new events does not invalidate previously distributed bundles.
+- Blocked with HTTP 422 when `PRIVACY_MODE=on` (STIX patterns require raw IPs).
+- No `stix2` library dependency — plain Python dicts.
+
+**JSONL replica retirement (PR 4)**
+- The JSONL replica write path (`tmp_events.jsonl`) was removed from the ingest route.
+- `scripts/import_jsonl.py` is retained for one-time historical data migrations.
+- See [JSONL_RETIREMENT.md](JSONL_RETIREMENT.md) for backup and restore procedures.
+
+---
+
+## Architectural Changes
+
+### New Modules
+
+| Module | Role |
+|--------|------|
+| `app/routers/intelligence.py` | Intelligence API router |
+| `app/routers/exports.py` | Standard exports router |
+| `app/exports/attack_navigator.py` | Pure transform: technique counts → Navigator layer |
+| `app/exports/stix.py` | Pure transform: IP records → STIX 2.1 bundle |
+| `app/db/repositories/intelligence.py` | SQL queries for intelligence and export data |
+
+### Export Layer Design Rule
+
+`app/exports/` modules are pure transformation functions. They receive plain Python dicts from the repository layer and return plain Python dicts. They have no imports from FastAPI, SQLAlchemy, or `app.core.config`. This boundary must be maintained: the export layer does not know about HTTP, database sessions, or environment configuration.
+
+### Repository Mixin Pattern
+
+`EventRepository` inherits from three mixin classes: `WriteRepository`, `ReadRepository`, and `IntelligenceRepository`. New query methods belong in the mixin that matches their concern. The class hierarchy is:
+
+```
+EventRepository(WriteRepository, ReadRepository, IntelligenceRepository)
+```
+
+---
+
+## Intentional Deferrals
+
+These items were considered during Phase 3 and explicitly deferred. They must not be added until their prerequisite layer is stable.
+
+| Item | Reason deferred | Prerequisite |
+|------|----------------|--------------|
+| STIX Relationship objects | Relationships require campaign-level data to be meaningful | Campaign clustering (Phase 4) |
+| STIX Campaign and AttackPattern objects | Same as above | Phase 4 |
+| Sigma rule export | Sigma rules encode behavioral patterns; no behavioral pattern layer exists yet | Phase 4 |
+| MISP event package export | MISP packages benefit from campaign attribution | Phase 4 |
+| AI narrative analysis | No reasoning layer exists; querying raw events without semantic compression produces noise | Phase 5 |
+| Campaign clustering | Requires behavioral fingerprint schema design; out of scope for Phase 3 | Phase 4 |
+| Webhook alerting | No campaign detection threshold to trigger alerts against | Phase 4 |
+
+---
+
+## Operational Risks
+
+**GeoLite2-City.mmdb is not auto-updated.** The bundled MaxMind database is a point-in-time snapshot. ASN and country assignments for IPs change over time. Operators should establish a process to refresh this file periodically (MaxMind provides a free update subscription).
+
+**Reputation scoring is heuristic only.** The current reputation score is a local heuristic based on observed event patterns. It has no external feed backing. An IP with a score of 0.9 has been observed behaving maliciously against this sensor — it has not been cross-referenced with any external threat intelligence source.
+
+**STIX bundle has no `spec_version` at the bundle level.** This is correct per the STIX 2.1 specification but differs from STIX 2.0 behavior. Consumers targeting STIX 2.0 will behave unexpectedly.
+
+**STIX IDs are deployment-stable, not globally unique.** Two independent LegionTrap deployments observing the same IP will produce the same STIX object IDs. This is intentional (enables deduplication in MISP/TAXII) but means consumers must not assume IDs are globally allocated.
+
+**Dashboard panels poll independently.** IntelligenceIPs, TopCountries, and TopASNs each poll on their own 30-second interval. Under heavy load this produces multiple concurrent API calls. A shared polling coordinator is a future improvement.
+
+---
+
+## Phase 4 Direction
+
+Phase 4 should not start until this close-out PR is merged. The Phase 4 objective is campaign intelligence: moving from per-event and per-IP observations to behavioral campaign recognition.
+
+### Guiding constraint
+
+Do not build STIX Relationship objects, Sigma rules, or MISP packages until there is campaign data to populate them. Building these export formats against per-IP data produces technically correct but semantically weak output.
+
+### Recommended Phase 4 sequence
+
+1. **Define behavioral fingerprint schema.** What fields constitute a behavioral signature? Port sequence, timing distribution, event type sequence, tool signature (User-Agent patterns, payload fingerprints). Decide which fields are stored in `source_ips`, which require a new `behavioral_fingerprints` table.
+
+2. **Campaign clustering.** Group `source_ips` rows into campaigns using behavioral similarity. Start simple: shared ASN + overlapping port sequences + overlapping time windows. A campaign is a set of source IPs that appear to operate as a coordinated unit.
+
+3. **`GET /api/campaigns` endpoint.** Return active and historical campaign clusters. Each campaign has a stable ID, a behavioral summary, member IPs, first/last activity, and a confidence score.
+
+4. **Campaign recurrence detection.** When a new IP is ingested, check whether its behavioral fingerprint matches any historical campaign. If so, flag it as a recurrence. This is the core value proposition of LegionTrap's intelligence layer.
+
+5. **STIX Relationship and Campaign objects.** Once campaign data exists, add `relationship` SDOs (Indicator `indicates` Campaign) and `campaign` SDOs to the STIX bundle. These are the objects that make a STIX bundle actionable in a MISP or TAXII workflow.
+
+6. **Export maturity.** Sigma rules and MISP packages naturally follow from campaign data. Defer until step 5 is complete.
+
+---
+
+*Cross-references: [ROADMAP.md](ROADMAP.md) · [ARCHITECTURE.md](ARCHITECTURE.md) · [JSONL_RETIREMENT.md](JSONL_RETIREMENT.md)*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,21 +14,24 @@ The order of this roadmap is not arbitrary. Each phase is a prerequisite for the
 
 ---
 
-## Current State (as of Phase 1B)
+## Current State (as of Phase 3)
 
 | Capability | Status | Notes |
 |---|---|---|
-| Event storage | SQLite (WAL mode) | `storage/legiontrap.db`; JSONL as best-effort replica |
-| Event ingestion | `POST /api/ingest` | Batch ingest, Pydantic validation, deduplication |
+| Event storage | SQLite (WAL mode) | `storage/legiontrap.db`; JSONL replica retired (PR 4) |
+| Event ingestion | `POST /api/ingest` | Batch ingest, Pydantic validation, GeoIP enrichment, deduplication |
+| GeoIP enrichment | Working | `geoip2` + `GeoLite2-City.mmdb`; country, city, ASN on every routable IP |
 | Stats API | Working | SQL queries via `EventRepository` |
+| Intelligence API | Working | Top IPs, top countries, top ASNs, IP detail, reputation scoring |
 | IOC export (pf.conf, UFW) | Working | SQL-backed; privacy masking via HMAC or octet mask |
+| ATT&CK Navigator export | Working | `GET /api/exports/attack-navigator`; technique IDs from `event_types` table |
+| STIX 2.1 export | Working | `GET /api/exports/stix`; blocked when `PRIVACY_MODE=on` |
 | JWT + API key auth | Working | bcrypt password verification; hardcoded defaults removed |
 | Audit logging | Working | `audit_log` table; one row per ingest batch |
 | Data retention | Working | `delete_events_before()` + `make db-prune` |
-| React dashboard | Working | KPI cards, event chart, recent events |
+| React dashboard | Working | KPI cards, event chart, recent events, intelligence panels (IPs, countries, ASNs) |
 | CI/CD | Working | Lint, test, semantic release; Black 26.5.1 pinned |
 | Docker Compose | Working | Edge deployment profile |
-| GeoIP library | Installed | Not wired into ingest route; Phase 3 work |
 | AI integration | None | Planned Phase 5 |
 | Behavioral memory | None | Planned Phase 6 |
 
@@ -108,41 +111,49 @@ Without this, LegionTrap cannot receive events from remote sensors, cloud functi
 
 ---
 
-## Phase 3 — GeoIP Enrichment and Event Context
+## Phase 3 — GeoIP Enrichment and Event Context — **Complete**
 
-**Duration:** 1 week
-**Goal:** Wire in the already-installed GeoIP library. Every event gets country, city, and ASN context at ingestion time.
+**Goal:** Wire in the already-installed GeoIP library. Every event gets country, city, and ASN context at ingestion time. Expose intelligence endpoints and standard exports.
 
-This is low-effort, high-value. The library and database are already present. This is the first step toward behavioral intelligence — geographic and organizational context is the simplest behavioral signal.
+| Task | Status | Notes |
+|---|---|---|
+| Enrich `src_ip` with country, city, ASN on ingestion | ✅ | `geoip2` + `GeoLite2-City.mmdb`; fires on every routable IP |
+| Add enrichment fields to `HoneypotEvent` schema | ✅ | `country_code`, `country_name`, `city`, `asn`, `asn_org` |
+| Add geographic filtering to stats endpoint | ✅ | `GET /api/intelligence/top-countries`, `GET /api/intelligence/top-asns` |
+| Update dashboard to display geographic context | ✅ | IntelligenceIPs, TopCountries, TopASNs panels |
+| Intelligence API — top IPs with reputation scoring | ✅ | `GET /api/intelligence/ips`, `GET /api/intelligence/ips/{ip}` |
+| JSONL replica write removed from ingest path | ✅ | PR 4; `scripts/import_jsonl.py` retained for one-time migrations |
+| ATT&CK Navigator export | ✅ | `GET /api/exports/attack-navigator`; technique weights from event counts |
+| STIX 2.1 Indicator bundle export | ✅ | `GET /api/exports/stix`; deterministic IDs; blocked by `PRIVACY_MODE` |
 
-| Task | Notes |
-|---|---|
-| Enrich `src_ip` with country, city, ASN on ingestion | `geoip2` is already installed; `GeoLite2-City.mmdb` is present |
-| Add enrichment fields to `HoneypotEvent` schema | `country_code`, `country_name`, `city`, `asn`, `asn_org` |
-| Add geographic filtering to stats endpoint | Top countries, top ASNs |
-| Update dashboard to display geographic context | Flag + country in event table |
+**Deferred out of Phase 3:** Sigma rules, MISP event packages, campaign clustering, AI reasoning. See Phase 4 and Phase 5.
 
-**Exit criteria:** Every ingested event with a routable IP has country and ASN attached. The dashboard shows geographic breakdown.
+**Exit criteria met:** Every ingested event with a routable IP has country and ASN attached. The dashboard shows geographic and intelligence breakdowns. Standard TI exports are operational.
 
 ---
 
-## Phase 4 — ATT&CK Mapping and Standard Exports
+## Phase 4 — Campaign Intelligence and Export Maturity
 
-**Duration:** 2–3 weeks
-**Goal:** Map event types to MITRE ATT&CK technique IDs. Export intelligence in standard formats.
+**Duration:** 3–5 weeks
+**Goal:** Move from individual event intelligence to behavioral campaign recognition. Mature the export layer with additional standard formats.
 
-This makes LegionTrap interoperable with the broader security ecosystem and signals to the community that the platform speaks the same language as serious TI tools.
+Phase 3 delivered the foundation: enriched events, a queryable intelligence layer, ATT&CK mapping, and initial STIX/Navigator exports. Phase 4 builds the first layer of memory — grouping events into campaigns and producing richer export artifacts from those clusters.
 
 | Task | Notes |
 |---|---|
-| Define event type taxonomy | `ssh_login_fail`, `port_scan`, `http_probe`, `malware_upload`, etc. |
-| Map event types to ATT&CK technique IDs | T1110 (brute force), T1046 (network scan), etc. |
-| `GET /api/exports/attack-navigator` | ATT&CK Navigator layer JSON |
+| Campaign detection (simple clustering) | Group events by source ASN, port sequence, timing, tool signatures |
+| `source_ips` behavioral tagging improvements | Automated tag assignment from event type patterns |
+| `GET /api/campaigns` | Active and historical campaign clusters |
+| Campaign recurrence detection | Alert when a known fingerprint reappears with new infrastructure |
+| `GET /api/exports/stix` — Relationship objects | Add `relationship` SDOs between IPv4-Addr and Indicator once campaigns exist |
 | `GET /api/exports/sigma` | Sigma rule per observed behavioral pattern |
-| `GET /api/exports/stix` | STIX 2.1 bundle of observed indicators |
 | `GET /api/exports/misp` | MISP-compatible event package |
+| STIX AttackPattern and Campaign objects | Requires campaign data; deferred from Phase 3 deliberately |
+| Webhook alerting | Notify operator when campaign threshold is crossed |
 
-**Exit criteria:** An analyst can import LegionTrap's output directly into MISP, ATT&CK Navigator, or a Sigma-compatible SIEM.
+**Prerequisite note:** STIX Campaign and Relationship objects, Sigma rules, and MISP packages all require campaign-level data. Do not attempt them before campaign clustering is operational.
+
+**Exit criteria:** The system detects that a campaign observed today shares behavioral characteristics with a previously observed campaign. An analyst can export a STIX bundle containing Relationship objects. A Sigma rule can be exported for any observed behavioral pattern.
 
 ---
 
@@ -223,10 +234,10 @@ These items are valid strategic directions but must not be attempted before the 
 Phase 0:  Fix security hygiene (no architecture change)
 Phase 1:  JSONL → SQLite (storage layer replacement)
 Phase 2:  File ingestion → HTTP ingestion API (input layer addition)
-Phase 3:  Raw events → enriched events (processing layer addition)
-Phase 4:  Events → standard intelligence exports (output layer expansion)
+Phase 3:  Raw events → enriched events + intelligence API + standard exports (processing + output layer)
+Phase 4:  Events → campaign clusters + export maturity (memory layer foundation)
 Phase 5:  Data → AI-reasoned intelligence (reasoning layer addition)
-Phase 6:  Events → behavioral memory + campaigns (memory layer addition)
+Phase 6:  Events → behavioral memory + campaigns (memory layer maturation)
 Phase 7:  Local memory → federated collective intelligence (network layer addition)
 ```
 


### PR DESCRIPTION
## Summary

- Marks Phase 3 complete in ROADMAP.md, README.md, and ARCHITECTURE.md
- Updates "Current State" table from stale Phase 1B snapshot to Phase 3 reality
- Reframes Phase 4 around campaign/behavioral intelligence (ATT&CK Navigator and STIX 2.1 were delivered in Phase 3)
- Creates `docs/PHASE_3_CLOSEOUT.md` documenting what was delivered, architectural changes, intentional deferrals, operational risks, and Phase 4 recommended sequence

## Changes

**README.md**
- Roadmap table: Phase 3 → ✅ Complete, Phase 4 renamed and marked ⏳ Next
- Architecture diagram updated to show GeoIP enrichment step and four output paths
- API endpoints table expanded from 7 to 13 entries (intelligence and export endpoints added)
- PRIVACY_MODE description updated to mention STIX blocking

**docs/ROADMAP.md**
- "Current State" updated to reflect Phase 3 completion (GeoIP, intelligence API, ATT&CK/STIX exports, JSONL retirement)
- Phase 3 section marked Complete with per-task status checklist
- Phase 4 reframed: removes tasks already shipped in Phase 3, adds campaign clustering, recurrence detection, and export maturity gating on campaign data
- Architecture Evolution Summary updated

**docs/ARCHITECTURE.md**
- Component map: adds `intelligence.py` and `exports.py` routers, `app/exports/` layer, full `repositories/` subdirectory structure, corrects schema filename (`ingest.py` → `models.py`)
- Event Flow diagram: shows GeoIP enrichment step and four distinct read paths
- Frontend Structure: adds IntelligenceIPs, TopCountries, TopASNs components
- Privacy Model: documents STIX export blocking behavior under PRIVACY_MODE

**docs/PHASE_3_CLOSEOUT.md** (new)
- Full record of Phase 3 PRs and capabilities delivered
- Export layer design rule (pure transform, no FastAPI/DB imports)
- Repository mixin pattern documentation
- Intentional deferrals with rationale (Sigma, MISP, campaigns, AI)
- Operational risks (GeoLite2 staleness, heuristic scoring, STIX ID semantics, dashboard polling)
- Phase 4 recommended sequence

## Scope

Documentation only. No application code, API, schema, or dashboard changes.