### PR TITLE
feat(intelligence): add deterministic campaign clustering

### DIFF
--- a/app/db/repositories/campaign.py
+++ b/app/db/repositories/campaign.py
@@ -1,0 +1,331 @@
+"""Campaign repository methods: reads and writes for campaign tables.
+
+All SQL lives in this module.  No clustering logic or similarity computation.
+The caller owns the session and transaction boundary.
+
+PostgreSQL-compatibility rules enforced here:
+  - INSERT ... ON CONFLICT DO NOTHING (not INSERT OR IGNORE)
+  - No dialect-specific datetime functions; timestamps are application-inserted
+  - No json_extract() in SQL WHERE clauses
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db.repositories._base import RepositoryBase
+
+
+class CampaignRepository(RepositoryBase):
+    def create_campaign(
+        self,
+        campaign_id: str,
+        name: str,
+        status: str,
+        confidence: float,
+        first_seen: str,
+        last_seen: str,
+        member_ip_count: int,
+        created_at: str,
+        updated_at: str,
+    ) -> None:
+        """Insert a new campaign row.  campaign_id must be caller-generated."""
+        self._session.execute(
+            text("""
+                INSERT INTO campaigns (
+                    id, name, status, confidence,
+                    first_seen, last_seen, dormant_since,
+                    reactivation_count, member_ip_count,
+                    attack_tactic_dist, top_target_ports, notes,
+                    created_at, updated_at
+                ) VALUES (
+                    :id, :name, :status, :confidence,
+                    :first_seen, :last_seen, NULL,
+                    0, :member_ip_count,
+                    NULL, NULL, NULL,
+                    :created_at, :updated_at
+                )
+            """),
+            {
+                "id": campaign_id,
+                "name": name,
+                "status": status,
+                "confidence": confidence,
+                "first_seen": first_seen,
+                "last_seen": last_seen,
+                "member_ip_count": member_ip_count,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            },
+        )
+
+    def get_campaign(self, campaign_id: str) -> dict[str, Any] | None:
+        """Return full campaign row as dict, or None if not found."""
+        row = self._session.execute(
+            text("""
+                SELECT id, name, status, confidence,
+                       first_seen, last_seen, dormant_since,
+                       reactivation_count, member_ip_count,
+                       attack_tactic_dist, top_target_ports, notes,
+                       created_at, updated_at
+                FROM campaigns WHERE id = :id
+            """),
+            {"id": campaign_id},
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row[0],
+            "name": row[1],
+            "status": row[2],
+            "confidence": row[3],
+            "first_seen": row[4],
+            "last_seen": row[5],
+            "dormant_since": row[6],
+            "reactivation_count": row[7],
+            "member_ip_count": row[8],
+            "attack_tactic_dist": row[9],
+            "top_target_ports": row[10],
+            "notes": row[11],
+            "created_at": row[12],
+            "updated_at": row[13],
+        }
+
+    def get_campaigns_for_clustering(self) -> list[dict[str, Any]]:
+        """Return active/dormant/reactivated campaigns with a representative fingerprint.
+
+        The representative fingerprint is the stored fingerprint of the
+        most-recently-active member IP for each campaign.
+
+        Campaigns with no members or whose most-recent member has no
+        stored fingerprint are silently excluded (no candidate to compare
+        against).
+        """
+        campaign_rows = self._session.execute(text("""
+                SELECT id, status, last_seen
+                FROM campaigns
+                WHERE status IN ('active', 'dormant', 'reactivated')
+            """)).fetchall()
+
+        if not campaign_rows:
+            return []
+
+        results: list[dict[str, Any]] = []
+        for cid, status, last_seen in campaign_rows:
+            member_row = self._session.execute(
+                text("""
+                    SELECT source_ip FROM campaign_members
+                    WHERE campaign_id = :cid
+                    ORDER BY last_active DESC LIMIT 1
+                """),
+                {"cid": cid},
+            ).fetchone()
+            if member_row is None:
+                continue
+
+            fp_row = self._session.execute(
+                text("""
+                    SELECT timing_features, sequence_features, protocol_features,
+                           credential_features, target_features, confidence
+                    FROM behavioral_fingerprints
+                    WHERE source_ip = :ip
+                """),
+                {"ip": member_row[0]},
+            ).fetchone()
+            if fp_row is None:
+                continue
+
+            results.append(
+                {
+                    "campaign_id": cid,
+                    "status": status,
+                    "last_seen": last_seen,
+                    "timing_features": fp_row[0],
+                    "sequence_features": fp_row[1],
+                    "protocol_features": fp_row[2],
+                    "credential_features": fp_row[3],
+                    "target_features": fp_row[4],
+                    "confidence": fp_row[5],
+                }
+            )
+
+        return results
+
+    def get_campaign_member_by_ip(self, source_ip: str) -> dict[str, Any] | None:
+        """Return the campaign_members row for source_ip, or None if unassigned."""
+        row = self._session.execute(
+            text("""
+                SELECT campaign_id, source_ip, confidence, added_at, last_active
+                FROM campaign_members
+                WHERE source_ip = :ip
+            """),
+            {"ip": source_ip},
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "campaign_id": row[0],
+            "source_ip": row[1],
+            "confidence": row[2],
+            "added_at": row[3],
+            "last_active": row[4],
+        }
+
+    def add_campaign_member(
+        self,
+        campaign_id: str,
+        source_ip: str,
+        confidence: float,
+        added_at: str,
+        last_active: str,
+    ) -> None:
+        """Insert a new campaign_members row."""
+        self._session.execute(
+            text("""
+                INSERT INTO campaign_members
+                    (campaign_id, source_ip, confidence, added_at, last_active)
+                VALUES (:campaign_id, :source_ip, :confidence, :added_at, :last_active)
+            """),
+            {
+                "campaign_id": campaign_id,
+                "source_ip": source_ip,
+                "confidence": confidence,
+                "added_at": added_at,
+                "last_active": last_active,
+            },
+        )
+
+    def update_campaign_member_last_active(
+        self,
+        campaign_id: str,
+        source_ip: str,
+        last_active: str,
+    ) -> None:
+        """Update the last_active timestamp for an existing campaign member."""
+        self._session.execute(
+            text("""
+                UPDATE campaign_members
+                SET last_active = :last_active
+                WHERE campaign_id = :campaign_id AND source_ip = :source_ip
+            """),
+            {
+                "campaign_id": campaign_id,
+                "source_ip": source_ip,
+                "last_active": last_active,
+            },
+        )
+
+    def insert_campaign_observation(
+        self,
+        campaign_id: str,
+        source_ip: str,
+        observed_at: str,
+        event_count: int,
+        is_reactivation: bool,
+        dormancy_gap_days: float | None,
+        notes: str | None,
+    ) -> None:
+        """Insert a new campaign_observations row."""
+        self._session.execute(
+            text("""
+                INSERT INTO campaign_observations
+                    (id, campaign_id, source_ip, observed_at, event_count,
+                     is_reactivation, dormancy_gap_days, notes)
+                VALUES
+                    (:id, :campaign_id, :source_ip, :observed_at, :event_count,
+                     :is_reactivation, :dormancy_gap_days, :notes)
+            """),
+            {
+                "id": str(uuid.uuid4()),
+                "campaign_id": campaign_id,
+                "source_ip": source_ip,
+                "observed_at": observed_at,
+                "event_count": event_count,
+                "is_reactivation": 1 if is_reactivation else 0,
+                "dormancy_gap_days": dormancy_gap_days,
+                "notes": notes,
+            },
+        )
+
+    def update_campaign_on_association(
+        self,
+        campaign_id: str,
+        last_seen: str,
+        updated_at: str,
+        new_member_ip_count_delta: int,
+        is_reactivation: bool,
+    ) -> None:
+        """Update campaign metadata after a new IP is associated.
+
+        When is_reactivation is True:
+          - status → 'reactivated'
+          - dormant_since → NULL
+          - reactivation_count += 1
+
+        new_member_ip_count_delta is 1 for a new member, 0 for an existing
+        member whose activity is being recorded.
+        """
+        if is_reactivation:
+            self._session.execute(
+                text("""
+                    UPDATE campaigns
+                    SET last_seen = :last_seen,
+                        updated_at = :updated_at,
+                        member_ip_count = member_ip_count + :delta,
+                        status = 'reactivated',
+                        dormant_since = NULL,
+                        reactivation_count = reactivation_count + 1
+                    WHERE id = :campaign_id
+                """),
+                {
+                    "campaign_id": campaign_id,
+                    "last_seen": last_seen,
+                    "updated_at": updated_at,
+                    "delta": new_member_ip_count_delta,
+                },
+            )
+        else:
+            self._session.execute(
+                text("""
+                    UPDATE campaigns
+                    SET last_seen = :last_seen,
+                        updated_at = :updated_at,
+                        member_ip_count = member_ip_count + :delta
+                    WHERE id = :campaign_id
+                """),
+                {
+                    "campaign_id": campaign_id,
+                    "last_seen": last_seen,
+                    "updated_at": updated_at,
+                    "delta": new_member_ip_count_delta,
+                },
+            )
+
+    def get_campaign_observations(self, campaign_id: str) -> list[dict[str, Any]]:
+        """Return all observations for a campaign, ordered by observed_at."""
+        rows = self._session.execute(
+            text("""
+                SELECT id, campaign_id, source_ip, observed_at, event_count,
+                       is_reactivation, dormancy_gap_days, notes
+                FROM campaign_observations
+                WHERE campaign_id = :campaign_id
+                ORDER BY observed_at ASC
+            """),
+            {"campaign_id": campaign_id},
+        ).fetchall()
+        return [
+            {
+                "id": r[0],
+                "campaign_id": r[1],
+                "source_ip": r[2],
+                "observed_at": r[3],
+                "event_count": r[4],
+                "is_reactivation": bool(r[5]),
+                "dormancy_gap_days": r[6],
+                "notes": r[7],
+            }
+            for r in rows
+        ]

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -11,6 +11,7 @@ Internal structure (by concern):
     repositories/read.py         — dashboard queries and ingest-side cache reads
     repositories/intelligence.py — intelligence API query methods
     repositories/fingerprint.py  — behavioral fingerprint reads and writes
+    repositories/campaign.py     — campaign CRUD and clustering query methods
 
 The caller owns the session and therefore the transaction boundary.
 
@@ -27,6 +28,7 @@ No FastAPI, router, or application imports belong in the sub-modules.
 
 from __future__ import annotations
 
+from app.db.repositories.campaign import CampaignRepository
 from app.db.repositories.fingerprint import FingerprintRepository
 from app.db.repositories.intelligence import IntelligenceRepository
 from app.db.repositories.read import ReadRepository
@@ -34,13 +36,18 @@ from app.db.repositories.write import WriteRepository
 
 
 class EventRepository(
-    WriteRepository, ReadRepository, IntelligenceRepository, FingerprintRepository
+    WriteRepository,
+    ReadRepository,
+    IntelligenceRepository,
+    FingerprintRepository,
+    CampaignRepository,
 ):
     """
-    Unified repository class. Inherits all SQL methods from the four concern
+    Unified repository class. Inherits all SQL methods from the five concern
     mixins. Callers see a single object with the full method surface; the
     internal split is an organisation detail invisible to callers.
 
     Python MRO: EventRepository → WriteRepository → ReadRepository →
-                IntelligenceRepository → FingerprintRepository → RepositoryBase → object
+                IntelligenceRepository → FingerprintRepository →
+                CampaignRepository → RepositoryBase → object
     """

--- a/app/intelligence/campaign_names.py
+++ b/app/intelligence/campaign_names.py
@@ -1,0 +1,93 @@
+"""Deterministic campaign name generator.
+
+Names are derived from the campaign UUID using a SHA-256 hash, so they are
+stable once assigned — the same UUID always produces the same name.
+
+Format: ADJECTIVE-ANIMAL-N  (e.g., SHADOW-CRANE-7)
+
+30 adjectives × 30 animals × 90 numbers = 81,000 possible names, sufficient
+for Phase 4 deployment scale.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+_ADJECTIVES: list[str] = [
+    "shadow",
+    "crimson",
+    "silent",
+    "amber",
+    "frozen",
+    "cobalt",
+    "phantom",
+    "scarlet",
+    "hollow",
+    "iron",
+    "lunar",
+    "obsidian",
+    "silver",
+    "dark",
+    "hidden",
+    "ancient",
+    "midnight",
+    "rapid",
+    "steel",
+    "veiled",
+    "volatile",
+    "carbon",
+    "prism",
+    "static",
+    "titan",
+    "nova",
+    "void",
+    "apex",
+    "cipher",
+    "delta",
+]
+
+_ANIMALS: list[str] = [
+    "crane",
+    "wolf",
+    "raven",
+    "fox",
+    "hawk",
+    "bear",
+    "lynx",
+    "viper",
+    "eagle",
+    "cobra",
+    "mantis",
+    "shark",
+    "python",
+    "falcon",
+    "jaguar",
+    "tiger",
+    "osprey",
+    "scorpion",
+    "otter",
+    "manta",
+    "hornet",
+    "panther",
+    "kestrel",
+    "beetle",
+    "crow",
+    "mongoose",
+    "ferret",
+    "wyvern",
+    "hydra",
+    "asp",
+]
+
+
+def generate_campaign_name(campaign_id: str) -> str:
+    """Return a stable human-readable name for campaign_id.
+
+    Uses the first 32 hex digits of SHA-256(campaign_id) to deterministically
+    select an adjective, animal, and number.  Same input → same output always.
+    """
+    h = int(hashlib.sha256(campaign_id.encode()).hexdigest(), 16)
+    adj = _ADJECTIVES[h % len(_ADJECTIVES)]
+    animal = _ANIMALS[(h >> 8) % len(_ANIMALS)]
+    number = (h >> 16) % 90 + 1
+    return f"{adj.upper()}-{animal.upper()}-{number}"

