### PR TITLE
feat(intelligence): behavioral fingerprint generation (Phase 4 PR 2+3)

### DIFF
--- a/app/db/repositories/fingerprint.py
+++ b/app/db/repositories/fingerprint.py
@@ -1,0 +1,163 @@
+"""Fingerprint repository methods: reads and writes for behavioral_fingerprints.
+
+All SQL lives in this module.  No application logic, no fingerprint computation.
+The caller owns the session and transaction boundary.
+
+PostgreSQL-compatibility rules enforced here:
+  - INSERT ... ON CONFLICT(source_ip) DO UPDATE SET (not INSERT OR REPLACE)
+  - No json_extract() in SQL WHERE clauses
+  - No dialect-specific datetime functions; timestamps are application-inserted
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db.repositories._base import RepositoryBase
+
+
+class FingerprintRepository(RepositoryBase):
+    def get_events_for_fingerprint(self, ip: str) -> list[dict[str, Any]]:
+        """Return all events for ip joined with their raw_data.
+
+        Ordered chronologically ascending.  Each row becomes one entry in the
+        event list consumed by the sequence extraction utilities.
+
+        The raw_json column stores the full serialised RawEvent.  Only the
+        data sub-dict is extracted here; the rest is discarded before the
+        caller sees it.  This keeps credential fields (if any) constrained
+        to the raw_data key and out of other columns.
+        """
+        rows = self._session.execute(
+            text("""
+                SELECT e.ts, e.dst_port, e.event_type, e.service, r.raw_json
+                FROM events e
+                JOIN raw_events r ON e.id = r.id
+                WHERE e.src_ip = :ip
+                ORDER BY e.ts ASC
+            """),
+            {"ip": ip},
+        ).fetchall()
+
+        result: list[dict[str, Any]] = []
+        for ts, dst_port, event_type, service, raw_json_str in rows:
+            try:
+                parsed = json.loads(raw_json_str)
+                raw_data: dict[str, Any] = parsed.get("data") or {}
+                source: str = parsed.get("source") or ""
+            except (json.JSONDecodeError, AttributeError, TypeError):
+                raw_data = {}
+                source = ""
+            result.append(
+                {
+                    "ts": ts,
+                    "dst_port": dst_port,
+                    "event_type": event_type,
+                    "service": service,
+                    "source": source,
+                    "raw_data": raw_data,
+                }
+            )
+        return result
+
+    def upsert_behavioral_fingerprint(
+        self,
+        ip: str,
+        fingerprint_version: int,
+        computed_at: str,
+        event_count: int,
+        timing_features: str | None,
+        sequence_features: str | None,
+        protocol_features: str | None,
+        credential_features: str | None,
+        target_features: str | None,
+        tool_signals: str | None,
+        confidence: float,
+    ) -> None:
+        """Insert or update the behavioral fingerprint for ip.
+
+        On first insertion for an ip: creates a new row with a fresh UUID.
+        On subsequent calls (recomputation): updates all feature columns in
+        place; the row's primary key (id) is preserved.
+
+        Uses INSERT ... ON CONFLICT(source_ip) DO UPDATE, which is identical
+        syntax in both SQLite (3.24+) and PostgreSQL.
+        """
+        self._session.execute(
+            text("""
+                INSERT INTO behavioral_fingerprints (
+                    id, source_ip, fingerprint_version, computed_at,
+                    event_count_at_computation, timing_features, sequence_features,
+                    protocol_features, credential_features, target_features,
+                    tool_signals, confidence
+                ) VALUES (
+                    :id, :source_ip, :fingerprint_version, :computed_at,
+                    :event_count, :timing_features, :sequence_features,
+                    :protocol_features, :credential_features, :target_features,
+                    :tool_signals, :confidence
+                )
+                ON CONFLICT(source_ip) DO UPDATE SET
+                    fingerprint_version        = excluded.fingerprint_version,
+                    computed_at                = excluded.computed_at,
+                    event_count_at_computation = excluded.event_count_at_computation,
+                    timing_features            = excluded.timing_features,
+                    sequence_features          = excluded.sequence_features,
+                    protocol_features          = excluded.protocol_features,
+                    credential_features        = excluded.credential_features,
+                    target_features            = excluded.target_features,
+                    tool_signals               = excluded.tool_signals,
+                    confidence                 = excluded.confidence
+            """),
+            {
+                "id": str(uuid.uuid4()),
+                "source_ip": ip,
+                "fingerprint_version": fingerprint_version,
+                "computed_at": computed_at,
+                "event_count": event_count,
+                "timing_features": timing_features,
+                "sequence_features": sequence_features,
+                "protocol_features": protocol_features,
+                "credential_features": credential_features,
+                "target_features": target_features,
+                "tool_signals": tool_signals,
+                "confidence": confidence,
+            },
+        )
+
+    def get_behavioral_fingerprint(self, ip: str) -> dict[str, Any] | None:
+        """Return the stored fingerprint for ip, or None if not found.
+
+        Used by tests and future intelligence endpoints.  Feature category
+        values are returned as raw JSON strings (or None); callers parse them.
+        """
+        row = self._session.execute(
+            text("""
+                SELECT id, source_ip, fingerprint_version, computed_at,
+                       event_count_at_computation, timing_features, sequence_features,
+                       protocol_features, credential_features, target_features,
+                       tool_signals, confidence
+                FROM behavioral_fingerprints
+                WHERE source_ip = :ip
+            """),
+            {"ip": ip},
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row[0],
+            "source_ip": row[1],
+            "fingerprint_version": row[2],
+            "computed_at": row[3],
+            "event_count_at_computation": row[4],
+            "timing_features": row[5],
+            "sequence_features": row[6],
+            "protocol_features": row[7],
+            "credential_features": row[8],
+            "target_features": row[9],
+            "tool_signals": row[10],
+            "confidence": row[11],
+        }

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -10,6 +10,7 @@ Internal structure (by concern):
     repositories/write.py        — insert, upsert, update, delete
     repositories/read.py         — dashboard queries and ingest-side cache reads
     repositories/intelligence.py — intelligence API query methods
+    repositories/fingerprint.py  — behavioral fingerprint reads and writes
 
 The caller owns the session and therefore the transaction boundary.
 
@@ -26,17 +27,20 @@ No FastAPI, router, or application imports belong in the sub-modules.
 
 from __future__ import annotations
 
+from app.db.repositories.fingerprint import FingerprintRepository
 from app.db.repositories.intelligence import IntelligenceRepository
 from app.db.repositories.read import ReadRepository
 from app.db.repositories.write import WriteRepository
 
 
-class EventRepository(WriteRepository, ReadRepository, IntelligenceRepository):
+class EventRepository(
+    WriteRepository, ReadRepository, IntelligenceRepository, FingerprintRepository
+):
     """
-    Unified repository class. Inherits all SQL methods from the three concern
+    Unified repository class. Inherits all SQL methods from the four concern
     mixins. Callers see a single object with the full method surface; the
     internal split is an organisation detail invisible to callers.
 
     Python MRO: EventRepository → WriteRepository → ReadRepository →
