### PR TITLE
feat(campaigns): expose campaign API and dashboard panel

### DIFF
--- a/app/db/repositories/campaign.py
+++ b/app/db/repositories/campaign.py
@@ -304,6 +304,63 @@ class CampaignRepository(RepositoryBase):
                 },
             )
 
+    def list_campaigns(self, limit: int = 100) -> list[dict[str, Any]]:
+        """Return campaigns sorted by last_seen DESC."""
+        rows = self._session.execute(
+            text("""
+                SELECT id, name, status, confidence,
+                       first_seen, last_seen, dormant_since,
+                       reactivation_count, member_ip_count,
+                       attack_tactic_dist, top_target_ports, notes,
+                       created_at, updated_at
+                FROM campaigns
+                ORDER BY last_seen DESC
+                LIMIT :limit
+            """),
+            {"limit": limit},
+        ).fetchall()
+        return [
+            {
+                "id": r[0],
+                "name": r[1],
+                "status": r[2],
+                "confidence": r[3],
+                "first_seen": r[4],
+                "last_seen": r[5],
+                "dormant_since": r[6],
+                "reactivation_count": r[7],
+                "member_ip_count": r[8],
+                "attack_tactic_dist": r[9],
+                "top_target_ports": r[10],
+                "notes": r[11],
+                "created_at": r[12],
+                "updated_at": r[13],
+            }
+            for r in rows
+        ]
+
+    def get_campaign_members(self, campaign_id: str) -> list[dict[str, Any]]:
+        """Return all members of a campaign ordered by last_active DESC."""
+        rows = self._session.execute(
+            text("""
+                SELECT campaign_id, source_ip, confidence, added_at, last_active
+                FROM campaign_members
+                WHERE campaign_id = :campaign_id
+                ORDER BY last_active DESC
+            """),
+            {"campaign_id": campaign_id},
+        ).fetchall()
+        return [
+            {
+                "campaign_id": r[0],
+                "source_ip": r[1],
+                "confidence": r[2],
+                "added_at": r[3],
+                "last_active": r[4],
+            }
+            for r in rows
+        ]
+
     def get_campaign_observations(self, campaign_id: str) -> list[dict[str, Any]]:
         """Return all observations for a campaign, ordered by observed_at."""
         rows = self._session.execute(

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.routers import (
     auth_router,  # Login & JWT auth
     events,  # Event listing endpoint
 )
+from app.routers.campaigns import router as campaigns_router  # GET /api/campaigns/*
 from app.routers.exports import router as exports_router  # GET /api/exports/*
 from app.routers.ingest import router as ingest_router  # POST /api/ingest
 from app.routers.intelligence import router as intelligence_router  # GET /api/intelligence/*
@@ -56,6 +57,7 @@ app.add_middleware(
 app.include_router(auth_router.router)  # /api/login
 app.include_router(ingest_router)  # /api/ingest
 app.include_router(intelligence_router)  # /api/intelligence/*
+app.include_router(campaigns_router)  # /api/campaigns/*
 app.include_router(exports_router)  # /api/exports/*
 app.include_router(iocs_pf_router, prefix="/api/iocs")  # pf.conf generator
 app.include_router(stats_router)  # /api/stats

--- a/app/routers/campaigns.py
+++ b/app/routers/campaigns.py
@@ -1,0 +1,70 @@
+"""Campaign intelligence endpoints.
+
+GET /api/campaigns                          — paginated campaign list
+GET /api/campaigns/{campaign_id}            — detail: campaign + members + observations
+GET /api/campaigns/{campaign_id}/observations — observation list for one campaign
+
+All endpoints require API key or JWT authentication via require_jwt_or_api_key.
+No SQL belongs here — all queries go through EventRepository.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.db.connection import get_session
+from app.db.repository import EventRepository
+from app.utils.auth import require_jwt_or_api_key
+
+router = APIRouter(prefix="/api/campaigns", tags=["campaigns"])
+
+
+@router.get("")
+def list_campaigns(
+    limit: int = Query(default=100, ge=1, le=1000),
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return campaigns sorted by last_seen DESC."""
+    with get_session() as session:
+        items = EventRepository(session).list_campaigns(limit=limit)
+    return {"items": items, "count": len(items)}
+
+
+@router.get("/{campaign_id}")
+def get_campaign(
+    campaign_id: str,
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return campaign detail with members and observations. 404 if not found."""
+    with get_session() as session:
+        repo = EventRepository(session)
+        campaign = repo.get_campaign(campaign_id)
+        if campaign is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Campaign {campaign_id!r} not found",
+            )
+        members = repo.get_campaign_members(campaign_id)
+        observations = repo.get_campaign_observations(campaign_id)
+    return {
+        **campaign,
+        "members": members,
+        "observations": observations,
+    }
+
+
+@router.get("/{campaign_id}/observations")
+def get_campaign_observations(
+    campaign_id: str,
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return observations for a campaign ordered by observed_at ASC. 404 if not found."""
+    with get_session() as session:
+        repo = EventRepository(session)
+        if repo.get_campaign(campaign_id) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Campaign {campaign_id!r} not found",
+            )
+        observations = repo.get_campaign_observations(campaign_id)
+    return {"items": observations, "count": len(observations)}

--- a/tests/integration/test_campaign_endpoints.py
+++ b/tests/integration/test_campaign_endpoints.py
@@ -1,0 +1,364 @@
+"""Integration tests for the campaign API endpoints.
+
+Tests hit the full HTTP → router → repository → in-memory SQLite stack.
+Schema is bootstrapped by tests/conftest.py; rows reset per test by
+tests/integration/conftest.py (reset_db_rows fixture).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.db.connection import get_engine
+from app.main import app
+
+client = TestClient(app)
+API_KEY = "dev-123"
+HEADERS = {"x-api-key": API_KEY}
+
+_TS = "2025-06-01T12:00:00+00:00"
+_IP = "10.0.0.1"
+_IP2 = "10.0.0.2"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_source_ip(ip: str = _IP) -> None:
+    with get_engine().connect() as conn:
+        conn.execute(
+            text(
+                "INSERT OR IGNORE INTO source_ips"
+                " (ip, first_seen, last_seen, event_count) VALUES (:ip, :ts, :ts, 1)"
+            ),
+            {"ip": ip, "ts": _TS},
+        )
+        conn.commit()
+
+
+def _insert_campaign(
+    campaign_id: str | None = None,
+    status: str = "active",
+    last_seen: str = _TS,
+    name: str = "TEST-WOLF-1",
+) -> str:
+    cid = campaign_id or str(uuid.uuid4())
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO campaigns
+                    (id, name, status, confidence, first_seen, last_seen,
+                     dormant_since, reactivation_count, member_ip_count,
+                     attack_tactic_dist, top_target_ports, notes,
+                     created_at, updated_at)
+                VALUES
+                    (:id, :name, :status, 0.7, :ts, :last_seen,
+                     NULL, 0, 1,
+                     NULL, NULL, NULL,
+                     :ts, :ts)
+            """),
+            {"id": cid, "name": name, "status": status, "ts": _TS, "last_seen": last_seen},
+        )
+        conn.commit()
+    return cid
+
+
+def _insert_member(campaign_id: str, ip: str = _IP) -> None:
+    _insert_source_ip(ip)
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO campaign_members
+                    (campaign_id, source_ip, confidence, added_at, last_active)
+                VALUES (:cid, :ip, 0.8, :ts, :ts)
+            """),
+            {"cid": campaign_id, "ip": ip, "ts": _TS},
+        )
+        conn.commit()
+
+
+def _insert_observation(
+    campaign_id: str,
+    ip: str = _IP,
+    is_reactivation: bool = False,
+    notes: str | None = None,
+    observed_at: str = _TS,
+) -> None:
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO campaign_observations
+                    (id, campaign_id, source_ip, observed_at, event_count,
+                     is_reactivation, dormancy_gap_days, notes)
+                VALUES (:id, :cid, :ip, :ts, 10, :is_react, NULL, :notes)
+            """),
+            {
+                "id": str(uuid.uuid4()),
+                "cid": campaign_id,
+                "ip": ip,
+                "ts": observed_at,
+                "is_react": 1 if is_reactivation else 0,
+                "notes": notes,
+            },
+        )
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/campaigns — list
+# ---------------------------------------------------------------------------
+
+
+def test_list_campaigns_empty_returns_empty():
+    resp = client.get("/api/campaigns", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["count"] == 0
+
+
+def test_list_campaigns_returns_inserted_campaign():
+    cid = _insert_campaign()
+    resp = client.get("/api/campaigns", headers=HEADERS)
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["id"] == cid
+
+
+def test_list_campaigns_count_matches_items():
+    _insert_campaign()
+    _insert_campaign()
+    resp = client.get("/api/campaigns", headers=HEADERS)
+    data = resp.json()
+    assert data["count"] == len(data["items"])
+
+
+def test_list_campaigns_required_fields():
+    _insert_campaign()
+    resp = client.get("/api/campaigns", headers=HEADERS)
+    item = resp.json()["items"][0]
+    required = {
+        "id",
+        "name",
+        "status",
+        "confidence",
+        "first_seen",
+        "last_seen",
+        "dormant_since",
+        "reactivation_count",
+        "member_ip_count",
+        "attack_tactic_dist",
+        "top_target_ports",
+        "notes",
+        "created_at",
+        "updated_at",
+    }
+    assert required.issubset(item.keys())
+
+
+def test_list_campaigns_sorted_by_last_seen_desc():
+    _insert_campaign(last_seen="2025-06-01T00:00:00+00:00")
+    _insert_campaign(last_seen="2025-08-01T00:00:00+00:00")
+    _insert_campaign(last_seen="2025-07-01T00:00:00+00:00")
+    resp = client.get("/api/campaigns", headers=HEADERS)
+    dates = [item["last_seen"] for item in resp.json()["items"]]
+    assert dates == sorted(dates, reverse=True)
+
+
+def test_list_campaigns_limit_respected():
+    for i in range(5):
+        _insert_campaign(name=f"WOLF-{i}")
+    resp = client.get("/api/campaigns?limit=3", headers=HEADERS)
+    data = resp.json()
+    assert len(data["items"]) == 3
+    assert data["count"] == 3
+
+
+def test_list_campaigns_limit_below_minimum_returns_422():
+    resp = client.get("/api/campaigns?limit=0", headers=HEADERS)
+    assert resp.status_code == 422
+
+
+def test_list_campaigns_limit_above_maximum_returns_422():
+    resp = client.get("/api/campaigns?limit=1001", headers=HEADERS)
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/campaigns — auth
+# ---------------------------------------------------------------------------
+
+
+def test_list_campaigns_no_auth_returns_401():
+    resp = client.get("/api/campaigns")
+    assert resp.status_code == 401
+
+
+def test_list_campaigns_wrong_key_returns_401():
+    resp = client.get("/api/campaigns", headers={"x-api-key": "bad"})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/campaigns/{campaign_id} — detail
+# ---------------------------------------------------------------------------
+
+
+def test_get_campaign_returns_detail():
+    cid = _insert_campaign()
+    resp = client.get(f"/api/campaigns/{cid}", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == cid
+    assert data["name"] == "TEST-WOLF-1"
+
+
+def test_get_campaign_includes_members_key():
+    cid = _insert_campaign()
+    _insert_member(cid)
+    resp = client.get(f"/api/campaigns/{cid}", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "members" in data
+    assert isinstance(data["members"], list)
+    assert len(data["members"]) == 1
+    assert data["members"][0]["source_ip"] == _IP
+
+
+def test_get_campaign_includes_observations_key():
+    cid = _insert_campaign()
+    _insert_member(cid)
+    _insert_observation(cid)
+    resp = client.get(f"/api/campaigns/{cid}", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "observations" in data
+    assert len(data["observations"]) == 1
+
+
+def test_get_campaign_members_empty_when_none():
+    cid = _insert_campaign()
+    resp = client.get(f"/api/campaigns/{cid}", headers=HEADERS)
+    assert resp.json()["members"] == []
+
+
+def test_get_campaign_observations_empty_when_none():
+    cid = _insert_campaign()
+    resp = client.get(f"/api/campaigns/{cid}", headers=HEADERS)
+    assert resp.json()["observations"] == []
+
+
+def test_get_campaign_observation_has_notes():
+    cid = _insert_campaign()
+    _insert_member(cid)
+    notes = json.dumps({"weighted_total": 0.92, "decision": "automatic_association"})
+    _insert_observation(cid, notes=notes)
+    resp = client.get(f"/api/campaigns/{cid}", headers=HEADERS)
+    obs = resp.json()["observations"][0]
+    assert obs["notes"] == notes
+
+
+def test_get_campaign_observation_is_reactivation_flag():
+    cid = _insert_campaign()
+    _insert_member(cid)
+    _insert_observation(cid, is_reactivation=True)
+    resp = client.get(f"/api/campaigns/{cid}", headers=HEADERS)
+    obs = resp.json()["observations"][0]
+    assert obs["is_reactivation"] is True
+
+
+def test_get_campaign_not_found_returns_404():
+    resp = client.get(f"/api/campaigns/{uuid.uuid4()}", headers=HEADERS)
+    assert resp.status_code == 404
+
+
+def test_get_campaign_no_auth_returns_401():
+    cid = _insert_campaign()
+    resp = client.get(f"/api/campaigns/{cid}")
+    assert resp.status_code == 401
+
+
+def test_get_campaign_wrong_key_returns_401():
+    cid = _insert_campaign()
+    resp = client.get(f"/api/campaigns/{cid}", headers={"x-api-key": "bad"})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/campaigns/{campaign_id}/observations
+# ---------------------------------------------------------------------------
+
+
+def test_get_observations_empty_when_none():
+    cid = _insert_campaign()
+    resp = client.get(f"/api/campaigns/{cid}/observations", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["count"] == 0
+
+
+def test_get_observations_returns_inserted():
+    cid = _insert_campaign()
+    _insert_member(cid)
+    _insert_observation(cid)
+    resp = client.get(f"/api/campaigns/{cid}/observations", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    assert data["items"][0]["campaign_id"] == cid
+
+
+def test_get_observations_required_fields():
+    cid = _insert_campaign()
+    _insert_member(cid)
+    _insert_observation(cid)
+    resp = client.get(f"/api/campaigns/{cid}/observations", headers=HEADERS)
+    obs = resp.json()["items"][0]
+    required = {
+        "id",
+        "campaign_id",
+        "source_ip",
+        "observed_at",
+        "event_count",
+        "is_reactivation",
+        "dormancy_gap_days",
+        "notes",
+    }
+    assert required.issubset(obs.keys())
+
+
+def test_get_observations_ordered_by_observed_at():
+    cid = _insert_campaign()
+    _insert_member(cid)
+    _insert_observation(cid, observed_at="2025-06-03T00:00:00+00:00")
+    _insert_observation(cid, observed_at="2025-06-01T00:00:00+00:00")
+    _insert_observation(cid, observed_at="2025-06-02T00:00:00+00:00")
+    resp = client.get(f"/api/campaigns/{cid}/observations", headers=HEADERS)
+    items = resp.json()["items"]
+    ts_list = [o["observed_at"] for o in items]
+    assert ts_list == sorted(ts_list)
+
+
+def test_get_observations_not_found_returns_404():
+    resp = client.get(f"/api/campaigns/{uuid.uuid4()}/observations", headers=HEADERS)
+    assert resp.status_code == 404
+
+
+def test_get_observations_no_auth_returns_401():
+    cid = _insert_campaign()
+    resp = client.get(f"/api/campaigns/{cid}/observations")
+    assert resp.status_code == 401
+
+
+def test_get_observations_wrong_key_returns_401():
+    cid = _insert_campaign()
+    resp = client.get(f"/api/campaigns/{cid}/observations", headers={"x-api-key": "bad"})
+    assert resp.status_code == 401

--- a/ui/dashboard/src/App.jsx
+++ b/ui/dashboard/src/App.jsx
@@ -5,6 +5,7 @@ import EventTrends from "./components/EventTrends";
 import IntelligenceIPs from "./components/IntelligenceIPs";
 import TopCountries from "./components/TopCountries";
 import TopASNs from "./components/TopASNs";
+import Campaigns from "./components/Campaigns";
 
 
 // keep <body> background in sync with dashboard theme
@@ -221,6 +222,11 @@ export default function App() {
         }}>
           <TopCountries dark={dark} />
           <TopASNs dark={dark} />
+        </div>
+
+        {/* 🎯 Campaigns */}
+        <div style={{ marginTop: 36 }}>
+          <Campaigns dark={dark} />
         </div>
       </div>
     </div>

--- a/ui/dashboard/src/components/Campaigns.jsx
+++ b/ui/dashboard/src/components/Campaigns.jsx
@@ -1,0 +1,341 @@
+import { Fragment, useEffect, useState } from "react";
+import { getCampaigns, getCampaignDetail } from "../lib/api";
+import { timeAgo } from "../utils/format";
+
+const REFRESH_MS = 30_000;
+
+function statusColor(status) {
+  switch (status) {
+    case "active": return "#22c55e";
+    case "reactivated": return "#f97316";
+    case "dormant": return "#60a5fa";
+    case "historical": return "#6b7280";
+    default: return "#9ca3af";
+  }
+}
+
+function StatusBadge({ status }) {
+  const color = statusColor(status);
+  return (
+    <span style={{
+      padding: "2px 8px",
+      borderRadius: 9999,
+      fontSize: 11,
+      fontWeight: 600,
+      background: `${color}22`,
+      color,
+      textTransform: "uppercase",
+      letterSpacing: "0.04em",
+    }}>
+      {status ?? "—"}
+    </span>
+  );
+}
+
+function ConfidenceBar({ value, dark }) {
+  if (value == null) return <span style={{ opacity: 0.4 }}>—</span>;
+  const pct = Math.round(value * 100);
+  const color = pct >= 80 ? "#ef4444" : pct >= 60 ? "#f97316" : "#22c55e";
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+      <span style={{
+        display: "inline-block",
+        width: 48,
+        height: 6,
+        borderRadius: 3,
+        background: dark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.08)",
+        overflow: "hidden",
+      }}>
+        <span style={{
+          display: "block",
+          width: `${pct}%`,
+          height: "100%",
+          background: color,
+          borderRadius: 3,
+        }} />
+      </span>
+      <span style={{ fontFamily: "monospace", fontSize: 12, color }}>{pct}%</span>
+    </span>
+  );
+}
+
+function ExplainSummary({ notes, dark }) {
+  if (!notes) return null;
+  let parsed;
+  try { parsed = JSON.parse(notes); } catch { return null; }
+  const score = parsed.weighted_total;
+  const dims = parsed.dimensions_used;
+  const decision = parsed.decision;
+  if (score == null) return null;
+  const label = decision?.replace(/_/g, " ") ?? "—";
+  const fg = dark ? "#9ca3af" : "#6b7280";
+  return (
+    <span style={{ fontSize: 11, color: fg, fontFamily: "monospace" }}>
+      sim {(score * 100).toFixed(1)}%
+      {dims != null && <span style={{ marginLeft: 4 }}>({dims}d)</span>}
+      {" · "}
+      <span style={{ color: decision === "automatic_association" ? "#22c55e" : "#f97316" }}>
+        {label}
+      </span>
+    </span>
+  );
+}
+
+function CampaignDetail({ detail, dark }) {
+  const fg = dark ? "#d1d5db" : "#374151";
+  const border = dark ? "#374151" : "#e5e7eb";
+
+  const observations = detail.observations ?? [];
+  const members = detail.members ?? [];
+  const recent = observations.slice().reverse().slice(0, 5);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14, fontSize: 13, color: fg }}>
+      {/* Summary row */}
+      <div style={{ display: "flex", gap: 24, flexWrap: "wrap" }}>
+        <div>
+          <div style={{ fontSize: 11, textTransform: "uppercase", opacity: 0.55, marginBottom: 2 }}>First Seen</div>
+          <div style={{ fontFamily: "monospace" }}>{detail.first_seen ? timeAgo(detail.first_seen) : "—"}</div>
+        </div>
+        {detail.dormant_since && (
+          <div>
+            <div style={{ fontSize: 11, textTransform: "uppercase", opacity: 0.55, marginBottom: 2 }}>Dormant Since</div>
+            <div style={{ fontFamily: "monospace" }}>{timeAgo(detail.dormant_since)}</div>
+          </div>
+        )}
+        <div>
+          <div style={{ fontSize: 11, textTransform: "uppercase", opacity: 0.55, marginBottom: 2 }}>Members</div>
+          <div style={{ fontFamily: "monospace" }}>{members.length}</div>
+        </div>
+        <div>
+          <div style={{ fontSize: 11, textTransform: "uppercase", opacity: 0.55, marginBottom: 2 }}>Total Observations</div>
+          <div style={{ fontFamily: "monospace" }}>{observations.length}</div>
+        </div>
+      </div>
+
+      {/* Recent observations */}
+      {recent.length > 0 && (
+        <div>
+          <div style={{ fontSize: 11, textTransform: "uppercase", opacity: 0.55, marginBottom: 6 }}>
+            Recent Observations
+          </div>
+          <div style={{
+            borderRadius: 8,
+            border: `1px solid ${border}`,
+            overflow: "hidden",
+          }}>
+            <table style={{ width: "100%", fontSize: 12, borderCollapse: "collapse" }}>
+              <thead>
+                <tr style={{ background: dark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.04)" }}>
+                  {["When", "Source IP", "Events", "Flags", "Similarity"].map((h) => (
+                    <th key={h} style={{
+                      padding: "4px 10px",
+                      textAlign: "left",
+                      fontSize: 11,
+                      fontWeight: 600,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.04em",
+                      whiteSpace: "nowrap",
+                      opacity: 0.7,
+                    }}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {recent.map((obs, i) => (
+                  <tr key={obs.id} style={{
+                    borderTop: i > 0 ? `1px solid ${border}` : "none",
+                  }}>
+                    <td style={{ padding: "4px 10px", fontFamily: "monospace", whiteSpace: "nowrap" }}>
+                      {timeAgo(obs.observed_at)}
+                    </td>
+                    <td style={{ padding: "4px 10px", fontFamily: "monospace" }}>{obs.source_ip}</td>
+                    <td style={{ padding: "4px 10px" }}>{obs.event_count ?? "—"}</td>
+                    <td style={{ padding: "4px 10px" }}>
+                      {obs.is_reactivation && (
+                        <span style={{
+                          padding: "1px 6px",
+                          borderRadius: 9999,
+                          fontSize: 10,
+                          fontWeight: 700,
+                          background: "rgba(249,115,22,0.15)",
+                          color: "#f97316",
+                          textTransform: "uppercase",
+                        }}>
+                          reactivation
+                        </span>
+                      )}
+                    </td>
+                    <td style={{ padding: "4px 10px" }}>
+                      <ExplainSummary notes={obs.notes} dark={dark} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Campaigns({ dark }) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [online, setOnline] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const [expandedId, setExpandedId] = useState(null);
+  const [details, setDetails] = useState({});
+  const [detailLoading, setDetailLoading] = useState(null);
+
+  const cardBg = dark ? "#111827" : "#f9fafb";
+  const border = dark ? "#374151" : "#d1d5db";
+  const fg = dark ? "#e5e7eb" : "#111827";
+  const th = {
+    padding: "0.5rem 0.8rem",
+    textAlign: "left",
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: "uppercase",
+    letterSpacing: "0.05em",
+    whiteSpace: "nowrap",
+  };
+  const td = { padding: "0.55rem 0.8rem" };
+
+  async function fetchList() {
+    try {
+      const data = await getCampaigns(Date.now());
+      setItems(data.items ?? []);
+      setOnline(true);
+      setLastUpdated(new Date());
+    } catch (e) {
+      console.error("Campaigns fetch:", e);
+      setOnline(false);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function toggleRow(id) {
+    if (expandedId === id) {
+      setExpandedId(null);
+      return;
+    }
+    setExpandedId(id);
+    if (details[id]) return;
+    setDetailLoading(id);
+    try {
+      const detail = await getCampaignDetail(id);
+      setDetails((prev) => ({ ...prev, [id]: detail }));
+    } catch (e) {
+      console.error("Campaign detail fetch:", e);
+    } finally {
+      setDetailLoading(null);
+    }
+  }
+
+  useEffect(() => {
+    fetchList();
+    const t = setInterval(fetchList, REFRESH_MS);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <div style={{ color: fg }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
+        <h2 style={{ fontSize: 18, fontWeight: 600, margin: 0 }}>Campaigns</h2>
+        <span style={{ fontSize: 12, opacity: 0.6 }}>
+          {online
+            ? lastUpdated
+              ? `Updated ${timeAgo(lastUpdated)}`
+              : "Loading…"
+            : "Offline"}
+        </span>
+      </div>
+
+      <div style={{ borderRadius: 12, border: `1px solid ${border}`, overflow: "hidden", background: cardBg }}>
+        <table style={{ width: "100%", fontSize: 13, borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ background: dark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.04)" }}>
+              <th style={th}>Name</th>
+              <th style={th}>Status</th>
+              <th style={th}>Confidence</th>
+              <th style={th}>Members</th>
+              <th style={th}>Last Seen</th>
+              <th style={th}>Reactivations</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 && !loading && (
+              <tr>
+                <td colSpan={6} style={{ ...td, textAlign: "center", opacity: 0.5 }}>
+                  No campaigns detected yet.
+                </td>
+              </tr>
+            )}
+            {items.map((item, idx) => {
+              const isExpanded = expandedId === item.id;
+              const evenBg = dark ? "rgba(255,255,255,0.03)" : "rgba(0,0,0,0.01)";
+              const oddBg = dark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.04)";
+              const rowBg = idx % 2 === 0 ? evenBg : oddBg;
+              const hoverBg = dark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.09)";
+              const detail = details[item.id];
+
+              return (
+                <Fragment key={item.id}>
+                  <tr
+                    onClick={() => toggleRow(item.id)}
+                    style={{
+                      background: rowBg,
+                      cursor: "pointer",
+                      borderTop: idx > 0 ? `1px solid ${border}` : "none",
+                    }}
+                    onMouseEnter={(e) => (e.currentTarget.style.background = hoverBg)}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = rowBg)}
+                  >
+                    <td style={{ ...td, fontFamily: "monospace", fontWeight: 600 }}>
+                      {item.name}
+                      <span style={{ marginLeft: 6, fontSize: 10, opacity: 0.45 }}>
+                        {isExpanded ? "▲" : "▼"}
+                      </span>
+                    </td>
+                    <td style={td}><StatusBadge status={item.status} /></td>
+                    <td style={td}><ConfidenceBar value={item.confidence} dark={dark} /></td>
+                    <td style={{ ...td, fontFamily: "monospace" }}>{item.member_ip_count ?? "—"}</td>
+                    <td style={{ ...td, fontFamily: "monospace", fontSize: 12 }}>
+                      {item.last_seen ? timeAgo(item.last_seen) : "—"}
+                    </td>
+                    <td style={{ ...td, fontFamily: "monospace" }}>
+                      {item.reactivation_count > 0
+                        ? <span style={{ color: "#f97316", fontWeight: 600 }}>{item.reactivation_count}</span>
+                        : <span style={{ opacity: 0.4 }}>0</span>
+                      }
+                    </td>
+                  </tr>
+                  {isExpanded && (
+                    <tr style={{ borderTop: `1px solid ${border}` }}>
+                      <td colSpan={6} style={{
+                        padding: "14px 16px",
+                        background: dark ? "rgba(99,102,241,0.06)" : "rgba(99,102,241,0.03)",
+                        borderBottom: `1px solid ${border}`,
+                      }}>
+                        {detailLoading === item.id ? (
+                          <span style={{ opacity: 0.5, fontSize: 13 }}>Loading detail…</span>
+                        ) : detail ? (
+                          <CampaignDetail detail={detail} dark={dark} />
+                        ) : (
+                          <span style={{ opacity: 0.5, fontSize: 13 }}>Detail unavailable.</span>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/ui/dashboard/src/lib/api.js
+++ b/ui/dashboard/src/lib/api.js
@@ -33,3 +33,15 @@ export async function getTopASNs(ts = Date.now()) {
   if (!r.ok) throw new Error(`top-asns ${r.status}`);
   return r.json();
 }
+
+export async function getCampaigns(ts = Date.now()) {
+  const r = await fetch(`/api/campaigns?ts=${ts}`, { headers: { 'x-api-key': 'dev-123' } });
+  if (!r.ok) throw new Error(`campaigns ${r.status}`);
+  return r.json();
+}
+
+export async function getCampaignDetail(campaignId) {
+  const r = await fetch(`/api/campaigns/${encodeURIComponent(campaignId)}`, { headers: { 'x-api-key': 'dev-123' } });
+  if (!r.ok) throw new Error(`campaigns/${campaignId} ${r.status}`);
+  return r.json();
+}


### PR DESCRIPTION
## Summary

- **`app/routers/campaigns.py`**: 3 auth-required, thin endpoints — `GET /api/campaigns` (list, sorted `last_seen DESC`, paginated 1–1000), `GET /api/campaigns/{id}` (detail with `members` + `observations` arrays inlined), `GET /api/campaigns/{id}/observations` (observations only); 404 on unknown id
- **`app/db/repositories/campaign.py`**: `list_campaigns(limit)` and `get_campaign_members(campaign_id)` added to `CampaignRepository` mixin; all SQL stays in the repository layer
- **`app/main.py`**: `campaigns_router` registered at `/api/campaigns/*`
- **`ui/dashboard/src/components/Campaigns.jsx`**: campaign table with status badge (color-coded by lifecycle state), confidence bar, member count, last seen, reactivation count; expandable row lazy-fetches detail on first open and shows recent observations with reactivation flags and weighted similarity score parsed from explainability notes
- **`ui/dashboard/src/lib/api.js`**: `getCampaigns()` and `getCampaignDetail()` helpers, same fetch/auth pattern as existing helpers
- **`ui/dashboard/src/App.jsx`**: `<Campaigns>` panel mounted below TopCountries/TopASNs, 30 s auto-refresh

## Deferred

- Campaign editing / manual analyst notes
- Campaign tagging API
- `attack_tactic_dist` / `top_target_ports` population (schema columns exist, values not yet computed)
- Campaign search/filter controls

## Test plan

- [x] `tests/integration/test_campaign_endpoints.py` — 27 tests: empty state, required fields, sort order, limit validation, 404 on unknown id, 401 on missing/wrong credentials for all 3 endpoints
- [x] `python -m pytest --tb=short -q` → 562 passed, 3 skipped
- [x] `pre-commit run --all-files` → all hooks passed
- [x] `eslint src/components/Campaigns.jsx src/lib/api.js src/App.jsx` → 0 errors, 0 warnings