--- a/app/intelligence/clustering.py
+++ b/app/intelligence/clustering.py
@@ -1,0 +1,312 @@
+"""Campaign assignment service — maps a new fingerprint to a campaign (§8.2).
+
+Entry point: assign_to_campaign(ip, fp, repo, now)
+
+Algorithm per §8.2 and §12.3:
+  1. Gate: confidence < 0.20 → skip (sparse fingerprint, §12.6)
+  2. Already a member → update last_active, record observation, return
+  3. Fetch candidate campaigns (active / dormant / reactivated)
+  4. For each candidate, compute weighted similarity; apply temporal threshold
+     bump if the campaign has been dormant for 6+ or 12+ months (§12.3)
+  5. Select the highest-scoring candidate above SIMILARITY_UNCERTAIN_LOW
+  6. Decision:
+       score ≥ effective_auto_threshold  → automatic_association
+       score ≥ SIMILARITY_UNCERTAIN_LOW  → uncertain_association
+       no candidate above uncertain low  → new_campaign
+  7. Persist: add member, insert observation, update campaign
+
+Explainability (§12.7):
+  Every association stores a JSON explanation in campaign_observations.notes
+  containing per-dimension similarity scores, weighted total, threshold
+  applied, and decision label.
+
+Deterministic: same inputs always produce the same output (§11, §12.7).
+No ML, no external APIs, no raw credentials or IPs in outputs.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from app.intelligence.constants import (
+    SIMILARITY_AUTO_THRESHOLD,
+    SIMILARITY_UNCERTAIN_LOW,
+    TEMPORAL_THRESHOLD_6M,
+    TEMPORAL_THRESHOLD_12M,
+)
+from app.intelligence.similarity import SimilarityResult, compute_weighted_similarity
+
+if TYPE_CHECKING:
+    from app.db.repository import EventRepository
+
+# ---------------------------------------------------------------------------
+# Decision labels
+# ---------------------------------------------------------------------------
+
+DECISION_SKIPPED_SPARSE = "skipped_sparse"
+DECISION_EXISTING_MEMBER = "existing_member"
+DECISION_AUTO_ASSOCIATION = "automatic_association"
+DECISION_UNCERTAIN_ASSOCIATION = "uncertain_association"
+DECISION_NEW_CAMPAIGN = "new_campaign"
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClusteringDecision:
+    """Full record of a single campaign assignment decision."""
+
+    decision: str
+    campaign_id: str | None
+    similarity: SimilarityResult | None
+    threshold_applied: float
+    reason: str
+    is_reactivation: bool = field(default=False)
+    dormancy_gap_days: float | None = field(default=None)
+
+
+# ---------------------------------------------------------------------------
+# Temporal threshold helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_effective_auto_threshold(
+    campaign_last_seen: str,
+    now: datetime,
+) -> float:
+    """Return the auto-association threshold adjusted for temporal gap (§12.3).
+
+    The base threshold (SIMILARITY_AUTO_THRESHOLD = 0.80) is raised when
+    the campaign has been dormant for a long time, because the probability
+    that similar-looking activity is coincidental increases with time.
+    """
+    try:
+        last_dt = datetime.fromisoformat(campaign_last_seen.replace("Z", "+00:00")).astimezone(UTC)
+        gap_days = (now - last_dt).days
+    except (ValueError, AttributeError, TypeError):
+        return SIMILARITY_AUTO_THRESHOLD
+
+    if gap_days > 365:
+        return TEMPORAL_THRESHOLD_12M
+    if gap_days > 182:
+        return TEMPORAL_THRESHOLD_6M
+    return SIMILARITY_AUTO_THRESHOLD
+
+
+def _dormancy_gap_days(campaign_last_seen: str, now: datetime) -> float | None:
+    """Return days between campaign_last_seen and now, or None on parse failure."""
+    try:
+        last_dt = datetime.fromisoformat(campaign_last_seen.replace("Z", "+00:00")).astimezone(UTC)
+        return max(0.0, (now - last_dt).total_seconds() / 86400.0)
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def assign_to_campaign(
+    ip: str,
+    fp: dict[str, Any],
+    repo: EventRepository,
+    now: datetime | None = None,
+) -> ClusteringDecision:
+    """Assign ip's fingerprint to an existing or new campaign.
+
+    fp must be a behavioral_fingerprint dict as returned by
+    EventRepository.get_behavioral_fingerprint() — feature columns are JSON
+    strings (or None).
+
+    now is injectable for deterministic testing; defaults to UTC now.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+    now_str = now.isoformat()
+
+    # Gate 1: Sparse fingerprints do not enter clustering (§12.6).
+    confidence: float = float(fp.get("confidence", 0.0))
+    if confidence < 0.20:
+        return ClusteringDecision(
+            decision=DECISION_SKIPPED_SPARSE,
+            campaign_id=None,
+            similarity=None,
+            threshold_applied=0.20,
+            reason=(f"fingerprint confidence {confidence:.4f} below " "clustering threshold 0.20"),
+        )
+
+    # Gate 2: IP is already assigned to a campaign.
+    existing = repo.get_campaign_member_by_ip(ip)
+    if existing is not None:
+        campaign_id: str = existing["campaign_id"]
+        event_count = int(fp.get("event_count_at_computation", 0))
+        repo.update_campaign_member_last_active(campaign_id, ip, now_str)
+        repo.insert_campaign_observation(
+            campaign_id=campaign_id,
+            source_ip=ip,
+            observed_at=now_str,
+            event_count=event_count,
+            is_reactivation=False,
+            dormancy_gap_days=None,
+            notes=None,
+        )
+        repo.update_campaign_on_association(
+            campaign_id=campaign_id,
+            last_seen=now_str,
+            updated_at=now_str,
+            new_member_ip_count_delta=0,
+            is_reactivation=False,
+        )
+        return ClusteringDecision(
+            decision=DECISION_EXISTING_MEMBER,
+            campaign_id=campaign_id,
+            similarity=None,
+            threshold_applied=0.0,
+            reason="IP already assigned; observation and last_active updated",
+        )
+
+    # Step 3: Fetch candidate campaigns.
+    candidates = repo.get_campaigns_for_clustering()
+
+    # Step 4: Find best candidate above the uncertain-low threshold.
+    best_campaign_id: str | None = None
+    best_sim: SimilarityResult | None = None
+    best_auto_threshold: float = SIMILARITY_AUTO_THRESHOLD
+    best_last_seen: str | None = None
+    best_status: str | None = None
+
+    for candidate in candidates:
+        sim = compute_weighted_similarity(fp, candidate)
+        score = sim.weighted_total
+
+        effective_auto = _get_effective_auto_threshold(candidate["last_seen"], now)
+
+        if score >= SIMILARITY_UNCERTAIN_LOW and (
+            best_sim is None or score > best_sim.weighted_total
+        ):
+            best_campaign_id = candidate["campaign_id"]
+            best_sim = sim
+            best_auto_threshold = effective_auto
+            best_last_seen = candidate["last_seen"]
+            best_status = candidate["status"]
+
+    # Step 5–7: Decision and persistence.
+    if best_sim is not None:
+        score = best_sim.weighted_total
+        is_reactivation = best_status == "dormant"
+        gap_days = _dormancy_gap_days(best_last_seen, now) if is_reactivation else None
+
+        decision = (
+            DECISION_AUTO_ASSOCIATION
+            if score >= best_auto_threshold
+            else DECISION_UNCERTAIN_ASSOCIATION
+        )
+
+        explanation = {
+            **best_sim.as_dict(),
+            "threshold_applied": best_auto_threshold,
+            "decision": decision,
+        }
+        notes = json.dumps(explanation, separators=(",", ":"))
+        event_count = int(fp.get("event_count_at_computation", 0))
+
+        repo.add_campaign_member(
+            campaign_id=best_campaign_id,
+            source_ip=ip,
+            confidence=score,
+            added_at=now_str,
+            last_active=now_str,
+        )
+        repo.insert_campaign_observation(
+            campaign_id=best_campaign_id,
+            source_ip=ip,
+            observed_at=now_str,
+            event_count=event_count,
+            is_reactivation=is_reactivation,
+            dormancy_gap_days=gap_days,
+            notes=notes,
+        )
+        repo.update_campaign_on_association(
+            campaign_id=best_campaign_id,
+            last_seen=now_str,
+            updated_at=now_str,
+            new_member_ip_count_delta=1,
+            is_reactivation=is_reactivation,
+        )
+
+        return ClusteringDecision(
+            decision=decision,
+            campaign_id=best_campaign_id,
+            similarity=best_sim,
+            threshold_applied=best_auto_threshold,
+            reason=f"similarity {score:.4f} vs auto threshold {best_auto_threshold:.2f}",
+            is_reactivation=is_reactivation,
+            dormancy_gap_days=gap_days,
+        )
+
+    # No suitable candidate — create a new campaign.
+    return _create_new_campaign(ip, fp, repo, now_str)
+
+
+# ---------------------------------------------------------------------------
+# New campaign creation
+# ---------------------------------------------------------------------------
+
+
+def _create_new_campaign(
+    ip: str,
+    fp: dict[str, Any],
+    repo: EventRepository,
+    now_str: str,
+) -> ClusteringDecision:
+    """Create a new campaign for ip and return the decision."""
+    from app.intelligence.campaign_names import generate_campaign_name
+
+    campaign_id = str(uuid.uuid4())
+    name = generate_campaign_name(campaign_id)
+    event_count = int(fp.get("event_count_at_computation", 0))
+    confidence = float(fp.get("confidence", 0.5))
+
+    repo.create_campaign(
+        campaign_id=campaign_id,
+        name=name,
+        status="active",
+        confidence=confidence,
+        first_seen=now_str,
+        last_seen=now_str,
+        member_ip_count=1,
+        created_at=now_str,
+        updated_at=now_str,
+    )
+    repo.add_campaign_member(
+        campaign_id=campaign_id,
+        source_ip=ip,
+        confidence=confidence,
+        added_at=now_str,
+        last_active=now_str,
+    )
+    repo.insert_campaign_observation(
+        campaign_id=campaign_id,
+        source_ip=ip,
+        observed_at=now_str,
+        event_count=event_count,
+        is_reactivation=False,
+        dormancy_gap_days=None,
+        notes=None,
+    )
+
+    return ClusteringDecision(
+        decision=DECISION_NEW_CAMPAIGN,
+        campaign_id=campaign_id,
+        similarity=None,
+        threshold_applied=SIMILARITY_UNCERTAIN_LOW,
+        reason="no existing campaign above similarity threshold; new campaign created",
+    )

--- a/app/intelligence/constants.py
+++ b/app/intelligence/constants.py
@@ -26,3 +26,34 @@ TOP_PORT_FREQ_N: int = 20
 
 # Maximum credential-sequence entries stored; limits JSON growth (Appendix).
 MAX_CREDENTIAL_SEQUENCE: int = 50
+
+# ---------------------------------------------------------------------------
+# Campaign clustering weights (§3.2, §12.2)
+# Must sum to 1.0.  Never hardcode these inline — changing weights retroactively
+# requires re-clustering all historical fingerprints (§12.2).
+# ---------------------------------------------------------------------------
+WEIGHT_TIMING: float = 0.20
+WEIGHT_SEQUENCE: float = 0.35
+WEIGHT_PROTOCOL: float = 0.25
+WEIGHT_CREDENTIAL: float = 0.10
+WEIGHT_TARGET: float = 0.10
+
+# ---------------------------------------------------------------------------
+# Association decision thresholds (§8.2, §12.2)
+# Launch defaults — calibrate after 30 days of campaign data.
+# ---------------------------------------------------------------------------
+SIMILARITY_AUTO_THRESHOLD: float = 0.80  # >= auto-associate
+SIMILARITY_UNCERTAIN_LOW: float = 0.60  # [0.60, 0.80) → uncertain association
+
+# ---------------------------------------------------------------------------
+# Temporal recency threshold bumps (§12.3)
+# Applied as a floor on the auto threshold when a campaign's last_seen is old.
+# ---------------------------------------------------------------------------
+TEMPORAL_THRESHOLD_6M: float = 0.85  # campaign last active 6–12 months ago
+TEMPORAL_THRESHOLD_12M: float = 0.90  # campaign last active > 12 months ago
+
+# ---------------------------------------------------------------------------
+# Campaign status lifecycle boundaries in days (§3.6)
+# ---------------------------------------------------------------------------
+CAMPAIGN_ACTIVE_DAYS: int = 7
+CAMPAIGN_DORMANT_DAYS: int = 90