-                IntelligenceRepository → RepositoryBase → object
+                IntelligenceRepository → FingerprintRepository → RepositoryBase → object
     """

--- a/app/intelligence/constants.py
+++ b/app/intelligence/constants.py
@@ -1,0 +1,28 @@
+"""Named constants for Phase 4 behavioral fingerprinting.
+
+All thresholds and limits are defined here so they can be adjusted without
+touching computation logic. Changing any value after production campaign data
+is established requires a re-clustering pass (§12.2).
+"""
+
+from __future__ import annotations
+
+# Schema version embedded in every fingerprint row.  Increment when the
+# JSON field structure changes and old fingerprints need recomputation (§12.1).
+FINGERPRINT_VERSION: int = 1
+
+# Fingerprints with fewer events than this are stored but excluded from
+# campaign clustering (§12.6).  Their confidence will be < 0.20.
+MIN_EVENTS_FOR_CLUSTERING: int = 10
+
+# Inactivity gap (seconds) that ends one session and starts the next (§3.3).
+SESSION_GAP_SECONDS: int = 1800  # 30 minutes
+
+# Maximum number of ports retained in sequence_features.port_sequence (Appendix).
+TOP_PORT_SEQUENCE_N: int = 50
+
+# Maximum number of ports retained in target_features.port_freq (Appendix).
+TOP_PORT_FREQ_N: int = 20
+
+# Maximum credential-sequence entries stored; limits JSON growth (Appendix).
+MAX_CREDENTIAL_SEQUENCE: int = 50

--- a/app/intelligence/fingerprint.py
+++ b/app/intelligence/fingerprint.py
@@ -1,0 +1,92 @@
+"""Behavioral fingerprint builder.
+
+Bridges the pure feature extraction in sequence.py and the database layer.
+build_fingerprint() accepts the event list returned by the repository and
+produces a dict whose keys map directly to behavioral_fingerprints columns.
+
+Confidence model (§12.6):
+  - event_count < MIN_EVENTS_FOR_CLUSTERING  →  confidence < 0.20 (sparse)
+  - event_count >= MIN_EVENTS_FOR_CLUSTERING  →  confidence derived from
+    event volume and feature completeness, in the range [0.20, 0.95]
+
+Sparse fingerprints are computed and stored but must not enter campaign
+clustering.  PR 4 gates clustering on confidence >= 0.20.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.intelligence.constants import MIN_EVENTS_FOR_CLUSTERING
+from app.intelligence.sequence import extract_all_features
+
+# ---------------------------------------------------------------------------
+# Confidence calculation
+# ---------------------------------------------------------------------------
+
+
+def compute_confidence(
+    event_count: int,
+    populated_categories: int,
+    total_categories: int,
+) -> float:
+    """Return a confidence score in [0.0, 0.95].
+
+    Sparse fingerprints (below MIN_EVENTS_FOR_CLUSTERING) receive confidence
+    strictly below 0.20, which the PR 4 clustering gate treats as
+    "insufficient for clustering" (§12.6).
+
+    For non-sparse fingerprints, confidence grows with both event volume
+    (saturates at ~500 events) and feature completeness.
+    """
+    if event_count <= 0:
+        return 0.0
+
+    if event_count < MIN_EVENTS_FOR_CLUSTERING:
+        # Linear ramp: 1 event → 0.019, 9 events → 0.171
+        return round(event_count * (0.19 / MIN_EVENTS_FOR_CLUSTERING), 4)
+
+    completeness = populated_categories / max(total_categories, 1)
+    count_factor = min(1.0, event_count / 500.0)
+    confidence = 0.3 * completeness + 0.5 * count_factor + 0.2
+    return round(min(0.95, confidence), 4)
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint builder
+# ---------------------------------------------------------------------------
+
+
+def build_fingerprint(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute a complete fingerprint from an event list.
+
+    The returned dict maps directly to behavioral_fingerprints column names.
+    Feature category values are JSON strings (or None when a category cannot
+    be computed from the available data).
+
+    Keys returned:
+        event_count, confidence,
+        timing_features, sequence_features, protocol_features,
+        credential_features, target_features, tool_signals
+    """
+    event_count = len(events)
+    raw_features = extract_all_features(events)
+
+    populated = sum(1 for v in raw_features.values() if v is not None)
+    total = len(raw_features)  # always 6
+    confidence = compute_confidence(event_count, populated, total)
+
+    def _to_json(val: Any) -> str | None:
+        return json.dumps(val, separators=(",", ":")) if val is not None else None
+
+    return {
+        "event_count": event_count,
+        "confidence": confidence,
+        "timing_features": _to_json(raw_features["timing_features"]),
+        "sequence_features": _to_json(raw_features["sequence_features"]),
+        "protocol_features": _to_json(raw_features["protocol_features"]),
+        "credential_features": _to_json(raw_features["credential_features"]),
+        "target_features": _to_json(raw_features["target_features"]),
+        "tool_signals": _to_json(raw_features["tool_signals"]),
+    }

--- a/app/intelligence/sequence.py
+++ b/app/intelligence/sequence.py
@@ -1,0 +1,567 @@
+"""Pure event sequence extraction and feature computation.
+
+All functions are pure: no database access, no I/O, no side effects.
+Input is a list of event dicts as returned by FingerprintRepository.get_events_for_fingerprint().
+
+Each event dict has the shape:
+    {
+        "ts":         str,         # ISO-8601 timestamp
+        "dst_port":   int | None,
+        "event_type": str,
+        "service":    str | None,
+        "source":     str,         # sensor identifier, e.g. "cowrie"
+        "raw_data":   dict,        # parsed from raw_events.raw_json["data"]
+    }
+
+Privacy invariants enforced by this module (tested in test_sequence_extraction.py):
+  - Raw credential strings (usernames, passwords) are NEVER stored in output.
+  - Source IP addresses are NEVER stored in any feature category.
+  - Raw payload bytes are NEVER stored.
+
+Infrastructure metadata (ASN, country) is intentionally absent from all
+feature categories.  It is available on source_ips for informational lookup
+but must not drive similarity scoring (§12.4).
+
+Feature encoding follows the Appendix: Fingerprint Feature Encoding Reference.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import Counter
+from datetime import UTC, datetime
+from typing import Any
+
+from app.intelligence.constants import (
+    MAX_CREDENTIAL_SEQUENCE,
+    SESSION_GAP_SECONDS,
+    TOP_PORT_FREQ_N,
+    TOP_PORT_SEQUENCE_N,
+)
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_epoch(ts: str) -> float:
+    """Parse an ISO-8601 timestamp string to a UTC Unix epoch float."""
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(UTC).timestamp()
+
+
+def _parse_dt(ts: str) -> datetime:
+    """Parse an ISO-8601 timestamp string to a timezone-aware datetime."""
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _percentile(sorted_data: list[float], p: float) -> float:
+    """Linear-interpolation percentile over a pre-sorted list."""
+    n = len(sorted_data)
+    if n == 0:
+        return 0.0
+    if n == 1:
+        return sorted_data[0]
+    idx = (n - 1) * p
+    lo = int(idx)
+    hi = min(lo + 1, n - 1)
+    return sorted_data[lo] + (idx - lo) * (sorted_data[hi] - sorted_data[lo])
+
+
+def _normalize_counts(counts: list[float]) -> list[float]:
+    """Normalize a list of counts to sum to 1.0.  Returns zeros on empty input."""
+    total = sum(counts)
+    if total == 0.0:
+        return counts
+    return [c / total for c in counts]
+
+
+# ---------------------------------------------------------------------------
+# Session extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_sessions(
+    events: list[dict[str, Any]],
+    gap_seconds: int = SESSION_GAP_SECONDS,
+) -> list[list[dict[str, Any]]]:
+    """Split events into sessions separated by inactivity gaps.
+
+    Events are sorted chronologically before splitting.  A new session begins
+    when the gap between consecutive events exceeds gap_seconds.
+
+    Returns a list of sessions; each session is a list of event dicts.
+    """
+    if not events:
+        return []
+
+    sorted_events = sorted(events, key=lambda e: e["ts"])
+    sessions: list[list[dict[str, Any]]] = [[sorted_events[0]]]
+
+    for event in sorted_events[1:]:
+        last_epoch = _parse_epoch(sessions[-1][-1]["ts"])
+        curr_epoch = _parse_epoch(event["ts"])
+        if curr_epoch - last_epoch > gap_seconds:
+            sessions.append([event])
+        else:
+            sessions[-1].append(event)
+
+    return sessions
+
+
+# ---------------------------------------------------------------------------
+# Timing features
+# ---------------------------------------------------------------------------
+
+
+def compute_timing_features(events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Compute timing-based behavioral features.
+
+    Requires at least 2 events to produce interval statistics.  Returns None
+    if the event list is too small to compute meaningful timing features.
+
+    Encoding (Appendix):
+        interval      — {"mean", "stddev", "p25", "p75", "p95"} in milliseconds
+        tod_histogram — 24-element list of normalized hourly frequencies
+        dow_histogram — 7-element list of normalized daily frequencies (Mon=0)
+        burst_cv      — coefficient of variation of within-session intervals;
+                        low value → metronomic automated tool (§6.2)
+    """
+    if len(events) < 2:
+        return None
+
+    sessions = extract_sessions(events)
+
+    # Collect within-session inter-probe intervals (milliseconds)
+    interval_ms: list[float] = []
+    session_durations_s: list[float] = []
+
+    for session in sessions:
+        if len(session) < 2:
+            continue
+        epochs = [_parse_epoch(e["ts"]) for e in session]
+        for i in range(len(epochs) - 1):
+            gap = (epochs[i + 1] - epochs[i]) * 1000.0  # ms
+            if gap >= 0:
+                interval_ms.append(gap)
+        duration = epochs[-1] - epochs[0]
+        if duration >= 0:
+            session_durations_s.append(duration)
+
+    if not interval_ms:
+        return None
+
+    sorted_intervals = sorted(interval_ms)
+    mean_iv = statistics.mean(interval_ms)
+    stddev_iv = statistics.pstdev(interval_ms)  # population stddev over all observed intervals
+
+    # Time-of-day histogram (24 UTC hour buckets)
+    tod: list[float] = [0.0] * 24
+    for e in events:
+        tod[_parse_dt(e["ts"]).hour] += 1.0
+    tod = _normalize_counts(tod)
+
+    # Day-of-week histogram (0=Monday … 6=Sunday)
+    dow: list[float] = [0.0] * 7
+    for e in events:
+        dow[_parse_dt(e["ts"]).weekday()] += 1.0
+    dow = _normalize_counts(dow)
+
+    # Burst coefficient of variation — low CV → metronomic tool
+    burst_cv = stddev_iv / mean_iv if mean_iv > 0.0 else 0.0
+
+    # Session duration stats (may be empty if no multi-event session)
+    session_dur: dict[str, float] | None = None
+    if session_durations_s:
+        session_dur = {
+            "mean": round(statistics.mean(session_durations_s), 3),
+            "stddev": round(statistics.pstdev(session_durations_s), 3),
+        }
+
+    return {
+        "interval": {
+            "mean": round(mean_iv, 3),
+            "stddev": round(stddev_iv, 3),
+            "p25": round(_percentile(sorted_intervals, 0.25), 3),
+            "p75": round(_percentile(sorted_intervals, 0.75), 3),
+            "p95": round(_percentile(sorted_intervals, 0.95), 3),
+        },
+        "session_duration": session_dur,
+        "tod_histogram": [round(v, 6) for v in tod],
+        "dow_histogram": [round(v, 6) for v in dow],
+        "burst_cv": round(burst_cv, 6),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Sequence features
+# ---------------------------------------------------------------------------
+
+
+def compute_sequence_features(events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Compute behavioral sequence features.
+
+    Extracts the ordered port probe sequence, event type sequence, and
+    credential attempt sequence (patterns only — no raw credential values).
+
+    Encoding (Appendix):
+        port_sequence       — ordered array of dst_port integers, top-N (≤50)
+        event_type_sequence — ordered array of event_type strings
+        credential_sequence — array of {"username_pattern": str, "password_class": str}
+    """
+    sorted_events = sorted(events, key=lambda e: e["ts"])
+
+    # Port probe sequence: ordered dst_port values (deduplicated while preserving first order)
+    seen_ports: set[int] = set()
+    port_sequence: list[int] = []
+    for e in sorted_events:
+        p = e.get("dst_port")
+        if isinstance(p, int) and p not in seen_ports:
+            seen_ports.add(p)
+            port_sequence.append(p)
+            if len(port_sequence) >= TOP_PORT_SEQUENCE_N:
+                break
+
+    # Event type sequence (ordered, all events)
+    event_type_sequence = [e["event_type"] for e in sorted_events]
+
+    # Credential sequence — patterns only, never raw values
+    cred_sequence = _extract_credential_sequence(sorted_events)
+
+    if not port_sequence and not cred_sequence:
+        return None
+
+    return {
+        "port_sequence": port_sequence,
+        "event_type_sequence": event_type_sequence,
+        "credential_sequence": cred_sequence,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Protocol features
+# ---------------------------------------------------------------------------
+
+
+def compute_protocol_features(events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Compute protocol-level behavioral features.
+
+    Service distribution is always available (derived from events.service).
+    SSH KEX ordering is extracted from raw_data when present (Cowrie sessions).
+    TLS cipher ordering is extracted from raw_data when present (HTTP sensors).
+
+    Encoding (Appendix):
+        service_distribution  — {service: proportion} for observed services
+        ssh_kex_ordering      — ordered list of KEX algorithm strings, or null
+        tls_cipher_ordering   — ordered list of hex cipher IDs, or null
+    """
+    # Service distribution (service → proportion of events with that service)
+    service_counts: Counter[str] = Counter()
+    for e in events:
+        svc = e.get("service")
+        if svc:
+            service_counts[svc] += 1
+
+    if not service_counts and not events:
+        return None
+
+    total = sum(service_counts.values())
+    service_dist = (
+        {svc: round(cnt / total, 6) for svc, cnt in service_counts.most_common()}
+        if total > 0
+        else {}
+    )
+
+    # SSH KEX ordering — take from the first event that has it (tool-level signal)
+    ssh_kex: list[str] | None = None
+    for e in events:
+        raw = e.get("raw_data") or {}
+        kex = raw.get("kex_algs") or raw.get("kex_algorithms")
+        if isinstance(kex, list) and all(isinstance(k, str) for k in kex):
+            ssh_kex = kex
+            break
+
+    # TLS cipher ordering — take from the first event that has it
+    tls_ciphers: list[str] | None = None
+    for e in events:
+        raw = e.get("raw_data") or {}
+        ciphers = raw.get("tls_cipher_suites") or raw.get("ja3_ciphers")
+        if isinstance(ciphers, list) and all(isinstance(c, str) for c in ciphers):
+            tls_ciphers = ciphers
+            break
+
+    return {
+        "service_distribution": service_dist,
+        "ssh_kex_ordering": ssh_kex,
+        "tls_cipher_ordering": tls_ciphers,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Credential features
+# ---------------------------------------------------------------------------
+
+
+# Username pattern categories — character class of the username string.
+# Raw username values are never stored.
+def _classify_username(username: str) -> str:
+    if not username:
+        return "empty"
+    if "@" in username:
+        return "email"
+    if username.isdigit():
+        return "numeric"
+    if username.isalpha():
+        return "alpha"
+    if username.isalnum():
+        return "alphanum"
+    return "special"
+
+
+# Password pattern categories — character class of the password string.
+# Raw password values are never stored.
+def _classify_password(password: str) -> str:
+    if not password:
+        return "empty"
+    if password.isdigit():
+        return "numeric"
+    if password.isalpha():
+        return "alpha"
+    if password.isalnum():
+        return "alphanum"
+    return "special"
+
+
+def _extract_credential_sequence(
+    sorted_events: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    """Return a credential sequence of pattern entries, no raw values."""
+    sequence: list[dict[str, str]] = []
+    for e in sorted_events:
+        raw = e.get("raw_data") or {}
+        username = raw.get("username")
+        password = raw.get("password")
+        if username is None and password is None:
+            continue
+        entry = {
+            "username_pattern": _classify_username(str(username) if username is not None else ""),
+            "password_class": _classify_password(str(password) if password is not None else ""),
+        }
+        sequence.append(entry)
+        if len(sequence) >= MAX_CREDENTIAL_SEQUENCE:
+            break
+    return sequence
+
+
+def compute_credential_features(events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Compute credential-attack behavioral features.
+
+    Only pattern statistics are stored — no raw usernames or passwords.
+
+    Returns None when no events contain credential data (username or password
+    fields absent from raw_data for all events).
+
+    Encoding (Appendix / §3.1 Credential features):
+        credential_count      — total credential pairs observed
+        username_class_dist   — {pattern_class: proportion}
+        password_length_mean  — mean password length (float)
+        password_char_class   — {metric: ratio} character class proportions
+        credential_sequence   — [{"username_pattern", "password_class"}, ...] (max 50)
+    """
+    cred_events = [
+        e
+        for e in events
+        if (e.get("raw_data") or {}).get("username") is not None
+        or (e.get("raw_data") or {}).get("password") is not None
+    ]
+    if not cred_events:
+        return None
+
+    username_classes: list[str] = []
+    password_lengths: list[int] = []
+    has_upper = has_lower = has_digit = has_special = 0
+
+    for e in cred_events:
+        raw = e.get("raw_data") or {}
+        uname = raw.get("username")
+        passwd = raw.get("password")
+
+        if uname is not None:
+            username_classes.append(_classify_username(str(uname)))
+
+        if passwd is not None:
+            pw = str(passwd)
+            password_lengths.append(len(pw))
+            if any(c.isupper() for c in pw):
+                has_upper += 1
+            if any(c.islower() for c in pw):
+                has_lower += 1
+            if any(c.isdigit() for c in pw):
+                has_digit += 1
+            if any(not c.isalnum() for c in pw):
+                has_special += 1
+
+    cred_count = len(cred_events)
+    pw_count = len(password_lengths)
+
+    # Username class distribution
+    class_counts: Counter[str] = Counter(username_classes)
+    total_u = sum(class_counts.values())
+    username_class_dist = (
+        {cls: round(cnt / total_u, 6) for cls, cnt in class_counts.most_common()}
+        if total_u > 0
+        else {}
+    )
+
+    # Password character class proportions
+    pw_char_class: dict[str, float] = {}
+    if pw_count > 0:
+        pw_char_class = {
+            "has_upper_ratio": round(has_upper / pw_count, 6),
+            "has_lower_ratio": round(has_lower / pw_count, 6),
+            "has_digit_ratio": round(has_digit / pw_count, 6),
+            "has_special_ratio": round(has_special / pw_count, 6),
+        }
+
+    # Password length stats
+    pw_length_mean = round(statistics.mean(password_lengths), 3) if password_lengths else None
+
+    # Credential sequence (pattern-only)
+    sorted_events = sorted(cred_events, key=lambda e: e["ts"])
+    cred_sequence = _extract_credential_sequence(sorted_events)
+
+    return {
+        "credential_count": cred_count,
+        "username_class_dist": username_class_dist,
+        "password_length_mean": pw_length_mean,
+        "password_char_class": pw_char_class,
+        "credential_sequence": cred_sequence,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Target features
+# ---------------------------------------------------------------------------
+
+
+def compute_target_features(events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Compute target selection behavioral features.
+
+    Encoding (Appendix / §3.1 Target selection features):
+        port_freq        — {port_str: proportion} for top-20 destination ports
+        unique_port_count — total number of distinct ports targeted
+        top_dst_ports    — ordered list of top-20 ports by frequency
+        service_dist     — {service: proportion} (redundant with protocol_features
+                           but retained here for clustering use)
+    """
+    port_counts: Counter[int] = Counter()
+    for e in events:
+        p = e.get("dst_port")
+        if isinstance(p, int):
+            port_counts[p] += 1
+
+    if not port_counts:
+        return None
+
+    total = sum(port_counts.values())
+    top_ports = port_counts.most_common(TOP_PORT_FREQ_N)
+
+    port_freq = {str(p): round(cnt / total, 6) for p, cnt in top_ports}
+    top_dst_ports = [p for p, _ in top_ports]
+
+    return {
+        "port_freq": port_freq,
+        "unique_port_count": len(port_counts),
+        "top_dst_ports": top_dst_ports,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool signals
+# ---------------------------------------------------------------------------
+
+
+def compute_tool_signals(events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Compute tool-level behavioral signals.
+
+    Source distribution reveals which sensor type observed the activity.
+    Event type distribution encodes the attack methodology mix.
+    Tool inferences are conservative: only string patterns, never binary
+    hashes or payload fragments.
+
+    Encoding (Appendix / §3.1):
+        source_dist      — {source: proportion} (sensor types)
+        event_type_dist  — {event_type: proportion}
+        inferred_tools   — [{tool: str, confidence: float}] (heuristic guesses)
+    """
+    if not events:
+        return None
+
+    source_counts: Counter[str] = Counter(e.get("source", "unknown") for e in events)
+    type_counts: Counter[str] = Counter(e["event_type"] for e in events)
+
+    total = len(events)
+    source_dist = {src: round(cnt / total, 6) for src, cnt in source_counts.most_common()}
+    event_type_dist = {et: round(cnt / total, 6) for et, cnt in type_counts.most_common()}
+
+    # Heuristic tool inference from source and event type patterns
+    inferred = _infer_tools(source_dist, event_type_dist)
+
+    return {
+        "source_dist": source_dist,
+        "event_type_dist": event_type_dist,
+        "inferred_tools": inferred,
+    }
+
+
+def _infer_tools(
+    source_dist: dict[str, float],
+    event_type_dist: dict[str, float],
+) -> list[dict[str, float]]:
+    """Heuristic tool signature detection from observable source/type patterns."""
+    inferred: list[dict[str, float]] = []
+
+    # Cowrie-based SSH scanner: primary source is cowrie, heavy auth_failed
+    cowrie_share = source_dist.get("cowrie", 0.0)
+    auth_fail_share = event_type_dist.get("auth_failed", 0.0)
+    if cowrie_share >= 0.5 and auth_fail_share >= 0.5:
+        confidence = round(min(1.0, (cowrie_share + auth_fail_share) / 2), 3)
+        inferred.append({"tool": "ssh_brute_force", "confidence": confidence})
+
+    # Port scanner: heavy port_scan activity
+    scan_share = event_type_dist.get("port_scan", 0.0)
+    if scan_share >= 0.5:
+        inferred.append({"tool": "port_scanner", "confidence": round(scan_share, 3)})
+
+    # Web scanner: heavy http_probe activity
+    http_share = event_type_dist.get("http_probe", 0.0)
+    if http_share >= 0.4:
+        inferred.append({"tool": "web_scanner", "confidence": round(http_share, 3)})
+
+    return inferred
+
+
+# ---------------------------------------------------------------------------
+# Combined extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_all_features(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute all six feature categories for the given event list.
+
+    Each value is a dict (if computable) or None (if insufficient data).
+    None values contribute nothing to fingerprint confidence and nothing
+    to similarity scoring (§8.1 — null dimensions excluded from both
+    numerator and denominator).
+
+    Returns a dict with exactly these six keys:
+        timing_features, sequence_features, protocol_features,
+        credential_features, target_features, tool_signals
+    """
+    return {
+        "timing_features": compute_timing_features(events),
+        "sequence_features": compute_sequence_features(events),
+        "protocol_features": compute_protocol_features(events),
+        "credential_features": compute_credential_features(events),
+        "target_features": compute_target_features(events),
+        "tool_signals": compute_tool_signals(events),
+    }

--- a/app/intelligence/tasks.py
+++ b/app/intelligence/tasks.py
@@ -1,0 +1,92 @@
+"""Background fingerprint computation tasks.
+
+Provides schedule_fingerprint_if_not_pending(), the only entry point called
+from the ingest router.  All fingerprint computation runs asynchronously via
+FastAPI BackgroundTasks — never in the synchronous ingest request path (§12.5).
+
+Deduplication model (§12.5):
+  A module-level set tracks IPs whose fingerprint tasks are pending or
+  in-flight.  A threading.Lock makes the check-and-add atomic, which is
+  correct for FastAPI's single-process BackgroundTasks execution model.
+
+  This design is intentionally scoped to single-process deployments (the
+  Phase 4 target environment with BackgroundTasks).  Multi-process worker
+  deployments (Gunicorn with multiple uvicorn workers) would need a shared
+  coordination store (Redis, DB advisory locks) — deferred to Phase 5/6
+  when task volume justifies the operational overhead (§11: No async worker
+  infrastructure unless task backlog is measured).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi import BackgroundTasks
+
+logger = logging.getLogger(__name__)
+
+_pending: set[str] = set()
+_pending_lock = threading.Lock()
+
+
+def schedule_fingerprint_if_not_pending(ip: str, background_tasks: BackgroundTasks) -> None:
+    """Enqueue a fingerprint computation task for ip unless one is already queued.
+
+    Thread-safe: the check-and-add is atomic under _pending_lock.
+    If an existing task is in-flight for this ip, the new request is silently
+    dropped — the in-flight task will read all events committed so far when
+    it executes.
+    """
+    with _pending_lock:
+        if ip in _pending:
+            return
+        _pending.add(ip)
+    background_tasks.add_task(_run_fingerprint_task, ip)
+
+
+def _run_fingerprint_task(ip: str) -> None:
+    """Execute fingerprint computation for ip in a background context.
+
+    Failures are logged but do not propagate — a fingerprint failure must
+    never surface as an ingest error to the sensor (§3.3 / §11).
+    The ip is removed from _pending in the finally block regardless of outcome.
+    """
+    try:
+        _compute_and_store(ip)
+    except Exception:
+        logger.exception("Fingerprint computation failed for ip=%s", ip)
+    finally:
+        with _pending_lock:
+            _pending.discard(ip)
+
+
+def _compute_and_store(ip: str) -> None:
+    """Fetch events, compute fingerprint, write to behavioral_fingerprints."""
+    from app.db.connection import get_session
+    from app.db.repository import EventRepository
+    from app.intelligence.constants import FINGERPRINT_VERSION
+    from app.intelligence.fingerprint import build_fingerprint
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        events = repo.get_events_for_fingerprint(ip)
+        if not events:
+            return
+        fp = build_fingerprint(events)
+        repo.upsert_behavioral_fingerprint(
+            ip=ip,
+            fingerprint_version=FINGERPRINT_VERSION,
+            computed_at=datetime.now(UTC).isoformat(),
+            event_count=fp["event_count"],
+            timing_features=fp["timing_features"],
+            sequence_features=fp["sequence_features"],
+            protocol_features=fp["protocol_features"],
+            credential_features=fp["credential_features"],
+            target_features=fp["target_features"],
+            tool_signals=fp["tool_signals"],
+            confidence=fp["confidence"],
+        )

--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -22,12 +22,13 @@ import json
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
 
 from app.core.config import settings
 from app.db.connection import get_session
 from app.db.repository import EventRepository
+from app.intelligence.tasks import schedule_fingerprint_if_not_pending
 from app.limiter import limiter
 from app.schemas.models import (
     EnrichedEvent,
@@ -60,6 +61,7 @@ def _require_api_key(
 def ingest_events(
     request: Request,
     body: IngestRequest,
+    background_tasks: BackgroundTasks,
     _: None = Depends(_require_api_key),
 ) -> IngestReceipt:
     """
@@ -79,6 +81,7 @@ def ingest_events(
     ingested_at = datetime.now(UTC)
     accepted = rejected = duplicate = 0
     errors: list[IngestError] = []
+    accepted_ips: set[str] = set()  # unique IPs from accepted events this batch
 
     with get_session() as session:
         repo = EventRepository(session)
@@ -166,6 +169,8 @@ def ingest_events(
                     score_sp.rollback()
 
             accepted += 1
+            if src_ip:
+                accepted_ips.add(src_ip)
 
     # Stage 6: Audit log — best-effort, isolated session (never fails ingest).
     try:
@@ -183,6 +188,11 @@ def ingest_events(
             )
     except Exception:
         pass
+
+    # Stage 7: Schedule fingerprint recomputation for each unique accepted IP.
+    # Runs after the ingest session is committed; never blocks the response.
+    for ip in accepted_ips:
+        schedule_fingerprint_if_not_pending(ip, background_tasks)
 
     return IngestReceipt(
         batch_id=batch_id,

--- a/tests/db/test_fingerprint_repository.py
+++ b/tests/db/test_fingerprint_repository.py
@@ -1,0 +1,319 @@
+"""Repository tests for FingerprintRepository methods.
+
+Uses the db_session fixture from tests/db/conftest.py for an isolated
+in-memory SQLite database per test.  No HTTP, no application startup.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+
+from app.db.repository import EventRepository
+from app.schemas.models import HoneypotEvent, RawEvent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_IP = "203.0.113.10"
+_TS = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _insert_event_for_ip(
+    session,
+    ip: str,
+    ts: datetime,
+    dst_port: int = 22,
+    event_type: str = "auth_failed",
+    username: str | None = None,
+    password: str | None = None,
+) -> str:
+    """Insert a raw_event + event row pair for ip and return the event id."""
+    eid = str(uuid.uuid4())
+    data: dict = {"ip": ip}
+    if username is not None:
+        data["username"] = username
+    if password is not None:
+        data["password"] = password
+
+    raw = RawEvent(
+        id=eid, ts=ts.isoformat(), source="cowrie", type="cowrie.login.failed", data=data
+    )
+    event = HoneypotEvent(
+        id=eid,
+        ts=ts,
+        ingested_at=datetime.now(UTC),
+        source="cowrie",
+        event_type=event_type,
+        src_ip=ip,
+        dst_port=dst_port,
+        service="ssh",
+    )
+    repo = EventRepository(session)
+    repo.insert_raw_event(raw)
+    repo.insert_event(event)
+    repo.upsert_source_ip(ip, ts)
+    return eid
+
+
+@pytest.fixture
+def with_source_ip(db_session):
+    """Insert _IP into source_ips so behavioral_fingerprints FK is satisfied."""
+    EventRepository(db_session).upsert_source_ip(_IP, _TS)
+    db_session.flush()
+
+
+def _fp_params(ip: str = _IP, event_count: int = 15, confidence: float = 0.5) -> dict:
+    return {
+        "ip": ip,
+        "fingerprint_version": 1,
+        "computed_at": datetime.now(UTC).isoformat(),
+        "event_count": event_count,
+        "timing_features": '{"interval":{"mean":1000,"stddev":0,"p25":1000,"p75":1000,"p95":1000}}',
+        "sequence_features": (
+            '{"port_sequence":[22],"event_type_sequence":["auth_failed"]'
+            ',"credential_sequence":[]}'
+        ),
+        "protocol_features": None,
+        "credential_features": None,
+        "target_features": '{"port_freq":{"22":1.0},"unique_port_count":1,"top_dst_ports":[22]}',
+        "tool_signals": None,
+        "confidence": confidence,
+    }
+
+
+# ---------------------------------------------------------------------------
+# get_events_for_fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_get_events_for_fingerprint_empty_when_no_events(db_session):
+    repo = EventRepository(db_session)
+    events = repo.get_events_for_fingerprint("1.2.3.4")
+    assert events == []
+
+
+def test_get_events_for_fingerprint_returns_events_for_ip(db_session):
+    _insert_event_for_ip(db_session, _IP, _TS)
+    db_session.flush()
+    repo = EventRepository(db_session)
+    events = repo.get_events_for_fingerprint(_IP)
+    assert len(events) == 1
+
+
+def test_get_events_for_fingerprint_only_for_target_ip(db_session):
+    _insert_event_for_ip(db_session, _IP, _TS)
+    _insert_event_for_ip(db_session, "10.0.0.1", _TS)
+    db_session.flush()
+    repo = EventRepository(db_session)
+    events = repo.get_events_for_fingerprint(_IP)
+    assert len(events) == 1
+
+
+def test_get_events_for_fingerprint_event_dict_keys(db_session):
+    _insert_event_for_ip(db_session, _IP, _TS)
+    db_session.flush()
+    repo = EventRepository(db_session)
+    events = repo.get_events_for_fingerprint(_IP)
+    assert len(events) == 1
+    e = events[0]
+    assert set(e.keys()) == {"ts", "dst_port", "event_type", "service", "source", "raw_data"}
+
+
+def test_get_events_for_fingerprint_raw_data_is_dict(db_session):
+    _insert_event_for_ip(db_session, _IP, _TS, username="admin", password="pass")
+    db_session.flush()
+    repo = EventRepository(db_session)
+    events = repo.get_events_for_fingerprint(_IP)
+    assert isinstance(events[0]["raw_data"], dict)
+
+
+def test_get_events_for_fingerprint_ordered_chronologically(db_session):
+    from datetime import timedelta
+
+    t1 = _TS
+    t2 = _TS + timedelta(minutes=5)
+    t3 = _TS + timedelta(minutes=10)
+    _insert_event_for_ip(db_session, _IP, t3)
+    _insert_event_for_ip(db_session, _IP, t1)
+    _insert_event_for_ip(db_session, _IP, t2)
+    db_session.flush()
+    repo = EventRepository(db_session)
+    events = repo.get_events_for_fingerprint(_IP)
+    ts_list = [e["ts"] for e in events]
+    assert ts_list == sorted(ts_list)
+
+
+def test_get_events_for_fingerprint_no_source_ip_in_returned_dicts(db_session):
+    """The returned event dicts must not contain a src_ip key — only raw_data may
+    have an ip field (from the sensor), and that's the sensor-reported IP,
+    not added by the repository layer."""
+    _insert_event_for_ip(db_session, _IP, _TS)
+    db_session.flush()
+    repo = EventRepository(db_session)
+    events = repo.get_events_for_fingerprint(_IP)
+    for e in events:
+        # Top-level dict must have no src_ip key
+        assert "src_ip" not in e
+
+
+# ---------------------------------------------------------------------------
+# upsert_behavioral_fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_fingerprint_creates_row(db_session, with_source_ip):
+    repo = EventRepository(db_session)
+    repo.upsert_behavioral_fingerprint(**_fp_params())
+    db_session.flush()
+
+    row = db_session.execute(
+        text("SELECT source_ip, confidence FROM behavioral_fingerprints WHERE source_ip = :ip"),
+        {"ip": _IP},
+    ).fetchone()
+    assert row is not None
+    assert row[0] == _IP
+
+
+def test_upsert_fingerprint_stores_confidence(db_session, with_source_ip):
+    repo = EventRepository(db_session)
+    repo.upsert_behavioral_fingerprint(**_fp_params(confidence=0.72))
+    db_session.flush()
+
+    row = db_session.execute(
+        text("SELECT confidence FROM behavioral_fingerprints WHERE source_ip = :ip"),
+        {"ip": _IP},
+    ).fetchone()
+    assert abs(row[0] - 0.72) < 1e-6
+
+
+def test_upsert_fingerprint_updates_on_recomputation(db_session, with_source_ip):
+    repo = EventRepository(db_session)
+    repo.upsert_behavioral_fingerprint(**_fp_params(event_count=10, confidence=0.3))
+    db_session.flush()
+    repo.upsert_behavioral_fingerprint(**_fp_params(event_count=50, confidence=0.7))
+    db_session.flush()
+
+    rows = db_session.execute(
+        text("SELECT COUNT(*) FROM behavioral_fingerprints WHERE source_ip = :ip"),
+        {"ip": _IP},
+    ).fetchone()
+    assert rows[0] == 1  # still one row
+
+    row = db_session.execute(
+        text(
+            "SELECT event_count_at_computation, confidence "
+            "FROM behavioral_fingerprints WHERE source_ip = :ip"
+        ),
+        {"ip": _IP},
+    ).fetchone()
+    assert row[0] == 50
+    assert abs(row[1] - 0.7) < 1e-6
+
+
+def test_upsert_fingerprint_preserves_id_on_update(db_session, with_source_ip):
+    repo = EventRepository(db_session)
+    repo.upsert_behavioral_fingerprint(**_fp_params())
+    db_session.flush()
+
+    original_id = db_session.execute(
+        text("SELECT id FROM behavioral_fingerprints WHERE source_ip = :ip"),
+        {"ip": _IP},
+    ).fetchone()[0]
+
+    repo.upsert_behavioral_fingerprint(**_fp_params(event_count=99))
+    db_session.flush()
+
+    updated_id = db_session.execute(
+        text("SELECT id FROM behavioral_fingerprints WHERE source_ip = :ip"),
+        {"ip": _IP},
+    ).fetchone()[0]
+    assert original_id == updated_id
+
+
+def test_upsert_fingerprint_null_features_accepted(db_session, with_source_ip):
+    repo = EventRepository(db_session)
+    params = _fp_params()
+    params["timing_features"] = None
+    params["sequence_features"] = None
+    repo.upsert_behavioral_fingerprint(**params)
+    db_session.flush()
+
+    row = db_session.execute(
+        text(
+            "SELECT timing_features, sequence_features "
+            "FROM behavioral_fingerprints WHERE source_ip = :ip"
+        ),
+        {"ip": _IP},
+    ).fetchone()
+    assert row[0] is None
+    assert row[1] is None
+
+
+# ---------------------------------------------------------------------------
+# get_behavioral_fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_get_fingerprint_returns_none_for_unknown_ip(db_session):
+    repo = EventRepository(db_session)
+    assert repo.get_behavioral_fingerprint("1.2.3.4") is None
+
+
+def test_get_fingerprint_returns_dict_after_upsert(db_session, with_source_ip):
+    repo = EventRepository(db_session)
+    repo.upsert_behavioral_fingerprint(**_fp_params())
+    db_session.flush()
+
+    fp = repo.get_behavioral_fingerprint(_IP)
+    assert fp is not None
+    assert isinstance(fp, dict)
+
+
+def test_get_fingerprint_returned_keys(db_session, with_source_ip):
+    repo = EventRepository(db_session)
+    repo.upsert_behavioral_fingerprint(**_fp_params())
+    db_session.flush()
+
+    fp = repo.get_behavioral_fingerprint(_IP)
+    assert set(fp.keys()) == {
+        "id",
+        "source_ip",
+        "fingerprint_version",
+        "computed_at",
+        "event_count_at_computation",
+        "timing_features",
+        "sequence_features",
+        "protocol_features",
+        "credential_features",
+        "target_features",
+        "tool_signals",
+        "confidence",
+    }
+
+
+def test_get_fingerprint_source_ip_matches(db_session, with_source_ip):
+    repo = EventRepository(db_session)
+    repo.upsert_behavioral_fingerprint(**_fp_params())
+    db_session.flush()
+
+    fp = repo.get_behavioral_fingerprint(_IP)
+    assert fp["source_ip"] == _IP
+
+
+def test_get_fingerprint_feature_json_is_parseable(db_session, with_source_ip):
+    repo = EventRepository(db_session)
+    repo.upsert_behavioral_fingerprint(**_fp_params())
+    db_session.flush()
+
+    fp = repo.get_behavioral_fingerprint(_IP)
+    for key in ("timing_features", "target_features", "sequence_features"):
+        val = fp[key]
+        if val is not None:
+            parsed = json.loads(val)
+            assert isinstance(parsed, dict)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,11 @@ def reset_db_rows():
     yield
     engine = get_engine()
     with engine.connect() as conn:
+        conn.execute(text("DELETE FROM behavioral_fingerprints"))
+        conn.execute(text("DELETE FROM campaign_tags"))
+        conn.execute(text("DELETE FROM campaign_observations"))
+        conn.execute(text("DELETE FROM campaign_members"))
+        conn.execute(text("DELETE FROM campaigns"))
         conn.execute(text("DELETE FROM events"))
         conn.execute(text("DELETE FROM raw_events"))
         conn.execute(text("DELETE FROM source_ips"))

--- a/tests/test_iocs.py
+++ b/tests/test_iocs.py
@@ -37,6 +37,11 @@ def clean_db():
     from app.db.connection import get_engine
 
     with get_engine().connect() as conn:
+        conn.execute(text("DELETE FROM behavioral_fingerprints"))
+        conn.execute(text("DELETE FROM campaign_tags"))
+        conn.execute(text("DELETE FROM campaign_observations"))
+        conn.execute(text("DELETE FROM campaign_members"))
+        conn.execute(text("DELETE FROM campaigns"))
         conn.execute(text("DELETE FROM events"))
         conn.execute(text("DELETE FROM raw_events"))
         conn.execute(text("DELETE FROM source_ips"))

--- a/tests/test_iocs_privacy_and_filter.py
+++ b/tests/test_iocs_privacy_and_filter.py
@@ -16,6 +16,11 @@ def clean_db():
     from app.db.connection import get_engine
 
     with get_engine().connect() as conn:
+        conn.execute(text("DELETE FROM behavioral_fingerprints"))
+        conn.execute(text("DELETE FROM campaign_tags"))
+        conn.execute(text("DELETE FROM campaign_observations"))
+        conn.execute(text("DELETE FROM campaign_members"))
+        conn.execute(text("DELETE FROM campaigns"))
         conn.execute(text("DELETE FROM events"))
         conn.execute(text("DELETE FROM raw_events"))
         conn.execute(text("DELETE FROM source_ips"))

--- a/tests/unit/test_fingerprint_generation.py
+++ b/tests/unit/test_fingerprint_generation.py
@@ -1,0 +1,174 @@
+"""Unit tests for app/intelligence/fingerprint.py.
+
+All tests use in-memory event dicts — no database, no HTTP.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from app.intelligence.constants import MIN_EVENTS_FOR_CLUSTERING
+from app.intelligence.fingerprint import build_fingerprint, compute_confidence
+
+_BASE_TS = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_event(offset_seconds: float = 0, dst_port: int = 22, source: str = "cowrie") -> dict:
+    return {
+        "ts": (_BASE_TS + timedelta(seconds=offset_seconds)).isoformat(),
+        "dst_port": dst_port,
+        "event_type": "auth_failed",
+        "service": "ssh",
+        "source": source,
+        "raw_data": {},
+    }
+
+
+def _events(n: int) -> list[dict]:
+    return [_make_event(i * 60) for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# compute_confidence
+# ---------------------------------------------------------------------------
+
+
+def test_confidence_zero_events():
+    assert compute_confidence(0, 0, 6) == 0.0
+
+
+def test_confidence_sparse_below_threshold():
+    """All event counts below MIN_EVENTS_FOR_CLUSTERING must produce confidence < 0.20."""
+    for n in range(1, MIN_EVENTS_FOR_CLUSTERING):
+        c = compute_confidence(n, 3, 6)
+        assert c < 0.20, f"Expected confidence < 0.20 for {n} events, got {c}"
+
+
+def test_confidence_at_threshold_meets_lower_bound():
+    """At exactly MIN_EVENTS_FOR_CLUSTERING, confidence must be >= 0.20."""
+    c = compute_confidence(MIN_EVENTS_FOR_CLUSTERING, 0, 6)
+    assert c >= 0.20
+
+
+def test_confidence_grows_with_more_events():
+    c10 = compute_confidence(10, 3, 6)
+    c100 = compute_confidence(100, 3, 6)
+    c500 = compute_confidence(500, 3, 6)
+    assert c10 < c100 < c500
+
+
+def test_confidence_grows_with_more_populated_categories():
+    base = compute_confidence(50, 0, 6)
+    full = compute_confidence(50, 6, 6)
+    assert full > base
+
+
+def test_confidence_capped_at_095():
+    assert compute_confidence(10_000, 6, 6) <= 0.95
+
+
+def test_confidence_is_non_negative():
+    for n in range(0, 20):
+        assert compute_confidence(n, 3, 6) >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# build_fingerprint — return shape
+# ---------------------------------------------------------------------------
+
+
+def test_build_fingerprint_returns_expected_keys():
+    result = build_fingerprint(_events(15))
+    assert set(result.keys()) == {
+        "event_count",
+        "confidence",
+        "timing_features",
+        "sequence_features",
+        "protocol_features",
+        "credential_features",
+        "target_features",
+        "tool_signals",
+    }
+
+
+def test_build_fingerprint_event_count_matches_input():
+    events = _events(25)
+    result = build_fingerprint(events)
+    assert result["event_count"] == 25
+
+
+# ---------------------------------------------------------------------------
+# build_fingerprint — sparse fingerprints (< MIN_EVENTS_FOR_CLUSTERING)
+# ---------------------------------------------------------------------------
+
+
+def test_build_fingerprint_sparse_has_low_confidence():
+    result = build_fingerprint(_events(MIN_EVENTS_FOR_CLUSTERING - 1))
+    assert result["confidence"] < 0.20
+
+
+def test_build_fingerprint_zero_events_confidence_zero():
+    result = build_fingerprint([])
+    assert result["confidence"] == 0.0
+
+
+def test_build_fingerprint_sparse_still_stored():
+    """Sparse fingerprints must be returned (for storage), not discarded."""
+    result = build_fingerprint(_events(3))
+    assert result is not None
+    assert result["event_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# build_fingerprint — feature JSON strings
+# ---------------------------------------------------------------------------
+
+
+def test_build_fingerprint_feature_values_are_json_strings_or_none():
+    feature_keys = [
+        "timing_features",
+        "sequence_features",
+        "protocol_features",
+        "credential_features",
+        "target_features",
+        "tool_signals",
+    ]
+    result = build_fingerprint(_events(20))
+    for key in feature_keys:
+        val = result[key]
+        assert val is None or isinstance(val, str), f"{key} should be str or None"
+        if isinstance(val, str):
+            parsed = json.loads(val)  # must be valid JSON
+            assert isinstance(parsed, dict)
+
+
+def test_build_fingerprint_timing_features_absent_below_2_events():
+    """timing_features requires at least 2 events."""
+    result = build_fingerprint(_events(1))
+    assert result["timing_features"] is None
+
+
+def test_build_fingerprint_credential_features_none_without_cred_data():
+    """credential_features must be None when events have no credential data."""
+    result = build_fingerprint(_events(20))
+    assert result["credential_features"] is None
+
+
+def test_build_fingerprint_with_cred_data_populates_credential_features():
+    events = [
+        {
+            "ts": (_BASE_TS + timedelta(seconds=i * 60)).isoformat(),
+            "dst_port": 22,
+            "event_type": "auth_failed",
+            "service": "ssh",
+            "source": "cowrie",
+            "raw_data": {"username": "admin", "password": "pass123"},
+        }
+        for i in range(15)
+    ]
+    result = build_fingerprint(events)
+    assert result["credential_features"] is not None
+    parsed = json.loads(result["credential_features"])
+    assert "credential_count" in parsed
+    assert parsed["credential_count"] == 15

--- a/tests/unit/test_sequence_extraction.py
+++ b/tests/unit/test_sequence_extraction.py
@@ -1,0 +1,540 @@
+"""Unit tests for app/intelligence/sequence.py.
+
+All tests use in-memory event dicts — no database, no HTTP.
+
+Privacy invariants verified here:
+  - Raw credential strings (usernames, passwords) never appear in output.
+  - Source IP addresses never appear in any feature category JSON.
+  - No raw payload bytes stored.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.intelligence.sequence import (
+    compute_credential_features,
+    compute_protocol_features,
+    compute_sequence_features,
+    compute_target_features,
+    compute_timing_features,
+    compute_tool_signals,
+    extract_all_features,
+    extract_sessions,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_TS = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_event(
+    offset_seconds: float = 0,
+    dst_port: int | None = 22,
+    event_type: str = "auth_failed",
+    service: str | None = "ssh",
+    source: str = "cowrie",
+    raw_data: dict | None = None,
+) -> dict:
+    ts = (_BASE_TS + timedelta(seconds=offset_seconds)).isoformat()
+    return {
+        "ts": ts,
+        "dst_port": dst_port,
+        "event_type": event_type,
+        "service": service,
+        "source": source,
+        "raw_data": raw_data or {},
+    }
+
+
+def _make_cred_event(
+    offset_seconds: float = 0,
+    username: str = "admin",
+    password: str = "password123",
+    dst_port: int | None = 22,
+) -> dict:
+    return _make_event(
+        offset_seconds=offset_seconds,
+        dst_port=dst_port,
+        raw_data={"ip": "203.0.113.1", "username": username, "password": password},
+    )
+
+
+# ---------------------------------------------------------------------------
+# extract_sessions
+# ---------------------------------------------------------------------------
+
+
+def test_extract_sessions_empty_returns_empty():
+    assert extract_sessions([]) == []
+
+
+def test_extract_sessions_single_event_one_session():
+    events = [_make_event()]
+    sessions = extract_sessions(events)
+    assert len(sessions) == 1
+    assert len(sessions[0]) == 1
+
+
+def test_extract_sessions_short_gap_stays_in_one_session():
+    events = [_make_event(0), _make_event(60), _make_event(120)]
+    sessions = extract_sessions(events)
+    assert len(sessions) == 1
+    assert len(sessions[0]) == 3
+
+
+def test_extract_sessions_splits_on_gap_exceeding_threshold():
+    # Default gap is 1800 s; 3601 s apart should split.
+    events = [_make_event(0), _make_event(3601)]
+    sessions = extract_sessions(events)
+    assert len(sessions) == 2
+
+
+def test_extract_sessions_boundary_exactly_at_gap_splits():
+    events = [_make_event(0), _make_event(1801)]
+    sessions = extract_sessions(events, gap_seconds=1800)
+    assert len(sessions) == 2
+
+
+def test_extract_sessions_boundary_just_under_gap_stays_together():
+    events = [_make_event(0), _make_event(1799)]
+    sessions = extract_sessions(events, gap_seconds=1800)
+    assert len(sessions) == 1
+
+
+def test_extract_sessions_sorts_events_chronologically():
+    # Pass events in reverse order; sessions must still be chronological.
+    events = [_make_event(300), _make_event(0), _make_event(150)]
+    sessions = extract_sessions(events)
+    assert len(sessions) == 1
+    ts_values = [e["ts"] for e in sessions[0]]
+    assert ts_values == sorted(ts_values)
+
+
+def test_extract_sessions_custom_gap():
+    events = [_make_event(0), _make_event(61)]
+    sessions = extract_sessions(events, gap_seconds=60)
+    assert len(sessions) == 2
+
+
+# ---------------------------------------------------------------------------
+# compute_timing_features
+# ---------------------------------------------------------------------------
+
+
+def test_compute_timing_features_none_for_single_event():
+    assert compute_timing_features([_make_event()]) is None
+
+
+def test_compute_timing_features_none_for_empty():
+    assert compute_timing_features([]) is None
+
+
+def test_compute_timing_features_returns_expected_keys():
+    events = [_make_event(i * 60) for i in range(5)]
+    result = compute_timing_features(events)
+    assert result is not None
+    assert "interval" in result
+    assert "tod_histogram" in result
+    assert "dow_histogram" in result
+    assert "burst_cv" in result
+
+
+def test_compute_timing_features_interval_keys():
+    events = [_make_event(i * 60) for i in range(5)]
+    iv = compute_timing_features(events)["interval"]
+    assert set(iv.keys()) == {"mean", "stddev", "p25", "p75", "p95"}
+
+
+def test_compute_timing_features_interval_mean_is_correct():
+    # Events spaced exactly 60 seconds apart → interval mean = 60_000 ms
+    events = [_make_event(i * 60) for i in range(4)]
+    iv = compute_timing_features(events)["interval"]
+    assert abs(iv["mean"] - 60_000.0) < 1.0
+
+
+def test_compute_timing_features_tod_histogram_length():
+    events = [_make_event(i * 60) for i in range(5)]
+    tod = compute_timing_features(events)["tod_histogram"]
+    assert len(tod) == 24
+
+
+def test_compute_timing_features_tod_histogram_sums_to_one():
+    events = [_make_event(i * 60) for i in range(5)]
+    tod = compute_timing_features(events)["tod_histogram"]
+    assert abs(sum(tod) - 1.0) < 1e-6
+
+
+def test_compute_timing_features_dow_histogram_length():
+    events = [_make_event(i * 60) for i in range(5)]
+    dow = compute_timing_features(events)["dow_histogram"]
+    assert len(dow) == 7
+
+
+def test_compute_timing_features_dow_histogram_sums_to_one():
+    events = [_make_event(i * 60) for i in range(5)]
+    dow = compute_timing_features(events)["dow_histogram"]
+    assert abs(sum(dow) - 1.0) < 1e-6
+
+
+def test_compute_timing_features_burst_cv_is_nonnegative():
+    events = [_make_event(i * 60) for i in range(5)]
+    cv = compute_timing_features(events)["burst_cv"]
+    assert cv >= 0.0
+
+
+def test_compute_timing_features_metronomic_tool_has_low_burst_cv():
+    # Perfectly even 60-second spacing → stddev = 0 → burst_cv = 0
+    events = [_make_event(i * 60) for i in range(10)]
+    cv = compute_timing_features(events)["burst_cv"]
+    assert cv == 0.0
+
+
+def test_compute_timing_features_cross_session_gap_excluded():
+    # Two sessions with a 1-hour gap.  The inter-session gap must not
+    # appear in interval stats — only within-session intervals count.
+    session1 = [_make_event(0), _make_event(60)]  # one 60s interval
+    session2 = [_make_event(3900), _make_event(3960)]  # one 60s interval
+    events = session1 + session2
+    result = compute_timing_features(events)
+    # All intervals are 60 000 ms; mean must be ~60 000, not ~1920 000
+    assert abs(result["interval"]["mean"] - 60_000.0) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# compute_sequence_features
+# ---------------------------------------------------------------------------
+
+
+def test_compute_sequence_features_empty_returns_none():
+    assert compute_sequence_features([]) is None
+
+
+def test_compute_sequence_features_no_port_no_cred_returns_none():
+    events = [_make_event(0, dst_port=None, raw_data={})]
+    result = compute_sequence_features(events)
+    assert result is None
+
+
+def test_compute_sequence_features_returns_expected_keys():
+    events = [_make_event(i * 60, dst_port=22 + i) for i in range(3)]
+    result = compute_sequence_features(events)
+    assert result is not None
+    assert "port_sequence" in result
+    assert "event_type_sequence" in result
+    assert "credential_sequence" in result
+
+
+def test_compute_sequence_features_port_order_preserved():
+    events = [_make_event(i * 10, dst_port=p) for i, p in enumerate([80, 22, 443])]
+    result = compute_sequence_features(events)
+    assert result["port_sequence"] == [80, 22, 443]
+
+
+def test_compute_sequence_features_port_sequence_deduped():
+    # Same port appearing twice should appear once in the sequence.
+    events = [
+        _make_event(0, dst_port=22),
+        _make_event(60, dst_port=22),
+        _make_event(120, dst_port=80),
+    ]
+    result = compute_sequence_features(events)
+    assert result["port_sequence"].count(22) == 1
+
+
+def test_compute_sequence_features_credential_sequence_no_raw_values():
+    events = [
+        _make_cred_event(0, username="definitely_unique_username", password="UNIQUE_RAW_PW_XYZ"),
+    ]
+    result = compute_sequence_features(events)
+    seq_str = json.dumps(result["credential_sequence"])
+    assert "definitely_unique_username" not in seq_str
+    assert "UNIQUE_RAW_PW_XYZ" not in seq_str
+
+
+def test_compute_sequence_features_credential_sequence_has_pattern_keys():
+    events = [_make_cred_event(0, username="admin", password="pass")]
+    result = compute_sequence_features(events)
+    seq = result["credential_sequence"]
+    assert len(seq) == 1
+    assert "username_pattern" in seq[0]
+    assert "password_class" in seq[0]
+
+
+# ---------------------------------------------------------------------------
+# compute_protocol_features
+# ---------------------------------------------------------------------------
+
+
+def test_compute_protocol_features_returns_service_distribution():
+    events = [
+        _make_event(0, service="ssh"),
+        _make_event(60, service="ssh"),
+        _make_event(120, service="http"),
+    ]
+    result = compute_protocol_features(events)
+    assert result is not None
+    assert "service_distribution" in result
+    dist = result["service_distribution"]
+    assert abs(dist["ssh"] - 2 / 3) < 1e-4
+    assert abs(dist["http"] - 1 / 3) < 1e-4
+
+
+def test_compute_protocol_features_null_service_excluded():
+    events = [_make_event(0, service=None), _make_event(60, service="ssh")]
+    result = compute_protocol_features(events)
+    assert "ssh" in result["service_distribution"]
+    assert None not in result["service_distribution"]
+
+
+def test_compute_protocol_features_ssh_kex_extracted_when_present():
+    kex = ["curve25519-sha256", "ecdh-sha2-nistp256"]
+    events = [_make_event(0, raw_data={"kex_algs": kex})]
+    result = compute_protocol_features(events)
+    assert result["ssh_kex_ordering"] == kex
+
+
+def test_compute_protocol_features_ssh_kex_null_when_absent():
+    events = [_make_event(0)]
+    result = compute_protocol_features(events)
+    assert result["ssh_kex_ordering"] is None
+
+
+def test_compute_protocol_features_tls_ciphers_null_when_absent():
+    events = [_make_event(0)]
+    result = compute_protocol_features(events)
+    assert result["tls_cipher_ordering"] is None
+
+
+# ---------------------------------------------------------------------------
+# compute_credential_features
+# ---------------------------------------------------------------------------
+
+
+def test_compute_credential_features_none_when_no_creds():
+    events = [_make_event(0, raw_data={})]
+    assert compute_credential_features(events) is None
+
+
+def test_compute_credential_features_none_for_empty():
+    assert compute_credential_features([]) is None
+
+
+def test_compute_credential_features_no_raw_usernames_stored():
+    """Raw username strings must never appear in the feature output."""
+    events = [_make_cred_event(0, username="unique_secret_user_abc", password="x")]
+    result = compute_credential_features(events)
+    result_str = json.dumps(result)
+    assert "unique_secret_user_abc" not in result_str
+
+
+def test_compute_credential_features_no_raw_passwords_stored():
+    """Raw password strings must never appear in the feature output."""
+    events = [_make_cred_event(0, username="u", password="unique_secret_pw_xyz")]
+    result = compute_credential_features(events)
+    result_str = json.dumps(result)
+    assert "unique_secret_pw_xyz" not in result_str
+
+
+def test_compute_credential_features_returns_expected_keys():
+    events = [_make_cred_event(0)]
+    result = compute_credential_features(events)
+    assert result is not None
+    assert "credential_count" in result
+    assert "username_class_dist" in result
+    assert "password_length_mean" in result
+    assert "password_char_class" in result
+    assert "credential_sequence" in result
+
+
+def test_compute_credential_features_credential_count():
+    events = [_make_cred_event(i * 60) for i in range(5)]
+    result = compute_credential_features(events)
+    assert result["credential_count"] == 5
+
+
+def test_compute_credential_features_username_class_alpha():
+    events = [_make_cred_event(0, username="admin")]
+    result = compute_credential_features(events)
+    dist = result["username_class_dist"]
+    assert "alpha" in dist
+    assert abs(dist["alpha"] - 1.0) < 1e-6
+
+
+def test_compute_credential_features_username_class_numeric():
+    events = [_make_cred_event(0, username="12345")]
+    result = compute_credential_features(events)
+    dist = result["username_class_dist"]
+    assert "numeric" in dist
+
+
+def test_compute_credential_features_username_class_email():
+    events = [_make_cred_event(0, username="user@example.com")]
+    result = compute_credential_features(events)
+    dist = result["username_class_dist"]
+    assert "email" in dist
+
+
+def test_compute_credential_features_password_length_mean():
+    # "pass" = 4, "password" = 8 → mean = 6.0
+    events = [
+        _make_cred_event(0, password="pass"),
+        _make_cred_event(60, password="password"),
+    ]
+    result = compute_credential_features(events)
+    assert abs(result["password_length_mean"] - 6.0) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# compute_target_features
+# ---------------------------------------------------------------------------
+
+
+def test_compute_target_features_none_when_no_ports():
+    events = [_make_event(0, dst_port=None)]
+    assert compute_target_features(events) is None
+
+
+def test_compute_target_features_none_for_empty():
+    assert compute_target_features([]) is None
+
+
+def test_compute_target_features_returns_expected_keys():
+    events = [_make_event(0, dst_port=22)]
+    result = compute_target_features(events)
+    assert result is not None
+    assert "port_freq" in result
+    assert "unique_port_count" in result
+    assert "top_dst_ports" in result
+
+
+def test_compute_target_features_port_freq_proportions():
+    events = [
+        _make_event(0, dst_port=22),
+        _make_event(60, dst_port=22),
+        _make_event(120, dst_port=80),
+    ]
+    result = compute_target_features(events)
+    freq = result["port_freq"]
+    assert abs(float(freq["22"]) - 2 / 3) < 1e-4
+    assert abs(float(freq["80"]) - 1 / 3) < 1e-4
+
+
+def test_compute_target_features_unique_port_count():
+    events = [_make_event(i * 10, dst_port=p) for i, p in enumerate([22, 22, 80, 443])]
+    result = compute_target_features(events)
+    assert result["unique_port_count"] == 3
+
+
+def test_compute_target_features_top_dst_ports_sorted_by_frequency():
+    events = [
+        _make_event(0, dst_port=22),
+        _make_event(10, dst_port=22),
+        _make_event(20, dst_port=22),
+        _make_event(30, dst_port=80),
+    ]
+    result = compute_target_features(events)
+    assert result["top_dst_ports"][0] == 22
+
+
+# ---------------------------------------------------------------------------
+# compute_tool_signals
+# ---------------------------------------------------------------------------
+
+
+def test_compute_tool_signals_none_for_empty():
+    assert compute_tool_signals([]) is None
+
+
+def test_compute_tool_signals_returns_expected_keys():
+    events = [_make_event(0)]
+    result = compute_tool_signals(events)
+    assert result is not None
+    assert "source_dist" in result
+    assert "event_type_dist" in result
+    assert "inferred_tools" in result
+
+
+def test_compute_tool_signals_source_distribution():
+    events = [
+        _make_event(0, source="cowrie"),
+        _make_event(60, source="cowrie"),
+        _make_event(120, source="dionaea"),
+    ]
+    result = compute_tool_signals(events)
+    dist = result["source_dist"]
+    assert abs(dist["cowrie"] - 2 / 3) < 1e-4
+
+
+def test_compute_tool_signals_infers_ssh_brute_force():
+    events = [_make_event(i * 10, source="cowrie", event_type="auth_failed") for i in range(10)]
+    result = compute_tool_signals(events)
+    tools = {t["tool"] for t in result["inferred_tools"]}
+    assert "ssh_brute_force" in tools
+
+
+# ---------------------------------------------------------------------------
+# extract_all_features
+# ---------------------------------------------------------------------------
+
+
+def test_extract_all_features_returns_six_keys():
+    events = [_make_event(i * 60) for i in range(5)]
+    result = extract_all_features(events)
+    assert set(result.keys()) == {
+        "timing_features",
+        "sequence_features",
+        "protocol_features",
+        "credential_features",
+        "target_features",
+        "tool_signals",
+    }
+
+
+def test_extract_all_features_empty_events_all_none_or_empty():
+    result = extract_all_features([])
+    # timing and target require data; some categories tolerate empty
+    assert result["timing_features"] is None
+    assert result["target_features"] is None
+    assert result["credential_features"] is None
+
+
+# ---------------------------------------------------------------------------
+# Privacy invariant: no source IP in any feature category
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        "timing_features",
+        "sequence_features",
+        "protocol_features",
+        "credential_features",
+        "target_features",
+        "tool_signals",
+    ],
+)
+def test_no_source_ip_in_feature_category(category):
+    """Source IP addresses must not appear in any computed feature category."""
+    # Events where raw_data.ip is a distinctive sentinel value
+    sentinel_ip = "198.51.100.99"
+    events = [
+        _make_event(
+            i * 60,
+            dst_port=22,
+            source="cowrie",
+            raw_data={"ip": sentinel_ip, "username": "root", "password": "pass"},
+        )
+        for i in range(5)
+    ]
+    result = extract_all_features(events)
+    cat_val = result.get(category)
+    if cat_val is not None:
+        cat_str = json.dumps(cat_val)
+        assert sentinel_ip not in cat_str, f"Source IP {sentinel_ip!r} leaked into {category}"


### PR DESCRIPTION
## Summary

- **`app/intelligence/sequence.py`** — six pure feature extractors: timing intervals, port/event-type sequences, credential patterns (no raw values stored), target port distribution, protocol signals, tool signals with heuristic inference
- **`app/intelligence/fingerprint.py`** — `build_fingerprint` aggregates all six extractors into versioned JSON columns; `compute_confidence` gates sparse fingerprints (< `MIN_EVENTS_FOR_CLUSTERING` = 10) to confidence < 0.20
- **`app/intelligence/tasks.py`** — `schedule_fingerprint_if_not_pending` enqueues recomputation via FastAPI `BackgroundTasks`; thread-safe per-IP deduplication with `threading.Lock` + module-level set prevents redundant in-flight tasks
- **`app/db/repositories/fingerprint.py`** — `FingerprintRepository` mixin: `get_events_for_fingerprint`, `upsert_behavioral_fingerprint` (PostgreSQL-compatible `ON CONFLICT` upsert), `get_behavioral_fingerprint`
- **`app/routers/ingest.py`** — Stage 7 added: schedules fingerprint recomputation for each unique accepted IP after the ingest session commits; never blocks the response
- **Test teardown fixtures** (`tests/integration/conftest.py`, `tests/test_iocs.py`, `tests/test_iocs_privacy_and_filter.py`) — Phase 4 tables deleted before `source_ips` to satisfy FK constraints

## Intentionally deferred

Campaign clustering, campaign assignment, similarity scanning, campaign API endpoints, and dashboard views are all excluded from this PR per Phase 4 sequencing.

## Privacy invariants

- Credential feature extraction stores only pattern classifications (`alpha`, `numeric`, `alphanum`, `special`, `email`) — no raw usernames or passwords
- Feature JSON contains no raw IP addresses
- Tests assert both invariants explicitly

## Test plan

- [ ] `python -m pytest --tb=short -q` → 432 passed, 3 skipped, 0 errors
- [ ] `pre-commit run --all-files` → all hooks pass
- [ ] Unit tests: `tests/unit/test_sequence_extraction.py` (feature extractors + privacy invariants), `tests/unit/test_fingerprint_generation.py` (confidence + build_fingerprint)
- [ ] DB tests: `tests/db/test_fingerprint_repository.py` (upsert, get, FK safety)