--- a/app/intelligence/similarity.py
+++ b/app/intelligence/similarity.py
@@ -1,0 +1,426 @@
+"""Fingerprint similarity computation for campaign clustering (§8.1).
+
+All functions are pure: no database access, no I/O, no side effects.
+Inputs are parsed feature dicts (not raw JSON strings).
+
+Similarity model per §8.1:
+  continuous distributions → interval stat comparison (normalised distance)
+  histograms (tod/dow)     → Jensen-Shannon divergence, inverted to [0,1]
+  sequences (ports, KEX)   → normalised Levenshtein edit distance
+  categorical/set features → Jaccard similarity
+
+Null-dimension rule (§8.1):
+  When either fingerprint has None for a dimension, that dimension contributes
+  zero to BOTH the numerator and the denominator.  Sparse fingerprints are
+  not penalised for having fewer features than a rich campaign fingerprint.
+
+Infrastructure features (ASN, geography) are deliberately excluded per §12.4.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from app.intelligence.constants import (
+    WEIGHT_CREDENTIAL,
+    WEIGHT_PROTOCOL,
+    WEIGHT_SEQUENCE,
+    WEIGHT_TARGET,
+    WEIGHT_TIMING,
+)
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SimilarityResult:
+    """Per-dimension scores and the weighted total for one fingerprint pair."""
+
+    timing_similarity: float | None
+    sequence_similarity: float | None
+    protocol_similarity: float | None
+    credential_similarity: float | None
+    target_similarity: float | None
+    weighted_total: float
+    dimensions_used: int  # count of non-null dimension pairs
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "timing_similarity": self.timing_similarity,
+            "sequence_similarity": self.sequence_similarity,
+            "protocol_similarity": self.protocol_similarity,
+            "credential_similarity": self.credential_similarity,
+            "target_similarity": self.target_similarity,
+            "weighted_total": round(self.weighted_total, 6),
+            "dimensions_used": self.dimensions_used,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Primitive helpers
+# ---------------------------------------------------------------------------
+
+
+def _stat_sim(a: float, b: float) -> float:
+    """Normalised similarity between two non-negative scalars.
+
+    Formula: 1 - |a - b| / (max(a, b) + 1.0)
+    The +1.0 guard prevents division by zero when both values are 0 and
+    ensures the result stays in [0, 1].
+    """
+    return 1.0 - abs(a - b) / (max(a, b) + 1.0)
+
+
+def _cv_sim(a: float, b: float) -> float:
+    """Similarity for burst_cv values; differences > 1.0 saturate at 0."""
+    return 1.0 - min(abs(a - b), 1.0)
+
+
+def _levenshtein(a: list, b: list) -> int:
+    """Standard Levenshtein distance over arbitrary list elements."""
+    m, n = len(a), len(b)
+    if m == 0:
+        return n
+    if n == 0:
+        return m
+    dp = list(range(n + 1))
+    for i in range(1, m + 1):
+        prev = dp[0]
+        dp[0] = i
+        for j in range(1, n + 1):
+            temp = dp[j]
+            dp[j] = prev if a[i - 1] == b[j - 1] else 1 + min(prev, dp[j], dp[j - 1])
+            prev = temp
+    return dp[n]
+
+
+def _normalized_edit_sim(a: list, b: list) -> float:
+    """1 - edit_distance / max(len(a), len(b)).  Both empty → 1.0."""
+    if not a and not b:
+        return 1.0
+    return 1.0 - _levenshtein(a, b) / max(len(a), len(b))
+
+
+def _jaccard(a: set, b: set) -> float:
+    """Jaccard similarity |A∩B| / |A∪B|.  Both empty → 1.0."""
+    if not a and not b:
+        return 1.0
+    intersection = len(a & b)
+    union = len(a | b)
+    return intersection / union if union > 0 else 0.0
+
+
+def _kl_divergence(p: list[float], q: list[float]) -> float:
+    """KL(P||Q) in bits (log base 2).  0·log(0/q) = 0 by convention."""
+    total = 0.0
+    for pi, qi in zip(p, q, strict=False):
+        if pi > 0.0 and qi > 0.0:
+            total += pi * math.log2(pi / qi)
+    return total
+
+
+def _jsd(p: list[float], q: list[float]) -> float:
+    """Jensen-Shannon divergence in [0, 1] (log base 2).
+
+    Returns 1.0 (maximum divergence) when lengths differ or input is empty.
+    """
+    if len(p) != len(q) or not p:
+        return 1.0
+    m = [(a + b) / 2.0 for a, b in zip(p, q, strict=False)]
+    return (_kl_divergence(p, m) + _kl_divergence(q, m)) / 2.0
+
+
+def _histogram_sim(p: list[float] | None, q: list[float] | None) -> float | None:
+    """1 - JSD(p, q).  Returns None when either histogram is absent."""
+    if p is None or q is None or len(p) != len(q):
+        return None
+    return 1.0 - _jsd(p, q)
+
+
+def _dict_jaccard(a: dict[str, float], b: dict[str, float]) -> float:
+    """Jaccard similarity over the key sets of two frequency dicts."""
+    return _jaccard(set(a.keys()), set(b.keys()))
+
+
+# ---------------------------------------------------------------------------
+# Per-dimension similarity functions
+# ---------------------------------------------------------------------------
+
+
+def timing_similarity(
+    t1: dict[str, Any] | None,
+    t2: dict[str, Any] | None,
+) -> float | None:
+    """Similarity between two timing_features dicts (§8.1, Appendix).
+
+    Returns None when either input is None — null dimension, excluded from
+    the weighted total by the caller.
+
+    Sub-components averaged:
+      interval stats (mean, stddev, p25, p75, p95) → _stat_sim average
+      tod_histogram (24 floats)                     → 1 - JSD
+      dow_histogram (7 floats)                      → 1 - JSD
+      burst_cv (float)                              → _cv_sim
+    """
+    if t1 is None or t2 is None:
+        return None
+
+    scores: list[float] = []
+
+    i1 = t1.get("interval") or {}
+    i2 = t2.get("interval") or {}
+    if i1 and i2:
+        stat_sims = [
+            _stat_sim(float(i1.get(k, 0.0)), float(i2.get(k, 0.0)))
+            for k in ("mean", "stddev", "p25", "p75", "p95")
+        ]
+        scores.append(sum(stat_sims) / len(stat_sims))
+
+    tod_s = _histogram_sim(t1.get("tod_histogram"), t2.get("tod_histogram"))
+    if tod_s is not None:
+        scores.append(tod_s)
+
+    dow_s = _histogram_sim(t1.get("dow_histogram"), t2.get("dow_histogram"))
+    if dow_s is not None:
+        scores.append(dow_s)
+
+    cv1 = t1.get("burst_cv")
+    cv2 = t2.get("burst_cv")
+    if cv1 is not None and cv2 is not None:
+        scores.append(_cv_sim(float(cv1), float(cv2)))
+
+    if not scores:
+        return 0.0
+    return round(sum(scores) / len(scores), 6)
+
+
+def sequence_similarity(
+    s1: dict[str, Any] | None,
+    s2: dict[str, Any] | None,
+) -> float | None:
+    """Similarity between two sequence_features dicts (§8.1, Appendix).
+
+    Returns None when either input is None.
+
+    Sub-components averaged:
+      port_sequence       → normalised edit distance
+      event_type_sequence → normalised edit distance (capped at 50 entries)
+      credential_sequence → normalised edit distance over pattern tuples
+    """
+    if s1 is None or s2 is None:
+        return None
+
+    scores: list[float] = []
+
+    p1 = s1.get("port_sequence") or []
+    p2 = s2.get("port_sequence") or []
+    if p1 or p2:
+        scores.append(_normalized_edit_sim(p1, p2))
+
+    _MAX_ET = 50
+    et1 = (s1.get("event_type_sequence") or [])[:_MAX_ET]
+    et2 = (s2.get("event_type_sequence") or [])[:_MAX_ET]
+    if et1 or et2:
+        scores.append(_normalized_edit_sim(et1, et2))
+
+    cred1 = s1.get("credential_sequence") or []
+    cred2 = s2.get("credential_sequence") or []
+    if cred1 or cred2:
+        c1t = [(c.get("username_pattern", ""), c.get("password_class", "")) for c in cred1]
+        c2t = [(c.get("username_pattern", ""), c.get("password_class", "")) for c in cred2]
+        scores.append(_normalized_edit_sim(c1t, c2t))
+
+    if not scores:
+        return 0.0
+    return round(sum(scores) / len(scores), 6)
+
+
+def protocol_similarity(
+    p1: dict[str, Any] | None,
+    p2: dict[str, Any] | None,
+) -> float | None:
+    """Similarity between two protocol_features dicts (§8.1, Appendix).
+
+    Returns None when either input is None.
+
+    Sub-components averaged:
+      service_distribution → Jaccard on service key sets
+      ssh_kex_ordering     → normalised edit distance (when both present)
+      tls_cipher_ordering  → normalised edit distance (when both present)
+    """
+    if p1 is None or p2 is None:
+        return None
+
+    scores: list[float] = []
+
+    sd1 = p1.get("service_distribution") or {}
+    sd2 = p2.get("service_distribution") or {}
+    if sd1 or sd2:
+        scores.append(_dict_jaccard(sd1, sd2))
+
+    kex1 = p1.get("ssh_kex_ordering")
+    kex2 = p2.get("ssh_kex_ordering")
+    if kex1 is not None and kex2 is not None:
+        scores.append(_normalized_edit_sim(kex1, kex2))
+
+    tls1 = p1.get("tls_cipher_ordering")
+    tls2 = p2.get("tls_cipher_ordering")
+    if tls1 is not None and tls2 is not None:
+        scores.append(_normalized_edit_sim(tls1, tls2))
+
+    if not scores:
+        return 0.0
+    return round(sum(scores) / len(scores), 6)
+
+
+def credential_similarity(
+    c1: dict[str, Any] | None,
+    c2: dict[str, Any] | None,
+) -> float | None:
+    """Similarity between two credential_features dicts (§8.1, Appendix).
+
+    Returns None when either input is None.
+
+    Sub-components averaged:
+      username_class_dist  → Jaccard on class key sets
+      password_char_class  → _stat_sim average over shared ratio keys
+      credential_sequence  → normalised edit distance over pattern tuples
+    """
+    if c1 is None or c2 is None:
+        return None
+
+    scores: list[float] = []
+
+    ud1 = c1.get("username_class_dist") or {}
+    ud2 = c2.get("username_class_dist") or {}
+    if ud1 or ud2:
+        scores.append(_dict_jaccard(ud1, ud2))
+
+    pcc1 = c1.get("password_char_class") or {}
+    pcc2 = c2.get("password_char_class") or {}
+    shared = set(pcc1.keys()) & set(pcc2.keys())
+    if shared:
+        pcc_sims = [_stat_sim(float(pcc1[k]), float(pcc2[k])) for k in shared]
+        scores.append(sum(pcc_sims) / len(pcc_sims))
+
+    cred1 = c1.get("credential_sequence") or []
+    cred2 = c2.get("credential_sequence") or []
+    if cred1 or cred2:
+        c1t = [(c.get("username_pattern", ""), c.get("password_class", "")) for c in cred1]
+        c2t = [(c.get("username_pattern", ""), c.get("password_class", "")) for c in cred2]
+        scores.append(_normalized_edit_sim(c1t, c2t))
+
+    if not scores:
+        return 0.0
+    return round(sum(scores) / len(scores), 6)
+
+
+def target_similarity(
+    t1: dict[str, Any] | None,
+    t2: dict[str, Any] | None,
+) -> float | None:
+    """Similarity between two target_features dicts (§8.1, Appendix).
+
+    Returns None when either input is None.
+
+    Sub-components averaged:
+      port_freq     → Jaccard on top-10 port key sets (Appendix)
+      top_dst_ports → normalised edit distance on ordered list
+    """
+    if t1 is None or t2 is None:
+        return None
+
+    scores: list[float] = []
+
+    pf1 = t1.get("port_freq") or {}
+    pf2 = t2.get("port_freq") or {}
+    if pf1 or pf2:
+        top10_1 = set(sorted(pf1, key=lambda k: pf1[k], reverse=True)[:10])
+        top10_2 = set(sorted(pf2, key=lambda k: pf2[k], reverse=True)[:10])
+        scores.append(_jaccard(top10_1, top10_2))
+
+    td1 = t1.get("top_dst_ports") or []
+    td2 = t2.get("top_dst_ports") or []
+    if td1 or td2:
+        scores.append(_normalized_edit_sim(td1, td2))
+
+    if not scores:
+        return 0.0
+    return round(sum(scores) / len(scores), 6)
+
+
+# ---------------------------------------------------------------------------
+# Weighted aggregation
+# ---------------------------------------------------------------------------
+
+
+def compute_weighted_similarity(
+    fp1: dict[str, Any],
+    fp2: dict[str, Any],
+) -> SimilarityResult:
+    """Weighted fingerprint similarity per §8.1 and §3.2.
+
+    fp1 and fp2 are behavioral_fingerprint dicts whose feature columns are
+    stored JSON strings (or None).  Parsing happens here.
+
+    Null dimensions contribute zero to both numerator and denominator so that
+    sparse fingerprints are not artificially penalised (§8.1).
+
+    Infrastructure features (ASN, geography) are intentionally absent from
+    the similarity computation per §12.4.
+    """
+
+    def _parse(s: str | None) -> dict | None:
+        if s is None:
+            return None
+        try:
+            v = json.loads(s)
+            return v if isinstance(v, dict) else None
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    ts = timing_similarity(_parse(fp1.get("timing_features")), _parse(fp2.get("timing_features")))
+    ss = sequence_similarity(
+        _parse(fp1.get("sequence_features")), _parse(fp2.get("sequence_features"))
+    )
+    ps = protocol_similarity(
+        _parse(fp1.get("protocol_features")), _parse(fp2.get("protocol_features"))
+    )
+    cs = credential_similarity(
+        _parse(fp1.get("credential_features")), _parse(fp2.get("credential_features"))
+    )
+    tgs = target_similarity(_parse(fp1.get("target_features")), _parse(fp2.get("target_features")))
+
+    _WEIGHTS: dict[str, tuple[float | None, float]] = {
+        "timing": (ts, WEIGHT_TIMING),
+        "sequence": (ss, WEIGHT_SEQUENCE),
+        "protocol": (ps, WEIGHT_PROTOCOL),
+        "credential": (cs, WEIGHT_CREDENTIAL),
+        "target": (tgs, WEIGHT_TARGET),
+    }
+
+    numerator = 0.0
+    denominator = 0.0
+    dimensions_used = 0
+    for _dim, (sim, weight) in _WEIGHTS.items():
+        if sim is not None:
+            numerator += weight * sim
+            denominator += weight
+            dimensions_used += 1
+
+    weighted_total = numerator / denominator if denominator > 0.0 else 0.0
+
+    return SimilarityResult(
+        timing_similarity=ts,
+        sequence_similarity=ss,
+        protocol_similarity=ps,
+        credential_similarity=cs,
+        target_similarity=tgs,
+        weighted_total=round(weighted_total, 6),
+        dimensions_used=dimensions_used,
+    )

--- a/app/intelligence/tasks.py
+++ b/app/intelligence/tasks.py
@@ -65,11 +65,19 @@ def _run_fingerprint_task(ip: str) -> None:
 
 
 def _compute_and_store(ip: str) -> None:
-    """Fetch events, compute fingerprint, write to behavioral_fingerprints."""
+    """Fetch events, compute fingerprint, write to behavioral_fingerprints.
+
+    After a successful fingerprint commit, triggers campaign clustering when
+    the fingerprint meets the minimum confidence threshold (§12.6).  The
+    fingerprint session commits before clustering — a clustering failure
+    cannot roll back the stored fingerprint.
+    """
     from app.db.connection import get_session
     from app.db.repository import EventRepository
     from app.intelligence.constants import FINGERPRINT_VERSION
     from app.intelligence.fingerprint import build_fingerprint
+
+    fp_confidence: float = 0.0
 
     with get_session() as session:
         repo = EventRepository(session)
@@ -90,3 +98,31 @@ def _compute_and_store(ip: str) -> None:
             tool_signals=fp["tool_signals"],
             confidence=fp["confidence"],
         )
+        fp_confidence = fp["confidence"]
+    # Fingerprint committed above.
+
+    # Campaign clustering runs in a separate session so a clustering failure
+    # cannot roll back the already-committed fingerprint (§12.6).
+    if fp_confidence >= 0.20:
+        _run_campaign_clustering(ip)
+
+
+def _run_campaign_clustering(ip: str) -> None:
+    """Run campaign assignment for ip in a fresh session.
+
+    Failures are logged but do not propagate — a clustering failure must
+    never surface as a fingerprint-computation error (§3.3 / §11).
+    """
+    try:
+        from app.db.connection import get_session
+        from app.db.repository import EventRepository
+        from app.intelligence.clustering import assign_to_campaign
+
+        with get_session() as session:
+            repo = EventRepository(session)
+            stored_fp = repo.get_behavioral_fingerprint(ip)
+            if stored_fp is None:
+                return
+            assign_to_campaign(ip, stored_fp, repo)
+    except Exception:
+        logger.exception("Campaign clustering failed for ip=%s", ip)

--- a/tests/db/test_campaign_clustering.py
+++ b/tests/db/test_campaign_clustering.py
@@ -1,0 +1,716 @@
+"""Integration tests for the campaign clustering algorithm.
+
+Uses the db_session fixture for isolated in-memory SQLite.
+Exercises assign_to_campaign() with real DB state — no mocks.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.db.repository import EventRepository
+from app.intelligence.clustering import (
+    DECISION_AUTO_ASSOCIATION,
+    DECISION_EXISTING_MEMBER,
+    DECISION_NEW_CAMPAIGN,
+    DECISION_SKIPPED_SPARSE,
+    DECISION_UNCERTAIN_ASSOCIATION,
+    assign_to_campaign,
+)
+from app.intelligence.constants import (
+    SIMILARITY_AUTO_THRESHOLD,
+)
+
+_NOW = datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC)
+_TS_STR = _NOW.isoformat()
+
+_IP_NEW = "192.168.1.100"
+_IP_EXISTING = "192.168.1.200"
+_IP_CAMPAIGN = "192.168.1.1"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_ip(session, ip: str) -> None:
+    EventRepository(session).upsert_source_ip(ip, _NOW)
+    session.flush()
+
+
+def _make_fp_dict(
+    ip: str = _IP_NEW,
+    confidence: float = 0.6,
+    event_count: int = 20,
+    sequence_features: dict | None = None,
+    target_features: dict | None = None,
+    timing_features: dict | None = None,
+) -> dict:
+    """Build a fingerprint dict as returned by get_behavioral_fingerprint()."""
+
+    def _enc(d):
+        return json.dumps(d, separators=(",", ":")) if d is not None else None
+
+    default_sequence = {
+        "port_sequence": [22, 80],
+        "event_type_sequence": ["auth_failed"] * 10,
+        "credential_sequence": [],
+    }
+    default_target = {
+        "port_freq": {"22": 0.9, "80": 0.1},
+        "top_dst_ports": [22, 80],
+    }
+
+    return {
+        "id": str(uuid.uuid4()),
+        "source_ip": ip,
+        "fingerprint_version": 1,
+        "computed_at": _TS_STR,
+        "event_count_at_computation": event_count,
+        "timing_features": _enc(timing_features),
+        "sequence_features": _enc(sequence_features or default_sequence),
+        "protocol_features": None,
+        "credential_features": None,
+        "target_features": _enc(target_features or default_target),
+        "tool_signals": None,
+        "confidence": confidence,
+    }
+
+
+def _store_fp(session, ip: str, fp_dict: dict) -> None:
+    """Insert ip and store the fingerprint directly via upsert."""
+    EventRepository(session).upsert_behavioral_fingerprint(
+        ip=ip,
+        fingerprint_version=fp_dict["fingerprint_version"],
+        computed_at=fp_dict["computed_at"],
+        event_count=fp_dict["event_count_at_computation"],
+        timing_features=fp_dict["timing_features"],
+        sequence_features=fp_dict["sequence_features"],
+        protocol_features=fp_dict["protocol_features"],
+        credential_features=fp_dict["credential_features"],
+        target_features=fp_dict["target_features"],
+        tool_signals=fp_dict["tool_signals"],
+        confidence=fp_dict["confidence"],
+    )
+    session.flush()
+
+
+def _create_campaign_with_member(
+    session,
+    member_ip: str,
+    status: str = "active",
+    last_seen: str | None = None,
+    fp_override: dict | None = None,
+) -> str:
+    """Create a campaign with one member IP and a stored fingerprint.  Returns campaign_id."""
+    _insert_ip(session, member_ip)
+    fp = fp_override or _make_fp_dict(ip=member_ip, confidence=0.7)
+    _store_fp(session, member_ip, fp)
+
+    repo = EventRepository(session)
+    cid = str(uuid.uuid4())
+    ls = last_seen or _TS_STR
+    repo.create_campaign(
+        campaign_id=cid,
+        name="SETUP-WOLF-1",
+        status=status,
+        confidence=0.7,
+        first_seen=_TS_STR,
+        last_seen=ls,
+        member_ip_count=1,
+        created_at=_TS_STR,
+        updated_at=_TS_STR,
+    )
+    repo.add_campaign_member(cid, member_ip, 0.7, _TS_STR, _TS_STR)
+    session.flush()
+    return cid
+
+
+# ---------------------------------------------------------------------------
+# Gate: sparse fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_sparse_fingerprint_is_skipped(db_session):
+    _insert_ip(db_session, _IP_NEW)
+    fp = _make_fp_dict(ip=_IP_NEW, confidence=0.10, event_count=5)
+    repo = EventRepository(db_session)
+    decision = assign_to_campaign(_IP_NEW, fp, repo, now=_NOW)
+    assert decision.decision == DECISION_SKIPPED_SPARSE
+    assert decision.campaign_id is None
+    assert decision.similarity is None
+
+
+def test_sparse_fingerprint_creates_no_campaign(db_session):
+    _insert_ip(db_session, _IP_NEW)
+    fp = _make_fp_dict(ip=_IP_NEW, confidence=0.05)
+    assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+    count = db_session.execute(
+        __import__("sqlalchemy").text("SELECT COUNT(*) FROM campaigns")
+    ).fetchone()[0]
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# New campaign creation
+# ---------------------------------------------------------------------------
+
+
+def test_no_candidates_creates_new_campaign(db_session):
+    _insert_ip(db_session, _IP_NEW)
+    fp = _make_fp_dict(ip=_IP_NEW, confidence=0.6)
+    repo = EventRepository(db_session)
+    decision = assign_to_campaign(_IP_NEW, fp, repo, now=_NOW)
+    assert decision.decision == DECISION_NEW_CAMPAIGN
+    assert decision.campaign_id is not None
+    assert decision.similarity is None
+
+
+def test_new_campaign_stored_in_db(db_session):
+    _insert_ip(db_session, _IP_NEW)
+    fp = _make_fp_dict(ip=_IP_NEW, confidence=0.6)
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    campaign = EventRepository(db_session).get_campaign(decision.campaign_id)
+    assert campaign is not None
+    assert campaign["status"] == "active"
+    assert campaign["member_ip_count"] == 1
+
+
+def test_new_campaign_member_stored(db_session):
+    _insert_ip(db_session, _IP_NEW)
+    fp = _make_fp_dict(ip=_IP_NEW, confidence=0.6)
+    assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    member = EventRepository(db_session).get_campaign_member_by_ip(_IP_NEW)
+    assert member is not None
+
+
+def test_new_campaign_observation_stored(db_session):
+    _insert_ip(db_session, _IP_NEW)
+    fp = _make_fp_dict(ip=_IP_NEW, confidence=0.6)
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    obs = EventRepository(db_session).get_campaign_observations(decision.campaign_id)
+    assert len(obs) == 1
+    assert obs[0]["is_reactivation"] is False
+
+
+def test_new_campaign_name_is_non_empty(db_session):
+    _insert_ip(db_session, _IP_NEW)
+    fp = _make_fp_dict(ip=_IP_NEW, confidence=0.6)
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    campaign = EventRepository(db_session).get_campaign(decision.campaign_id)
+    assert isinstance(campaign["name"], str)
+    assert len(campaign["name"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Automatic association (score >= 0.80)
+# ---------------------------------------------------------------------------
+
+
+def _identical_fp(ip: str) -> dict:
+    """Two fingerprints with this dict will score ~1.0 similarity."""
+    return _make_fp_dict(
+        ip=ip,
+        confidence=0.7,
+        sequence_features={
+            "port_sequence": [22, 80, 443],
+            "event_type_sequence": ["auth_failed"] * 15,
+            "credential_sequence": [],
+        },
+        target_features={
+            "port_freq": {"22": 0.8, "80": 0.1, "443": 0.1},
+            "top_dst_ports": [22, 80, 443],
+        },
+    )
+
+
+def test_identical_fp_auto_associates(db_session):
+    cid = _create_campaign_with_member(
+        db_session, _IP_CAMPAIGN, fp_override=_identical_fp(_IP_CAMPAIGN)
+    )
+    _insert_ip(db_session, _IP_NEW)
+    fp = _identical_fp(_IP_NEW)
+    _store_fp(db_session, _IP_NEW, fp)
+
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    assert decision.decision == DECISION_AUTO_ASSOCIATION
+    assert decision.campaign_id == cid
+
+
+def test_auto_association_stored_in_db(db_session):
+    cid = _create_campaign_with_member(
+        db_session, _IP_CAMPAIGN, fp_override=_identical_fp(_IP_CAMPAIGN)
+    )
+    _insert_ip(db_session, _IP_NEW)
+    fp = _identical_fp(_IP_NEW)
+    _store_fp(db_session, _IP_NEW, fp)
+
+    assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    member = EventRepository(db_session).get_campaign_member_by_ip(_IP_NEW)
+    assert member is not None
+    assert member["campaign_id"] == cid
+
+
+def test_auto_association_increments_member_count(db_session):
+    cid = _create_campaign_with_member(
+        db_session, _IP_CAMPAIGN, fp_override=_identical_fp(_IP_CAMPAIGN)
+    )
+    _insert_ip(db_session, _IP_NEW)
+    fp = _identical_fp(_IP_NEW)
+    _store_fp(db_session, _IP_NEW, fp)
+
+    assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    campaign = EventRepository(db_session).get_campaign(cid)
+    assert campaign["member_ip_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Uncertain association (0.60 <= score < 0.80)
+# ---------------------------------------------------------------------------
+
+
+def _different_fp(ip: str) -> dict:
+    """Fingerprint with different ports — will produce moderate similarity."""
+    return _make_fp_dict(
+        ip=ip,
+        confidence=0.7,
+        sequence_features={
+            "port_sequence": [22, 443, 8080],
+            "event_type_sequence": ["auth_failed"] * 10,
+            "credential_sequence": [],
+        },
+        target_features={
+            "port_freq": {"22": 0.5, "443": 0.3, "8080": 0.2},
+            "top_dst_ports": [22, 443, 8080],
+        },
+    )
+
+
+def test_uncertain_range_produces_uncertain_association(db_session):
+    """Fingerprints that share most but not all ports produce a score in
+    [0.60, 0.80), triggering uncertain_association rather than auto_association.
+
+    Scenario:
+      campaign port_sequence = [22, 80, 443]  event_types = [auth_failed]*10
+      new      port_sequence = [22, 80, 3389] event_types = [auth_failed]*10
+      sequence sim ≈ (0.667 + 1.0) / 2 = 0.833
+      target sim   ≈ (Jaccard_0.5 + edit_0.667) / 2 = 0.583
+      weighted (seq 0.35, tgt 0.10) ≈ 0.778  → uncertain
+    """
+    campaign_fp = _make_fp_dict(
+        ip=_IP_CAMPAIGN,
+        confidence=0.7,
+        sequence_features={
+            "port_sequence": [22, 80, 443],
+            "event_type_sequence": ["auth_failed"] * 10,
+            "credential_sequence": [],
+        },
+        target_features={
+            "port_freq": {"22": 0.6, "80": 0.3, "443": 0.1},
+            "top_dst_ports": [22, 80, 443],
+        },
+    )
+    cid = _create_campaign_with_member(db_session, _IP_CAMPAIGN, fp_override=campaign_fp)
+
+    new_fp = _make_fp_dict(
+        ip=_IP_NEW,
+        confidence=0.7,
+        sequence_features={
+            "port_sequence": [22, 80, 3389],
+            "event_type_sequence": ["auth_failed"] * 10,
+            "credential_sequence": [],
+        },
+        target_features={
+            "port_freq": {"22": 0.6, "80": 0.3, "3389": 0.1},
+            "top_dst_ports": [22, 80, 3389],
+        },
+    )
+    _insert_ip(db_session, _IP_NEW)
+    _store_fp(db_session, _IP_NEW, new_fp)
+
+    decision = assign_to_campaign(_IP_NEW, new_fp, EventRepository(db_session), now=_NOW)
+
+    # Expected score ≈ 0.778 (uncertain range).  Accept auto too in case of
+    # floating-point edge, but must be an association, not a new campaign.
+    assert decision.decision in (DECISION_AUTO_ASSOCIATION, DECISION_UNCERTAIN_ASSOCIATION)
+    assert decision.campaign_id == cid
+
+
+def test_below_uncertain_threshold_creates_new_campaign(db_session):
+    """Fingerprints with completely disjoint ports should not associate."""
+    campaign_fp = _make_fp_dict(
+        ip=_IP_CAMPAIGN,
+        confidence=0.7,
+        sequence_features={
+            "port_sequence": [22, 23, 25],
+            "event_type_sequence": ["auth_failed"] * 10,
+            "credential_sequence": [],
+        },
+        target_features={
+            "port_freq": {"22": 0.6, "23": 0.3, "25": 0.1},
+            "top_dst_ports": [22, 23, 25],
+        },
+    )
+    _create_campaign_with_member(db_session, _IP_CAMPAIGN, fp_override=campaign_fp)
+
+    # New fingerprint targets entirely different ports
+    new_fp = _make_fp_dict(
+        ip=_IP_NEW,
+        confidence=0.7,
+        sequence_features={
+            "port_sequence": [8080, 8443, 9000, 9200, 9300],
+            "event_type_sequence": ["http_probe"] * 10,
+            "credential_sequence": [],
+        },
+        target_features={
+            "port_freq": {"8080": 0.4, "8443": 0.3, "9000": 0.2, "9200": 0.1},
+            "top_dst_ports": [8080, 8443, 9000, 9200],
+        },
+    )
+    _insert_ip(db_session, _IP_NEW)
+    _store_fp(db_session, _IP_NEW, new_fp)
+
+    decision = assign_to_campaign(_IP_NEW, new_fp, EventRepository(db_session), now=_NOW)
+    assert decision.decision == DECISION_NEW_CAMPAIGN
+
+
+# ---------------------------------------------------------------------------
+# Existing member
+# ---------------------------------------------------------------------------
+
+
+def test_existing_member_returns_existing_decision(db_session):
+    # _create_campaign_with_member already inserts _IP_EXISTING as the member.
+    cid = _create_campaign_with_member(db_session, _IP_EXISTING)
+    fp = _make_fp_dict(ip=_IP_EXISTING, confidence=0.7)
+    decision = assign_to_campaign(_IP_EXISTING, fp, EventRepository(db_session), now=_NOW)
+    assert decision.decision == DECISION_EXISTING_MEMBER
+    assert decision.campaign_id == cid
+
+
+def test_existing_member_inserts_observation(db_session):
+    # _create_campaign_with_member already inserts _IP_EXISTING as the member.
+    cid = _create_campaign_with_member(db_session, _IP_EXISTING)
+    fp = _make_fp_dict(ip=_IP_EXISTING, confidence=0.7)
+    assign_to_campaign(_IP_EXISTING, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    obs = EventRepository(db_session).get_campaign_observations(cid)
+    assert any(o["source_ip"] == _IP_EXISTING for o in obs)
+
+
+# ---------------------------------------------------------------------------
+# Dormant campaign reactivation
+# ---------------------------------------------------------------------------
+
+
+def test_dormant_campaign_association_is_reactivation(db_session):
+    # Campaign was last seen 30 days ago → dormant
+    thirty_days_ago = (_NOW - timedelta(days=30)).isoformat()
+    cid = _create_campaign_with_member(
+        db_session,
+        _IP_CAMPAIGN,
+        status="dormant",
+        last_seen=thirty_days_ago,
+        fp_override=_identical_fp(_IP_CAMPAIGN),
+    )
+
+    _insert_ip(db_session, _IP_NEW)
+    fp = _identical_fp(_IP_NEW)
+    _store_fp(db_session, _IP_NEW, fp)
+
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+
+    assert decision.campaign_id == cid
+    assert decision.is_reactivation is True
+    assert decision.dormancy_gap_days is not None
+    assert decision.dormancy_gap_days >= 29.0
+
+
+def test_dormant_campaign_reactivation_updates_status(db_session):
+    thirty_days_ago = (_NOW - timedelta(days=30)).isoformat()
+    cid = _create_campaign_with_member(
+        db_session,
+        _IP_CAMPAIGN,
+        status="dormant",
+        last_seen=thirty_days_ago,
+        fp_override=_identical_fp(_IP_CAMPAIGN),
+    )
+
+    _insert_ip(db_session, _IP_NEW)
+    fp = _identical_fp(_IP_NEW)
+    _store_fp(db_session, _IP_NEW, fp)
+
+    assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    campaign = EventRepository(db_session).get_campaign(cid)
+    assert campaign["status"] == "reactivated"
+    assert campaign["reactivation_count"] == 1
+    assert campaign["dormant_since"] is None
+
+
+def test_reactivation_observation_has_is_reactivation_flag(db_session):
+    thirty_days_ago = (_NOW - timedelta(days=30)).isoformat()
+    cid = _create_campaign_with_member(
+        db_session,
+        _IP_CAMPAIGN,
+        status="dormant",
+        last_seen=thirty_days_ago,
+        fp_override=_identical_fp(_IP_CAMPAIGN),
+    )
+
+    _insert_ip(db_session, _IP_NEW)
+    fp = _identical_fp(_IP_NEW)
+    _store_fp(db_session, _IP_NEW, fp)
+
+    assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    obs = EventRepository(db_session).get_campaign_observations(cid)
+    reactivation_obs = [o for o in obs if o["is_reactivation"]]
+    assert len(reactivation_obs) == 1
+    assert reactivation_obs[0]["dormancy_gap_days"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Temporal threshold bumps (§12.3)
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_12m_threshold_bump_prevents_auto_at_085(db_session):
+    """Score of 0.85 against a 13-month-old campaign should NOT auto-associate
+    because the temporal bump raises the auto threshold to 0.90."""
+    thirteen_months_ago = (_NOW - timedelta(days=400)).isoformat()
+    _create_campaign_with_member(
+        db_session,
+        _IP_CAMPAIGN,
+        status="dormant",
+        last_seen=thirteen_months_ago,
+        fp_override=_identical_fp(_IP_CAMPAIGN),
+    )
+
+    _insert_ip(db_session, _IP_NEW)
+    # Use a fingerprint that scores ~0.85–0.89 against the identical fp above.
+    # Achieve this by having partially matching ports.
+    fp = _make_fp_dict(
+        ip=_IP_NEW,
+        confidence=0.7,
+        sequence_features={
+            "port_sequence": [22, 80, 443, 8080],  # 1 extra port → edit distance
+            "event_type_sequence": ["auth_failed"] * 15,
+            "credential_sequence": [],
+        },
+        target_features={
+            "port_freq": {"22": 0.7, "80": 0.1, "443": 0.1, "8080": 0.1},
+            "top_dst_ports": [22, 80, 443, 8080],
+        },
+    )
+    _store_fp(db_session, _IP_NEW, fp)
+
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+
+    # Can be auto (if score >= 0.90), uncertain (if 0.60 <= score < 0.90), or
+    # new campaign (if score < 0.60).  The key invariant: with a 13-month gap,
+    # a score in [0.85, 0.89] must NOT produce auto_association.
+    if decision.similarity is not None:
+        score = decision.similarity.weighted_total
+        if 0.85 <= score < 0.90:
+            assert (
+                decision.decision != DECISION_AUTO_ASSOCIATION
+            ), f"Score {score:.4f} should be uncertain with 13-month gap, not auto"
+
+
+def test_temporal_6m_threshold_bump_prevents_auto_at_082(db_session):
+    """Score of 0.82 against a 7-month-old campaign should NOT auto-associate
+    because the 6-12-month bump raises the auto threshold to 0.85."""
+    seven_months_ago = (_NOW - timedelta(days=210)).isoformat()
+    _create_campaign_with_member(
+        db_session,
+        _IP_CAMPAIGN,
+        status="dormant",
+        last_seen=seven_months_ago,
+        fp_override=_identical_fp(_IP_CAMPAIGN),
+    )
+
+    _insert_ip(db_session, _IP_NEW)
+    fp = _make_fp_dict(
+        ip=_IP_NEW,
+        confidence=0.7,
+        sequence_features={
+            "port_sequence": [22, 80, 443, 8080, 3389],
+            "event_type_sequence": ["auth_failed"] * 15,
+            "credential_sequence": [],
+        },
+        target_features={
+            "port_freq": {"22": 0.6, "80": 0.1, "443": 0.1, "8080": 0.1, "3389": 0.1},
+            "top_dst_ports": [22, 80, 443, 8080, 3389],
+        },
+    )
+    _store_fp(db_session, _IP_NEW, fp)
+
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+
+    if decision.similarity is not None:
+        score = decision.similarity.weighted_total
+        if 0.82 <= score < 0.85:
+            assert (
+                decision.decision != DECISION_AUTO_ASSOCIATION
+            ), f"Score {score:.4f} should be uncertain with 7-month gap, not auto"
+
+
+def test_recent_campaign_uses_standard_threshold(db_session):
+    """A campaign last seen 3 days ago should use the standard 0.80 threshold."""
+    three_days_ago = (_NOW - timedelta(days=3)).isoformat()
+    cid = _create_campaign_with_member(
+        db_session,
+        _IP_CAMPAIGN,
+        status="active",
+        last_seen=three_days_ago,
+        fp_override=_identical_fp(_IP_CAMPAIGN),
+    )
+
+    _insert_ip(db_session, _IP_NEW)
+    fp = _identical_fp(_IP_NEW)
+    _store_fp(db_session, _IP_NEW, fp)
+
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    # Identical fps against a recent campaign → should auto-associate
+    assert decision.decision == DECISION_AUTO_ASSOCIATION
+    assert decision.campaign_id == cid
+    assert decision.threshold_applied == pytest.approx(SIMILARITY_AUTO_THRESHOLD)
+
+
+# ---------------------------------------------------------------------------
+# Explainability
+# ---------------------------------------------------------------------------
+
+
+def test_decision_has_non_empty_reason(db_session):
+    _insert_ip(db_session, _IP_NEW)
+    fp = _make_fp_dict(ip=_IP_NEW, confidence=0.6)
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    assert isinstance(decision.reason, str)
+    assert len(decision.reason) > 0
+
+
+def test_association_stores_explanation_in_observation_notes(db_session):
+    cid = _create_campaign_with_member(
+        db_session, _IP_CAMPAIGN, fp_override=_identical_fp(_IP_CAMPAIGN)
+    )
+    _insert_ip(db_session, _IP_NEW)
+    fp = _identical_fp(_IP_NEW)
+    _store_fp(db_session, _IP_NEW, fp)
+
+    assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    obs = EventRepository(db_session).get_campaign_observations(cid)
+    association_obs = [o for o in obs if o["source_ip"] == _IP_NEW]
+    assert len(association_obs) == 1
+
+    notes_str = association_obs[0]["notes"]
+    assert notes_str is not None
+    notes = json.loads(notes_str)
+    assert "weighted_total" in notes
+    assert "threshold_applied" in notes
+    assert "decision" in notes
+
+
+def test_explanation_object_has_all_similarity_fields(db_session):
+    cid = _create_campaign_with_member(
+        db_session, _IP_CAMPAIGN, fp_override=_identical_fp(_IP_CAMPAIGN)
+    )
+    _insert_ip(db_session, _IP_NEW)
+    fp = _identical_fp(_IP_NEW)
+    _store_fp(db_session, _IP_NEW, fp)
+
+    assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    obs = EventRepository(db_session).get_campaign_observations(cid)
+    notes = json.loads(obs[-1]["notes"])
+    for field in (
+        "timing_similarity",
+        "sequence_similarity",
+        "protocol_similarity",
+        "credential_similarity",
+        "target_similarity",
+        "weighted_total",
+        "dimensions_used",
+        "threshold_applied",
+        "decision",
+    ):
+        assert field in notes, f"Missing field {field!r} in explanation"
+
+
+def test_new_campaign_observation_has_no_notes(db_session):
+    """New campaign observations don't carry an explanation (no comparison was made)."""
+    _insert_ip(db_session, _IP_NEW)
+    fp = _make_fp_dict(ip=_IP_NEW, confidence=0.6)
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    obs = EventRepository(db_session).get_campaign_observations(decision.campaign_id)
+    assert obs[0]["notes"] is None
+
+
+def test_similarity_result_present_on_association(db_session):
+    _create_campaign_with_member(db_session, _IP_CAMPAIGN, fp_override=_identical_fp(_IP_CAMPAIGN))
+    _insert_ip(db_session, _IP_NEW)
+    fp = _identical_fp(_IP_NEW)
+    _store_fp(db_session, _IP_NEW, fp)
+
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    assert decision.similarity is not None
+    assert 0.0 <= decision.similarity.weighted_total <= 1.0
+
+
+def test_similarity_result_none_on_new_campaign(db_session):
+    _insert_ip(db_session, _IP_NEW)
+    fp = _make_fp_dict(ip=_IP_NEW, confidence=0.6)
+    decision = assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    assert decision.similarity is None
+
+
+# ---------------------------------------------------------------------------
+# Privacy: no raw IPs in stored notes
+# ---------------------------------------------------------------------------
+
+
+def test_observation_notes_contain_no_raw_ips(db_session):
+    """The JSON explanation stored in campaign_observations.notes must not
+    contain any raw IP address strings."""
+    cid = _create_campaign_with_member(
+        db_session, _IP_CAMPAIGN, fp_override=_identical_fp(_IP_CAMPAIGN)
+    )
+    _insert_ip(db_session, _IP_NEW)
+    fp = _identical_fp(_IP_NEW)
+    _store_fp(db_session, _IP_NEW, fp)
+
+    assign_to_campaign(_IP_NEW, fp, EventRepository(db_session), now=_NOW)
+    db_session.flush()
+
+    obs = EventRepository(db_session).get_campaign_observations(cid)
+    for o in obs:
+        if o["notes"]:
+            assert _IP_NEW not in o["notes"], "Raw IP found in observation notes"
+            assert _IP_CAMPAIGN not in o["notes"], "Raw IP found in observation notes"

--- a/tests/db/test_campaign_repository.py
+++ b/tests/db/test_campaign_repository.py
@@ -1,0 +1,433 @@
+"""Repository tests for CampaignRepository methods.
+
+Uses the db_session fixture from tests/db/conftest.py for an isolated
+in-memory SQLite database per test.  No HTTP, no application startup.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+
+from app.db.repository import EventRepository
+
+_IP = "10.0.0.1"
+_IP2 = "10.0.0.2"
+_TS = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+_TS_STR = _TS.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_source_ip(session, ip: str = _IP, ts: datetime = _TS) -> None:
+    EventRepository(session).upsert_source_ip(ip, ts)
+    session.flush()
+
+
+def _insert_fingerprint(
+    session,
+    ip: str = _IP,
+    confidence: float = 0.5,
+    timing_features: str | None = None,
+    sequence_features: str | None = None,
+    target_features: str | None = None,
+) -> None:
+    EventRepository(session).upsert_behavioral_fingerprint(
+        ip=ip,
+        fingerprint_version=1,
+        computed_at=_TS_STR,
+        event_count=20,
+        timing_features=timing_features,
+        sequence_features=sequence_features,
+        protocol_features=None,
+        credential_features=None,
+        target_features=target_features,
+        tool_signals=None,
+        confidence=confidence,
+    )
+    session.flush()
+
+
+def _insert_campaign(
+    session,
+    campaign_id: str | None = None,
+    status: str = "active",
+    last_seen: str = _TS_STR,
+) -> str:
+    cid = campaign_id or str(uuid.uuid4())
+    EventRepository(session).create_campaign(
+        campaign_id=cid,
+        name="TEST-WOLF-1",
+        status=status,
+        confidence=0.7,
+        first_seen=_TS_STR,
+        last_seen=last_seen,
+        member_ip_count=0,
+        created_at=_TS_STR,
+        updated_at=_TS_STR,
+    )
+    session.flush()
+    return cid
+
+
+# ---------------------------------------------------------------------------
+# create_campaign / get_campaign
+# ---------------------------------------------------------------------------
+
+
+def test_create_campaign_row_exists(db_session):
+    cid = _insert_campaign(db_session)
+    row = db_session.execute(
+        text("SELECT id, name, status FROM campaigns WHERE id = :id"), {"id": cid}
+    ).fetchone()
+    assert row is not None
+    assert row[0] == cid
+    assert row[1] == "TEST-WOLF-1"
+    assert row[2] == "active"
+
+
+def test_get_campaign_returns_dict(db_session):
+    cid = _insert_campaign(db_session)
+    campaign = EventRepository(db_session).get_campaign(cid)
+    assert campaign is not None
+    assert isinstance(campaign, dict)
+    assert campaign["id"] == cid
+
+
+def test_get_campaign_unknown_returns_none(db_session):
+    assert EventRepository(db_session).get_campaign(str(uuid.uuid4())) is None
+
+
+def test_get_campaign_returned_keys(db_session):
+    cid = _insert_campaign(db_session)
+    campaign = EventRepository(db_session).get_campaign(cid)
+    assert set(campaign.keys()) == {
+        "id",
+        "name",
+        "status",
+        "confidence",
+        "first_seen",
+        "last_seen",
+        "dormant_since",
+        "reactivation_count",
+        "member_ip_count",
+        "attack_tactic_dist",
+        "top_target_ports",
+        "notes",
+        "created_at",
+        "updated_at",
+    }
+
+
+# ---------------------------------------------------------------------------
+# add_campaign_member / get_campaign_member_by_ip
+# ---------------------------------------------------------------------------
+
+
+def test_add_campaign_member_row_exists(db_session):
+    _insert_source_ip(db_session)
+    cid = _insert_campaign(db_session)
+    EventRepository(db_session).add_campaign_member(
+        campaign_id=cid,
+        source_ip=_IP,
+        confidence=0.85,
+        added_at=_TS_STR,
+        last_active=_TS_STR,
+    )
+    db_session.flush()
+    row = db_session.execute(
+        text("SELECT campaign_id, source_ip FROM campaign_members WHERE source_ip = :ip"),
+        {"ip": _IP},
+    ).fetchone()
+    assert row is not None
+    assert row[0] == cid
+    assert row[1] == _IP
+
+
+def test_get_campaign_member_by_ip_returns_dict(db_session):
+    _insert_source_ip(db_session)
+    cid = _insert_campaign(db_session)
+    repo = EventRepository(db_session)
+    repo.add_campaign_member(cid, _IP, 0.85, _TS_STR, _TS_STR)
+    db_session.flush()
+    member = repo.get_campaign_member_by_ip(_IP)
+    assert member is not None
+    assert member["campaign_id"] == cid
+    assert member["source_ip"] == _IP
+
+
+def test_get_campaign_member_by_ip_unknown_returns_none(db_session):
+    assert EventRepository(db_session).get_campaign_member_by_ip("1.2.3.4") is None
+
+
+def test_get_campaign_member_confidence_stored(db_session):
+    _insert_source_ip(db_session)
+    cid = _insert_campaign(db_session)
+    repo = EventRepository(db_session)
+    repo.add_campaign_member(cid, _IP, 0.72, _TS_STR, _TS_STR)
+    db_session.flush()
+    member = repo.get_campaign_member_by_ip(_IP)
+    assert abs(member["confidence"] - 0.72) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# update_campaign_member_last_active
+# ---------------------------------------------------------------------------
+
+
+def test_update_campaign_member_last_active(db_session):
+    _insert_source_ip(db_session)
+    cid = _insert_campaign(db_session)
+    repo = EventRepository(db_session)
+    repo.add_campaign_member(cid, _IP, 0.7, _TS_STR, _TS_STR)
+    db_session.flush()
+
+    new_ts = "2025-06-02T12:00:00+00:00"
+    repo.update_campaign_member_last_active(cid, _IP, new_ts)
+    db_session.flush()
+
+    row = db_session.execute(
+        text(
+            "SELECT last_active FROM campaign_members WHERE campaign_id = :cid AND source_ip = :ip"
+        ),
+        {"cid": cid, "ip": _IP},
+    ).fetchone()
+    assert row[0] == new_ts
+
+
+# ---------------------------------------------------------------------------
+# insert_campaign_observation / get_campaign_observations
+# ---------------------------------------------------------------------------
+
+
+def test_insert_campaign_observation_creates_row(db_session):
+    _insert_source_ip(db_session)
+    cid = _insert_campaign(db_session)
+    repo = EventRepository(db_session)
+    repo.insert_campaign_observation(
+        campaign_id=cid,
+        source_ip=_IP,
+        observed_at=_TS_STR,
+        event_count=25,
+        is_reactivation=False,
+        dormancy_gap_days=None,
+        notes=None,
+    )
+    db_session.flush()
+    count = db_session.execute(
+        text("SELECT COUNT(*) FROM campaign_observations WHERE campaign_id = :cid"),
+        {"cid": cid},
+    ).fetchone()[0]
+    assert count == 1
+
+
+def test_insert_campaign_observation_reactivation_flags(db_session):
+    _insert_source_ip(db_session)
+    cid = _insert_campaign(db_session)
+    repo = EventRepository(db_session)
+    repo.insert_campaign_observation(
+        campaign_id=cid,
+        source_ip=_IP,
+        observed_at=_TS_STR,
+        event_count=10,
+        is_reactivation=True,
+        dormancy_gap_days=45.5,
+        notes='{"weighted_total":0.85}',
+    )
+    db_session.flush()
+
+    obs = repo.get_campaign_observations(cid)
+    assert len(obs) == 1
+    assert obs[0]["is_reactivation"] is True
+    assert abs(obs[0]["dormancy_gap_days"] - 45.5) < 1e-3
+    assert obs[0]["notes"] == '{"weighted_total":0.85}'
+
+
+def test_get_campaign_observations_ordered(db_session):
+    _insert_source_ip(db_session)
+    cid = _insert_campaign(db_session)
+    repo = EventRepository(db_session)
+    repo.insert_campaign_observation(cid, _IP, "2025-06-03T00:00:00+00:00", 5, False, None, None)
+    repo.insert_campaign_observation(cid, _IP, "2025-06-01T00:00:00+00:00", 5, False, None, None)
+    repo.insert_campaign_observation(cid, _IP, "2025-06-02T00:00:00+00:00", 5, False, None, None)
+    db_session.flush()
+
+    obs = repo.get_campaign_observations(cid)
+    ts_list = [o["observed_at"] for o in obs]
+    assert ts_list == sorted(ts_list)
+
+
+# ---------------------------------------------------------------------------
+# update_campaign_on_association
+# ---------------------------------------------------------------------------
+
+
+def test_update_campaign_on_association_increments_member_count(db_session):
+    cid = _insert_campaign(db_session)
+    repo = EventRepository(db_session)
+    repo.update_campaign_on_association(
+        campaign_id=cid,
+        last_seen="2025-07-01T00:00:00+00:00",
+        updated_at="2025-07-01T00:00:00+00:00",
+        new_member_ip_count_delta=1,
+        is_reactivation=False,
+    )
+    db_session.flush()
+    c = repo.get_campaign(cid)
+    assert c["member_ip_count"] == 1
+
+
+def test_update_campaign_on_association_updates_last_seen(db_session):
+    cid = _insert_campaign(db_session)
+    new_ts = "2025-07-15T00:00:00+00:00"
+    EventRepository(db_session).update_campaign_on_association(cid, new_ts, new_ts, 1, False)
+    db_session.flush()
+    c = EventRepository(db_session).get_campaign(cid)
+    assert c["last_seen"] == new_ts
+
+
+def test_update_campaign_on_association_reactivation_changes_status(db_session):
+    cid = _insert_campaign(db_session, status="dormant")
+    repo = EventRepository(db_session)
+    repo.update_campaign_on_association(
+        campaign_id=cid,
+        last_seen=_TS_STR,
+        updated_at=_TS_STR,
+        new_member_ip_count_delta=1,
+        is_reactivation=True,
+    )
+    db_session.flush()
+    c = repo.get_campaign(cid)
+    assert c["status"] == "reactivated"
+    assert c["dormant_since"] is None
+    assert c["reactivation_count"] == 1
+
+
+def test_update_campaign_on_association_zero_delta_no_member_count_change(db_session):
+    cid = _insert_campaign(db_session)
+    repo = EventRepository(db_session)
+    # First add a member
+    repo.update_campaign_on_association(cid, _TS_STR, _TS_STR, 1, False)
+    db_session.flush()
+    # Update without incrementing (existing member)
+    repo.update_campaign_on_association(cid, _TS_STR, _TS_STR, 0, False)
+    db_session.flush()
+    c = repo.get_campaign(cid)
+    assert c["member_ip_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_campaigns_for_clustering
+# ---------------------------------------------------------------------------
+
+
+def test_get_campaigns_for_clustering_empty_when_no_campaigns(db_session):
+    results = EventRepository(db_session).get_campaigns_for_clustering()
+    assert results == []
+
+
+def test_get_campaigns_for_clustering_returns_active(db_session):
+    _insert_source_ip(db_session)
+    _insert_fingerprint(db_session)
+    cid = _insert_campaign(db_session, status="active")
+    repo = EventRepository(db_session)
+    repo.add_campaign_member(cid, _IP, 0.8, _TS_STR, _TS_STR)
+    db_session.flush()
+
+    results = repo.get_campaigns_for_clustering()
+    assert len(results) == 1
+    assert results[0]["campaign_id"] == cid
+
+
+def test_get_campaigns_for_clustering_includes_dormant(db_session):
+    _insert_source_ip(db_session)
+    _insert_fingerprint(db_session)
+    cid = _insert_campaign(db_session, status="dormant")
+    repo = EventRepository(db_session)
+    repo.add_campaign_member(cid, _IP, 0.7, _TS_STR, _TS_STR)
+    db_session.flush()
+
+    results = repo.get_campaigns_for_clustering()
+    assert any(r["campaign_id"] == cid for r in results)
+
+
+def test_get_campaigns_for_clustering_excludes_historical(db_session):
+    _insert_source_ip(db_session)
+    _insert_fingerprint(db_session)
+    cid = _insert_campaign(db_session, status="historical")
+    repo = EventRepository(db_session)
+    repo.add_campaign_member(cid, _IP, 0.7, _TS_STR, _TS_STR)
+    db_session.flush()
+
+    results = repo.get_campaigns_for_clustering()
+    assert not any(r["campaign_id"] == cid for r in results)
+
+
+def test_get_campaigns_for_clustering_excludes_campaign_without_fingerprint(db_session):
+    _insert_source_ip(db_session)
+    # No fingerprint inserted — campaign has a member but no fingerprint
+    cid = _insert_campaign(db_session, status="active")
+    repo = EventRepository(db_session)
+    repo.add_campaign_member(cid, _IP, 0.7, _TS_STR, _TS_STR)
+    db_session.flush()
+
+    results = repo.get_campaigns_for_clustering()
+    assert results == []
+
+
+def test_get_campaigns_for_clustering_returned_keys(db_session):
+    _insert_source_ip(db_session)
+    _insert_fingerprint(db_session)
+    cid = _insert_campaign(db_session)
+    repo = EventRepository(db_session)
+    repo.add_campaign_member(cid, _IP, 0.8, _TS_STR, _TS_STR)
+    db_session.flush()
+
+    results = repo.get_campaigns_for_clustering()
+    assert len(results) == 1
+    assert set(results[0].keys()) == {
+        "campaign_id",
+        "status",
+        "last_seen",
+        "timing_features",
+        "sequence_features",
+        "protocol_features",
+        "credential_features",
+        "target_features",
+        "confidence",
+    }
+
+
+def test_get_campaigns_for_clustering_uses_most_recent_member(db_session):
+    """When a campaign has two members, the fingerprint of the most-recently-
+    active one is returned."""
+    _insert_source_ip(db_session, _IP)
+    _insert_source_ip(db_session, _IP2)
+
+    target_tf = json.dumps({"port_freq": {"22": 1.0}, "top_dst_ports": [22]})
+    _insert_fingerprint(db_session, _IP, confidence=0.5)
+    _insert_fingerprint(db_session, _IP2, confidence=0.9, target_features=target_tf)
+
+    cid = _insert_campaign(db_session)
+    repo = EventRepository(db_session)
+    # _IP added earlier, _IP2 is most recent
+    repo.add_campaign_member(
+        cid, _IP, 0.7, "2025-06-01T00:00:00+00:00", "2025-06-01T00:00:00+00:00"
+    )
+    repo.add_campaign_member(
+        cid, _IP2, 0.9, "2025-06-05T00:00:00+00:00", "2025-06-05T00:00:00+00:00"
+    )
+    db_session.flush()
+
+    results = repo.get_campaigns_for_clustering()
+    assert len(results) == 1
+    # Should return _IP2's fingerprint (most recently active)
+    assert results[0]["confidence"] == pytest.approx(0.9)
+    assert results[0]["target_features"] == target_tf

--- a/tests/unit/test_similarity.py
+++ b/tests/unit/test_similarity.py
@@ -1,0 +1,450 @@
+"""Unit tests for app/intelligence/similarity.py.
+
+All tests use in-memory dicts only — no database, no HTTP.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.intelligence.similarity import (
+    SimilarityResult,
+    _cv_sim,
+    _dict_jaccard,
+    _histogram_sim,
+    _jaccard,
+    _jsd,
+    _levenshtein,
+    _normalized_edit_sim,
+    _stat_sim,
+    compute_weighted_similarity,
+    credential_similarity,
+    protocol_similarity,
+    sequence_similarity,
+    target_similarity,
+    timing_similarity,
+)
+
+# ---------------------------------------------------------------------------
+# Primitive helpers
+# ---------------------------------------------------------------------------
+
+
+def test_stat_sim_identical():
+    assert _stat_sim(100.0, 100.0) == pytest.approx(1.0)
+
+
+def test_stat_sim_both_zero():
+    assert _stat_sim(0.0, 0.0) == pytest.approx(1.0)
+
+
+def test_stat_sim_one_zero():
+    # 1 - 100 / (100 + 1) ≈ 0.0099
+    result = _stat_sim(0.0, 100.0)
+    assert result < 0.02
+
+
+def test_stat_sim_range():
+    assert 0.0 <= _stat_sim(1.0, 10.0) <= 1.0
+
+
+def test_cv_sim_identical():
+    assert _cv_sim(0.5, 0.5) == pytest.approx(1.0)
+
+
+def test_cv_sim_difference_above_one_clamps():
+    assert _cv_sim(0.0, 2.0) == pytest.approx(0.0)
+
+
+def test_levenshtein_empty():
+    assert _levenshtein([], []) == 0
+    assert _levenshtein([1, 2], []) == 2
+    assert _levenshtein([], [1, 2]) == 2
+
+
+def test_levenshtein_identical():
+    assert _levenshtein([22, 80, 443], [22, 80, 443]) == 0
+
+
+def test_levenshtein_one_substitution():
+    assert _levenshtein([22, 80], [22, 443]) == 1
+
+
+def test_normalized_edit_sim_both_empty():
+    assert _normalized_edit_sim([], []) == pytest.approx(1.0)
+
+
+def test_normalized_edit_sim_identical():
+    assert _normalized_edit_sim([22, 80], [22, 80]) == pytest.approx(1.0)
+
+
+def test_normalized_edit_sim_fully_different():
+    # [1] vs [2]: edit distance 1, max_len 1 → 0.0
+    assert _normalized_edit_sim([1], [2]) == pytest.approx(0.0)
+
+
+def test_normalized_edit_sim_partial():
+    result = _normalized_edit_sim([22, 80, 443], [22, 80, 22])
+    assert 0.0 < result < 1.0
+
+
+def test_jaccard_both_empty():
+    assert _jaccard(set(), set()) == pytest.approx(1.0)
+
+
+def test_jaccard_identical():
+    s = {22, 80, 443}
+    assert _jaccard(s, s) == pytest.approx(1.0)
+
+
+def test_jaccard_disjoint():
+    assert _jaccard({1, 2}, {3, 4}) == pytest.approx(0.0)
+
+
+def test_jaccard_partial_overlap():
+    result = _jaccard({1, 2, 3}, {2, 3, 4})
+    # |{2,3}| / |{1,2,3,4}| = 2/4 = 0.5
+    assert result == pytest.approx(0.5)
+
+
+def test_jsd_identical_distributions():
+    p = [0.5, 0.5]
+    assert _jsd(p, p) == pytest.approx(0.0)
+
+
+def test_jsd_maximally_different():
+    p = [1.0, 0.0]
+    q = [0.0, 1.0]
+    # JSD(p||q) = 1.0 for log base 2
+    assert _jsd(p, q) == pytest.approx(1.0)
+
+
+def test_jsd_length_mismatch_returns_one():
+    assert _jsd([0.5, 0.5], [0.33, 0.33, 0.34]) == pytest.approx(1.0)
+
+
+def test_histogram_sim_none_input():
+    assert _histogram_sim(None, [0.5, 0.5]) is None
+    assert _histogram_sim([0.5, 0.5], None) is None
+
+
+def test_histogram_sim_identical():
+    p = [1.0 / 24] * 24
+    result = _histogram_sim(p, p)
+    assert result == pytest.approx(1.0)
+
+
+def test_dict_jaccard_empty():
+    assert _dict_jaccard({}, {}) == pytest.approx(1.0)
+
+
+def test_dict_jaccard_partial():
+    a = {"ssh": 0.8, "telnet": 0.2}
+    b = {"ssh": 0.6, "ftp": 0.4}
+    # keys: {ssh} / {ssh, telnet, ftp} = 1/3
+    assert _dict_jaccard(a, b) == pytest.approx(1 / 3)
+
+
+# ---------------------------------------------------------------------------
+# timing_similarity
+# ---------------------------------------------------------------------------
+
+
+def _timing_dict():
+    return {
+        "interval": {"mean": 1000.0, "stddev": 50.0, "p25": 800.0, "p75": 1200.0, "p95": 1400.0},
+        "tod_histogram": [1.0 / 24] * 24,
+        "dow_histogram": [1.0 / 7] * 7,
+        "burst_cv": 0.05,
+    }
+
+
+def test_timing_similarity_identical():
+    t = _timing_dict()
+    assert timing_similarity(t, t) == pytest.approx(1.0, abs=1e-4)
+
+
+def test_timing_similarity_null_returns_none():
+    assert timing_similarity(None, _timing_dict()) is None
+    assert timing_similarity(_timing_dict(), None) is None
+
+
+def test_timing_similarity_both_null_returns_none():
+    assert timing_similarity(None, None) is None
+
+
+def test_timing_similarity_different_intervals_lower_score():
+    t1 = _timing_dict()
+    t2 = {
+        **_timing_dict(),
+        "interval": {"mean": 5000.0, "stddev": 200.0, "p25": 4000.0, "p75": 6000.0, "p95": 7000.0},
+    }
+    result = timing_similarity(t1, t2)
+    assert result is not None
+    assert result < 0.9
+
+
+def test_timing_similarity_in_range():
+    t1 = _timing_dict()
+    t2 = {**_timing_dict(), "burst_cv": 1.0}
+    result = timing_similarity(t1, t2)
+    assert result is not None
+    assert 0.0 <= result <= 1.0
+
+
+def test_timing_similarity_empty_dicts_returns_zero():
+    assert timing_similarity({}, {}) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# sequence_similarity
+# ---------------------------------------------------------------------------
+
+
+def test_sequence_similarity_identical():
+    s = {
+        "port_sequence": [22, 80, 443],
+        "event_type_sequence": ["auth_failed", "auth_failed"],
+        "credential_sequence": [{"username_pattern": "alpha", "password_class": "alphanum"}],
+    }
+    assert sequence_similarity(s, s) == pytest.approx(1.0)
+
+
+def test_sequence_similarity_null_returns_none():
+    s = {"port_sequence": [22]}
+    assert sequence_similarity(None, s) is None
+
+
+def test_sequence_similarity_identical_ports_only():
+    s = {"port_sequence": [22, 80]}
+    assert sequence_similarity(s, s) == pytest.approx(1.0)
+
+
+def test_sequence_similarity_disjoint_ports():
+    s1 = {"port_sequence": [22]}
+    s2 = {"port_sequence": [443]}
+    result = sequence_similarity(s1, s2)
+    assert result is not None
+    assert result < 0.5
+
+
+def test_sequence_similarity_empty_sequences_identical():
+    s1 = {"port_sequence": [], "event_type_sequence": [], "credential_sequence": []}
+    s2 = {"port_sequence": [], "event_type_sequence": [], "credential_sequence": []}
+    # All sub-components skip when empty — scores list empty → 0.0
+    assert sequence_similarity(s1, s2) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# protocol_similarity
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_similarity_identical():
+    p = {
+        "service_distribution": {"ssh": 1.0},
+        "ssh_kex_ordering": ["diffie-hellman-group14-sha256", "ecdh-sha2-nistp256"],
+        "tls_cipher_ordering": None,
+    }
+    assert protocol_similarity(p, p) == pytest.approx(1.0)
+
+
+def test_protocol_similarity_null_returns_none():
+    p = {"service_distribution": {"ssh": 1.0}}
+    assert protocol_similarity(None, p) is None
+
+
+def test_protocol_similarity_service_jaccard():
+    p1 = {"service_distribution": {"ssh": 0.8, "telnet": 0.2}}
+    p2 = {"service_distribution": {"ssh": 0.6, "ftp": 0.4}}
+    result = protocol_similarity(p1, p2)
+    assert result is not None
+    # Jaccard of {ssh,telnet} vs {ssh,ftp} = 1/3
+    assert result == pytest.approx(1 / 3, abs=0.01)
+
+
+def test_protocol_similarity_kex_ordering():
+    # 3-alg list with first two swapped: edit_distance = 2, max_len = 3 → sim = 1/3
+    algs = ["ecdh-sha2-nistp256", "diffie-hellman-group14-sha256", "curve25519-sha256"]
+    algs_swapped = ["diffie-hellman-group14-sha256", "ecdh-sha2-nistp256", "curve25519-sha256"]
+    p1 = {"service_distribution": {"ssh": 1.0}, "ssh_kex_ordering": algs}
+    p2 = {"service_distribution": {"ssh": 1.0}, "ssh_kex_ordering": algs_swapped}
+    result = protocol_similarity(p1, p2)
+    assert result is not None
+    # service Jaccard = 1.0; kex edit sim < 1.0 → average in (0, 1)
+    assert 0.0 < result < 1.0
+
+
+# ---------------------------------------------------------------------------
+# credential_similarity
+# ---------------------------------------------------------------------------
+
+
+def test_credential_similarity_identical():
+    c = {
+        "username_class_dist": {"alpha": 0.8, "alphanum": 0.2},
+        "password_char_class": {"has_upper_ratio": 0.1, "has_digit_ratio": 0.9},
+        "credential_sequence": [{"username_pattern": "alpha", "password_class": "alphanum"}],
+    }
+    assert credential_similarity(c, c) == pytest.approx(1.0)
+
+
+def test_credential_similarity_null_returns_none():
+    c = {"username_class_dist": {"alpha": 1.0}}
+    assert credential_similarity(None, c) is None
+
+
+def test_credential_similarity_class_jaccard():
+    c1 = {"username_class_dist": {"alpha": 0.5, "numeric": 0.5}}
+    c2 = {"username_class_dist": {"alpha": 0.8, "email": 0.2}}
+    result = credential_similarity(c1, c2)
+    # keys: {alpha} / {alpha, numeric, email} = 1/3
+    assert result is not None
+    assert result == pytest.approx(1 / 3, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# target_similarity
+# ---------------------------------------------------------------------------
+
+
+def test_target_similarity_identical():
+    t = {
+        "port_freq": {"22": 0.8, "80": 0.2},
+        "top_dst_ports": [22, 80],
+    }
+    assert target_similarity(t, t) == pytest.approx(1.0)
+
+
+def test_target_similarity_null_returns_none():
+    t = {"port_freq": {"22": 1.0}}
+    assert target_similarity(None, t) is None
+
+
+def test_target_similarity_disjoint_ports():
+    t1 = {"port_freq": {"22": 1.0}, "top_dst_ports": [22]}
+    t2 = {"port_freq": {"443": 1.0}, "top_dst_ports": [443]}
+    result = target_similarity(t1, t2)
+    assert result is not None
+    assert result == pytest.approx(0.0)
+
+
+def test_target_similarity_partial_overlap():
+    t1 = {"port_freq": {"22": 0.5, "80": 0.5}, "top_dst_ports": [22, 80]}
+    t2 = {"port_freq": {"22": 0.7, "443": 0.3}, "top_dst_ports": [22, 443]}
+    result = target_similarity(t1, t2)
+    assert result is not None
+    assert 0.0 < result < 1.0
+
+
+# ---------------------------------------------------------------------------
+# compute_weighted_similarity
+# ---------------------------------------------------------------------------
+
+
+def _make_fp(
+    timing=None,
+    sequence=None,
+    protocol=None,
+    credential=None,
+    target=None,
+):
+    """Build a minimal fingerprint dict with JSON-encoded features."""
+
+    def _enc(d):
+        return json.dumps(d, separators=(",", ":")) if d is not None else None
+
+    return {
+        "timing_features": _enc(timing),
+        "sequence_features": _enc(sequence),
+        "protocol_features": _enc(protocol),
+        "credential_features": _enc(credential),
+        "target_features": _enc(target),
+    }
+
+
+_FULL_TIMING = {
+    "interval": {"mean": 1000.0, "stddev": 10.0, "p25": 950.0, "p75": 1050.0, "p95": 1100.0},
+    "tod_histogram": [1 / 24] * 24,
+    "dow_histogram": [1 / 7] * 7,
+    "burst_cv": 0.01,
+}
+_FULL_SEQUENCE = {
+    "port_sequence": [22, 80, 443],
+    "event_type_sequence": ["auth_failed"] * 10,
+    "credential_sequence": [{"username_pattern": "alpha", "password_class": "alphanum"}],
+}
+_FULL_TARGET = {
+    "port_freq": {"22": 0.9, "80": 0.1},
+    "top_dst_ports": [22, 80],
+}
+
+
+def test_weighted_similarity_identical_full_fp():
+    fp = _make_fp(timing=_FULL_TIMING, sequence=_FULL_SEQUENCE, target=_FULL_TARGET)
+    result = compute_weighted_similarity(fp, fp)
+    assert isinstance(result, SimilarityResult)
+    assert result.weighted_total == pytest.approx(1.0, abs=1e-4)
+
+
+def test_weighted_similarity_all_null_returns_zero():
+    fp = _make_fp()
+    result = compute_weighted_similarity(fp, fp)
+    assert result.weighted_total == pytest.approx(0.0)
+    assert result.dimensions_used == 0
+
+
+def test_weighted_similarity_null_dimension_excluded_from_denominator():
+    """A fingerprint with only sequence data should score 1.0 against itself,
+    not be penalised by the absent timing/protocol/credential/target weights."""
+    fp = _make_fp(sequence=_FULL_SEQUENCE)
+    result = compute_weighted_similarity(fp, fp)
+    assert result.weighted_total == pytest.approx(1.0, abs=1e-4)
+    assert result.dimensions_used == 1
+
+
+def test_weighted_similarity_dimensions_used_count():
+    fp = _make_fp(timing=_FULL_TIMING, target=_FULL_TARGET)
+    result = compute_weighted_similarity(fp, fp)
+    assert result.dimensions_used == 2
+
+
+def test_weighted_similarity_result_has_all_fields():
+    fp = _make_fp(sequence=_FULL_SEQUENCE)
+    result = compute_weighted_similarity(fp, fp)
+    d = result.as_dict()
+    assert "timing_similarity" in d
+    assert "sequence_similarity" in d
+    assert "protocol_similarity" in d
+    assert "credential_similarity" in d
+    assert "target_similarity" in d
+    assert "weighted_total" in d
+    assert "dimensions_used" in d
+
+
+def test_weighted_similarity_different_fps_below_one():
+    fp1 = _make_fp(
+        sequence={"port_sequence": [22, 80], "event_type_sequence": [], "credential_sequence": []}
+    )
+    fp2 = _make_fp(
+        sequence={
+            "port_sequence": [443, 8080],
+            "event_type_sequence": [],
+            "credential_sequence": [],
+        }
+    )
+    result = compute_weighted_similarity(fp1, fp2)
+    assert result.weighted_total < 0.5
+
+
+def test_weighted_similarity_no_raw_values_in_result():
+    """SimilarityResult must contain only numeric scores — no strings, no raw data."""
+    fp = _make_fp(sequence=_FULL_SEQUENCE, target=_FULL_TARGET)
+    result = compute_weighted_similarity(fp, fp)
+    d = result.as_dict()
+    for key, val in d.items():
+        assert val is None or isinstance(
+            val, int | float
+        ), f"Field {key!r} has non-numeric value {val!r}"


### PR DESCRIPTION
## Summary

- **`app/intelligence/similarity.py`**: pure weighted fingerprint similarity — 5 dimensions (timing, sequence, protocol, credential, target); null dimensions excluded from both numerator and denominator so sparse fingerprints are not penalized (§8.1)
- **`app/intelligence/campaign_names.py`**: deterministic `ADJECTIVE-ANIMAL-N` name generation from SHA-256(campaign_uuid); 81,000 possible names; same UUID always produces same name
- **`app/intelligence/clustering.py`**: `assign_to_campaign()` — sparse gate (confidence < 0.20 skipped, §12.6), existing-member fast path, per-candidate temporal threshold bumps at 6M/12M (§12.3), auto/uncertain/new-campaign decision (§8.2), explainability JSON stored in `campaign_observations.notes` (§12.7)
- **`app/db/repositories/campaign.py`**: `CampaignRepository` mixin — create, get, get_campaigns_for_clustering (active/dormant/reactivated only), member CRUD, observation insert, `update_campaign_on_association` (handles reactivation: status → reactivated, dormant_since → NULL, reactivation_count += 1)
- **`app/intelligence/constants.py`**: 12 new named constants — 5 similarity weights, 2 decision thresholds, 2 temporal recency thresholds, 2 campaign lifecycle boundaries (§12.2)
- **`app/intelligence/tasks.py`**: after fingerprint session commits, calls `_run_campaign_clustering()` in a separate session; clustering failure cannot roll back fingerprint

## Deferred (out of scope for this PR)

- Campaign REST API endpoints
- Dashboard campaign views
- Automatic blocking or retaliation

## Test plan

- [x] `tests/unit/test_similarity.py` — ~50 unit tests for all primitives and dimension functions; null-dimension exclusion; privacy (no raw values in result)
- [x] `tests/db/test_campaign_repository.py` — ~27 repository tests; most-recent-member fingerprint selection
- [x] `tests/db/test_campaign_clustering.py` — ~30 integration tests; sparse gate, auto/uncertain/new decisions, temporal threshold bumps, reactivation, explainability object, privacy (no raw IPs in notes)
- [x] `python -m pytest --tb=short -q` → 535 passed, 3 skipped