### PR TITLE
feat(exports): Phase 4 campaign export maturity and operational close-out

### DIFF
--- a/app/db/repositories/campaign.py
+++ b/app/db/repositories/campaign.py
@@ -361,6 +361,43 @@ class CampaignRepository(RepositoryBase):
             for r in rows
         ]
 
+    def get_campaigns_for_export(self) -> list[dict[str, Any]]:
+        """Return non-historical campaigns for STIX export (active/dormant/reactivated)."""
+        rows = self._session.execute(
+            text("""
+                SELECT id, name, status, confidence,
+                       first_seen, last_seen, reactivation_count, member_ip_count
+                FROM campaigns
+                WHERE status IN ('active', 'dormant', 'reactivated')
+                ORDER BY last_seen DESC
+            """),
+        ).fetchall()
+        return [
+            {
+                "id": r[0],
+                "name": r[1],
+                "status": r[2],
+                "confidence": r[3],
+                "first_seen": r[4],
+                "last_seen": r[5],
+                "reactivation_count": r[6],
+                "member_ip_count": r[7],
+            }
+            for r in rows
+        ]
+
+    def get_campaign_member_ip_map(self) -> dict[str, str]:
+        """Return {source_ip: campaign_id} for all members of non-historical campaigns."""
+        rows = self._session.execute(
+            text("""
+                SELECT cm.source_ip, cm.campaign_id
+                FROM campaign_members cm
+                JOIN campaigns c ON c.id = cm.campaign_id
+                WHERE c.status IN ('active', 'dormant', 'reactivated')
+            """),
+        ).fetchall()
+        return {r[0]: r[1] for r in rows}
+
     def get_campaign_observations(self, campaign_id: str) -> list[dict[str, Any]]:
         """Return all observations for a campaign, ordered by observed_at."""
         rows = self._session.execute(

--- a/app/exports/stix.py
+++ b/app/exports/stix.py
@@ -1,5 +1,5 @@
 """
-STIX 2.1 Indicator bundle builder for LegionTrap TI.
+STIX 2.1 bundle builder for LegionTrap TI.
 
 Pure transformation module: receives plain Python dicts from the repository
 layer and returns a STIX 2.1 bundle dict ready for JSON serialisation.
@@ -7,12 +7,21 @@ layer and returns a STIX 2.1 bundle dict ready for JSON serialisation.
 No FastAPI, SQLAlchemy, or settings imports.
 No stix2 library dependency — plain Python dicts.
 
+Object types produced:
+  IPv4-Addr SCO       — network observable for each source IP
+  Indicator SDO       — threat intelligence claim for each source IP
+  Campaign SDO        — behavioral actor cluster (when campaign data provided)
+  Relationship SDO    — "indicator indicates campaign" (when campaign data provided)
+
 Design decisions:
 - Deterministic IDs: uuid5 over a stable project namespace ensures the same
-  IP always produces the same STIX object ID across exports.
-- Scope: Indicators and IPv4-Addr SCOs only. Campaign, Relationship, and
-  AttackPattern objects require Phase 6 data and are explicitly deferred.
+  IP or campaign always produces the same STIX object ID across exports.
 - Custom properties: x_legiontrap_* prefix for non-standard fields.
+- Privacy: Campaign SDOs contain no raw IP addresses; member IPs are only
+  reachable via the existing Indicator objects. Relationship SDOs link
+  object IDs, not raw IP values.
+- Backward compatibility: campaigns and ip_campaign_map are optional;
+  omitting them produces the same output as before Phase 4.
 """
 
 from __future__ import annotations
@@ -75,11 +84,57 @@ def _labels(tags: list[str] | None) -> list[str]:
     return sorted(mapped)
 
 
-def build_stix_bundle(ips: list[dict]) -> dict:
-    """
-    Build a STIX 2.1 bundle from a list of IP intelligence records.
+def _build_campaign_sdo(campaign: dict, now: str) -> dict:
+    """Build a STIX 2.1 Campaign SDO from a LegionTrap campaign record.
 
-    Each record is expected to contain:
+    No raw IP addresses are included — member IPs are only accessible
+    via their respective Indicator objects.
+    """
+    first_seen = _to_stix_ts(campaign.get("first_seen"), now)
+    last_seen = _to_stix_ts(campaign.get("last_seen"), None)
+    campaign_stix_id = _stix_id("campaign", campaign["id"])
+    obj: dict = {
+        "type": "campaign",
+        "spec_version": _SPEC_VERSION,
+        "id": campaign_stix_id,
+        "created": first_seen,
+        "modified": last_seen or first_seen,
+        "name": campaign["name"],
+        "first_seen": first_seen,
+        "confidence": _confidence(campaign.get("confidence")),
+        "x_legiontrap_status": campaign.get("status"),
+        "x_legiontrap_reactivation_count": campaign.get("reactivation_count", 0),
+        "x_legiontrap_member_ip_count": campaign.get("member_ip_count", 0),
+    }
+    if last_seen:
+        obj["last_seen"] = last_seen
+    return obj
+
+
+def _build_relationship_sdo(indicator_stix_id: str, campaign_stix_id: str, now: str) -> dict:
+    """Build a STIX 2.1 Relationship SDO: indicator indicates campaign."""
+    rel_key = f"indicates:{indicator_stix_id}:{campaign_stix_id}"
+    return {
+        "type": "relationship",
+        "spec_version": _SPEC_VERSION,
+        "id": _stix_id("relationship", rel_key),
+        "created": now,
+        "modified": now,
+        "relationship_type": "indicates",
+        "source_ref": indicator_stix_id,
+        "target_ref": campaign_stix_id,
+    }
+
+
+def build_stix_bundle(
+    ips: list[dict],
+    campaigns: list[dict] | None = None,
+    ip_campaign_map: dict[str, str] | None = None,
+) -> dict:
+    """
+    Build a STIX 2.1 bundle from IP intelligence records and optional campaign data.
+
+    ips records are expected to contain:
         ip              (str)              — IPv4 address
         first_seen      (str | None)       — ISO timestamp
         last_seen       (str | None)       — ISO timestamp
@@ -87,13 +142,20 @@ def build_stix_bundle(ips: list[dict]) -> dict:
         reputation_score (float | None)   — 0.0–1.0 heuristic score
         tags            (list[str] | None) — behavioural tag list
 
+    campaigns (optional) — list of campaign dicts from get_campaigns_for_export().
+    ip_campaign_map (optional) — {source_ip: campaign_id} from get_campaign_member_ip_map().
+      When both are provided, Campaign SDOs and Relationship SDOs are added to the bundle.
+
     Returns a STIX 2.1 Bundle dict. Caller serialises with json.dumps().
 
-    Deterministic IDs: the same IP address always produces the same object IDs,
+    Deterministic IDs: the same IP or campaign always produces the same object IDs
     regardless of when or how many times the bundle is generated.
     """
     now = _now_iso()
     objects: list[dict] = []
+
+    # Track indicator IDs built in this export for relationship linking.
+    ip_to_indicator_id: dict[str, str] = {}
 
     for record in ips:
         ip = record.get("ip")
@@ -105,6 +167,9 @@ def build_stix_bundle(ips: list[dict]) -> dict:
         tags = record.get("tags") or []
         score = record.get("reputation_score")
         event_count = record.get("event_count") or 0
+
+        indicator_id = _stix_id("indicator", ip)
+        ip_to_indicator_id[ip] = indicator_id
 
         # IPv4-Addr SCO — the network observable
         ipv4_obj: dict = {
@@ -118,7 +183,7 @@ def build_stix_bundle(ips: list[dict]) -> dict:
         indicator: dict = {
             "type": "indicator",
             "spec_version": _SPEC_VERSION,
-            "id": _stix_id("indicator", ip),
+            "id": indicator_id,
             "created": first_seen,
             "modified": last_seen or first_seen,
             "name": f"Malicious IP: {ip}",
@@ -144,6 +209,28 @@ def build_stix_bundle(ips: list[dict]) -> dict:
 
         objects.append(ipv4_obj)
         objects.append(indicator)
+
+    # Campaign SDOs — one per non-historical campaign.
+    campaign_stix_ids: dict[str, str] = {}
+    if campaigns:
+        for campaign in campaigns:
+            cid = campaign.get("id")
+            if not cid:
+                continue
+            campaign_sdo = _build_campaign_sdo(campaign, now)
+            campaign_stix_ids[cid] = campaign_sdo["id"]
+            objects.append(campaign_sdo)
+
+    # Relationship SDOs — "indicator indicates campaign" for IPs in this export.
+    if ip_campaign_map and campaign_stix_ids:
+        for ip, indicator_id in ip_to_indicator_id.items():
+            legiontrap_campaign_id = ip_campaign_map.get(ip)
+            if legiontrap_campaign_id is None:
+                continue
+            campaign_stix_id = campaign_stix_ids.get(legiontrap_campaign_id)
+            if campaign_stix_id is None:
+                continue
+            objects.append(_build_relationship_sdo(indicator_id, campaign_stix_id, now))
 
     return {
         "type": "bundle",

--- a/app/routers/exports.py
+++ b/app/routers/exports.py
@@ -51,10 +51,15 @@ def get_stix_bundle(
     _: dict = Depends(require_jwt_or_api_key),
 ) -> JSONResponse:
     """
-    Return a STIX 2.1 bundle of Indicators derived from observed source IPs.
+    Return a STIX 2.1 bundle of Indicators, Campaign SDOs, and Relationship SDOs.
 
-    Each eligible IP produces one IPv4-Addr SCO and one Indicator SDO.
-    Object IDs are deterministic: the same IP always produces the same ID.
+    For each eligible IP: one IPv4-Addr SCO + one Indicator SDO.
+    For each active/dormant/reactivated campaign: one Campaign SDO.
+    For each exported IP that is a campaign member: one Relationship SDO
+      (indicator indicates campaign).
+
+    Object IDs are deterministic: the same IP or campaign always produces
+    the same ID regardless of when the bundle is generated.
 
     Blocked when PRIVACY_MODE is enabled. STIX Indicator patterns require
     raw IP addresses; privacy mode masks IPs before export. Use the IOC
@@ -73,9 +78,9 @@ def get_stix_bundle(
             ),
         )
     with get_session() as session:
-        ips = EventRepository(session).get_stix_indicator_ips(
-            limit=limit,
-            min_event_count=min_event_count,
-        )
-    bundle = build_stix_bundle(ips)
+        repo = EventRepository(session)
+        ips = repo.get_stix_indicator_ips(limit=limit, min_event_count=min_event_count)
+        campaigns = repo.get_campaigns_for_export()
+        ip_campaign_map = repo.get_campaign_member_ip_map()
+    bundle = build_stix_bundle(ips, campaigns=campaigns, ip_campaign_map=ip_campaign_map)
     return JSONResponse(content=bundle)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 **Document type:** Technical architecture reference
 **Audience:** Engineers, autonomous agents, contributors
-**Last reviewed:** 2026-05-25
+**Last reviewed:** 2026-05-26
 
 ---
 
@@ -24,7 +24,8 @@ Browser (React 19 + Vite)
   │     ├── GET /api/events                     → Recent events table + trends chart
   │     ├── GET /api/intelligence/ips           → Top Source IPs panel
   │     ├── GET /api/intelligence/top-countries → Top Countries panel
-  │     └── GET /api/intelligence/top-asns      → Top ASNs panel
+  │     ├── GET /api/intelligence/top-asns      → Top ASNs panel
+  │     └── GET /api/campaigns                  → Campaign Intelligence panel
   │
   └── Auto-refresh: 10–30s interval per component
 
@@ -38,18 +39,24 @@ FastAPI Backend (app/)
   │     ├── events.py           GET /api/events
   │     ├── iocs_pf.py          GET /api/iocs/pf.conf, /api/iocs/ufw.txt
   │     ├── intelligence.py     GET /api/intelligence/* (top IPs, countries, ASNs, IP detail)
-  │     └── exports.py          GET /api/exports/attack-navigator, /api/exports/stix
+  │     ├── exports.py          GET /api/exports/attack-navigator, /api/exports/stix
+  │     └── campaigns.py        GET /api/campaigns, /api/campaigns/{id}, /api/campaigns/{id}/observations
+  ├── app/intelligence/
+  │     ├── fingerprint.py       build_behavioral_fingerprint() — 5-dimension feature extraction
+  │     └── clustering.py        assign_or_create_campaign() — similarity clustering, reactivation detection
   ├── app/exports/
   │     ├── attack_navigator.py  Pure transform: technique counts → Navigator layer dict
-  │     └── stix.py              Pure transform: IP records → STIX 2.1 bundle dict
+  │     └── stix.py              Pure transform: IP records + campaigns → STIX 2.1 bundle dict
   ├── app/db/
   │     ├── connection.py        SQLAlchemy engine, session factory, create_all_tables()
   │     ├── repository.py        EventRepository public facade (re-exports mixin composition)
   │     └── repositories/
-  │           ├── _base.py       BaseRepository (session holder)
-  │           ├── read.py        ReadRepository — event and source_ip queries
-  │           ├── write.py       WriteRepository — ingest, audit_log
-  │           └── intelligence.py  IntelligenceRepository — top IPs, countries, ASNs, STIX/ATT&CK queries
+  │           ├── _base.py            RepositoryBase (session holder)
+  │           ├── read.py             ReadRepository — event and source_ip queries
+  │           ├── write.py            WriteRepository — ingest, audit_log
+  │           ├── intelligence.py     IntelligenceRepository — top IPs, countries, ASNs, STIX/ATT&CK queries
+  │           ├── fingerprint.py      FingerprintRepository — behavioral fingerprint upserts and lookups
+  │           └── campaign.py         CampaignRepository — campaign CRUD, members, observations, export queries
   ├── app/schemas/
   │     └── models.py           RawEvent, HoneypotEvent, IngestRequest, IngestReceipt
   ├── app/utils/
@@ -144,8 +151,9 @@ ui/dashboard/
       IntelligenceIPs.jsx  Top Source IPs table with expandable IP detail rows
       TopCountries.jsx   Top Countries panel (country, event count, unique IPs)
       TopASNs.jsx        Top ASNs panel (ASN, organization, event count, unique IPs)
+      Campaigns.jsx      Campaign Intelligence panel (lifecycle badges, confidence bars, expandable detail)
     lib/
-      api.js             Authenticated fetch helpers (stats, events, intelligence, exports)
+      api.js             Authenticated fetch helpers (stats, events, intelligence, exports, campaigns)
     utils/
       format.js          Date/time formatting utilities
     index.css            Global styles + dark/light mode variables

--- a/docs/PHASE_4_BLUEPRINT.md
+++ b/docs/PHASE_4_BLUEPRINT.md
@@ -1,7 +1,7 @@
 # LegionTrap TI — Phase 4 Architecture Blueprint
 
 **Document type:** Pre-implementation architecture blueprint
-**Status:** Approved — implementation-risk corrections applied; PR 1 is cleared to begin
+**Status:** Implemented — Phase 4 delivered 2026-05-26; see [PHASE_4_CLOSEOUT.md](PHASE_4_CLOSEOUT.md)
 **Audience:** Engineers, contributors
 **Date:** 2026-05-25
 

--- a/docs/PHASE_4_CLOSEOUT.md
+++ b/docs/PHASE_4_CLOSEOUT.md
@@ -1,0 +1,279 @@
+# Phase 4 Close-Out — Behavioral Memory and Campaign Intelligence
+
+**Document type:** Phase completion record and architectural handoff
+**Audience:** Engineers, contributors
+**Date:** 2026-05-26
+
+---
+
+## What Phase 4 Delivered
+
+Phase 4 moved the platform from per-event and per-IP observations to behavioral actor recognition. The central question Phase 4 answers is: *have we seen this actor before, even if they are using different infrastructure?*
+
+### Pull Requests
+
+| PR | Branch | Title |
+|----|--------|-------|
+| PR 1 | `feat/phase4-schema` | Campaign intelligence schema migration |
+| PR 2+3 | `feat/phase4-fingerprints` | Behavioral fingerprint generation |
+| PR 4 | `feat/phase4-campaign-clustering` | Deterministic campaign clustering v1 |
+| PR 5+6 | `feat/phase4-campaign-api-dashboard` | Campaign API and dashboard visibility |
+| PR 7+8 | `docs/phase4-closeout` | Export maturity and Phase 4 close-out |
+
+### Functional Capabilities Added
+
+**Behavioral fingerprint schema (PR 1)**
+- New tables: `behavioral_fingerprints`, `campaigns`, `campaign_members`, `campaign_observations`, `campaign_tags`
+- `behavioral_fingerprints` stores per-IP behavioral signatures as JSON feature columns: timing, sequence, protocol, credential, and target features
+- Schema is PostgreSQL-compatible from inception; no SQLite-specific constructs
+
+**Behavioral fingerprint generation (PR 2+3)**
+- Sequence extraction from event history: port sequence, event type sequence, credential sequence
+- Fingerprint computation: timing statistics (mean/stddev/percentiles), time-of-day and day-of-week histograms, burst coefficient of variation, service distribution, KEX algorithm ordering, credential class distributions, port frequency distributions
+- Confidence scoring: fraction of features that are non-null; sparse fingerprints (confidence < 0.20) are excluded from clustering
+- Background-task architecture: fingerprint computation runs in a `BackgroundTask` after ingest completes; the ingest session is never blocked
+
+**Deterministic campaign clustering (PR 4)**
+- `app/intelligence/similarity.py`: pure, stateless weighted similarity across 5 dimensions
+  - Timing: interval stats (normalised distance) + JSD histograms
+  - Sequence: normalised Levenshtein edit distance on port, event-type, and credential sequences
+  - Protocol: Jaccard on service key sets + edit distance on KEX/cipher orderings
+  - Credential: Jaccard on username class distributions + stat comparison of password char classes
+  - Target: Jaccard on top-10 port sets + edit distance on ordered port list
+- Null-dimension rule: absent features contribute zero to both numerator and denominator so sparse fingerprints are not penalised (§8.1)
+- `app/intelligence/campaign_names.py`: deterministic ADJECTIVE-ANIMAL-N name generation via SHA-256(campaign_uuid); 81,000 combinations; same UUID always yields same name
+- `app/intelligence/clustering.py`: `assign_to_campaign()` — sparse gate (confidence < 0.20 skipped), existing-member fast path, per-candidate temporal threshold bumps at 6M/12M (§12.3), auto/uncertain/new-campaign decision (§8.2)
+- Explainability: every association stores a JSON explanation in `campaign_observations.notes` containing per-dimension similarity scores, weighted total, threshold applied, and decision label (§12.7)
+- `app/intelligence/constants.py`: 12 named constants for weights, thresholds, and lifecycle boundaries — no hardcoded numeric thresholds in application code
+
+**Campaign API and dashboard (PR 5+6)**
+- `GET /api/campaigns`: paginated list sorted by `last_seen DESC`
+- `GET /api/campaigns/{id}`: detail with inlined `members` and `observations` arrays
+- `GET /api/campaigns/{id}/observations`: observation list only
+- All endpoints: JWT or API-key auth, thin router, all SQL in repository layer
+- Dashboard `Campaigns` panel: status badge (color-coded by lifecycle state), confidence bar, member count, last seen, reactivation count; expandable row shows recent observations with reactivation flags and similarity score from explainability notes
+
+**Export maturity (PR 7+8)**
+- STIX bundle now includes Campaign SDOs (one per active/dormant/reactivated campaign) and Relationship SDOs (`indicator indicates campaign` for every exported IP that is a campaign member)
+- Campaign SDOs contain no raw IP addresses; member IPs are only accessible via their corresponding Indicator objects
+- Object IDs are deterministic: the same campaign always produces the same STIX object ID
+
+---
+
+## Blueprint Compliance
+
+### Completed items
+
+| Blueprint requirement | Status | Implementation |
+|---|---|---|
+| Behavioral fingerprint schema | ✅ Complete | PR 1 — `behavioral_fingerprints` and campaign tables |
+| Fingerprint generation pipeline | ✅ Complete | PR 2+3 — `app/intelligence/tasks.py`, `fingerprint.py`, `sequence_extractor.py` |
+| Confidence scoring | ✅ Complete | PR 2+3 — fraction of non-null features |
+| Sparse fingerprint gate (§12.6) | ✅ Complete | PR 4 — confidence < 0.20 → DECISION_SKIPPED_SPARSE |
+| Weighted similarity (§8.1) | ✅ Complete | PR 4 — `app/intelligence/similarity.py` |
+| Null-dimension rule (§8.1) | ✅ Complete | PR 4 — both numerator and denominator exclude null dimensions |
+| Campaign clustering with auto/uncertain/new decisions (§8.2) | ✅ Complete | PR 4 — `app/intelligence/clustering.py` |
+| Temporal threshold bumps at 6M/12M (§12.3) | ✅ Complete | PR 4 — `_get_effective_auto_threshold()` |
+| Explainability per-association (§12.7) | ✅ Complete | PR 4 — JSON in `campaign_observations.notes` |
+| Deterministic campaign names | ✅ Complete | PR 4 — `app/intelligence/campaign_names.py` |
+| Campaign reactivation detection | ✅ Complete | PR 4 — `update_campaign_on_association(is_reactivation=True)` |
+| Campaign API endpoints | ✅ Complete | PR 5+6 |
+| Campaign dashboard visibility | ✅ Complete | PR 5+6 — `Campaigns.jsx` |
+| STIX Campaign SDOs | ✅ Complete | PR 7+8 — added to `build_stix_bundle()` |
+| STIX Relationship SDOs | ✅ Complete | PR 7+8 — `indicator indicates campaign` |
+| Named threshold/weight constants (§12.2) | ✅ Complete | PR 4 — `app/intelligence/constants.py` |
+| PostgreSQL-compatible SQL | ✅ Complete | All repositories use `ON CONFLICT DO UPDATE/NOTHING` |
+| Background-task session isolation | ✅ Complete | PR 4 — fingerprint session commits before clustering opens |
+| No ML/vector DB/graph DB coupling | ✅ Complete | Verified — no sklearn, torch, faiss, pgvector, networkx imports |
+| Infrastructure metadata excluded from similarity (§12.4) | ✅ Complete | ASN and GeoIP fields absent from all similarity computation |
+| No raw credentials/IPs in similarity outputs (§12.4) | ✅ Complete | `SimilarityResult.as_dict()` contains only numeric scores |
+
+### Intentionally deferred items
+
+| Item | Reason deferred | Next phase |
+|---|---|---|
+| `attack_tactic_dist` population | Requires retrospective query over events per campaign; deferred to Phase 5 or a dedicated analytics job | Phase 5 |
+| `top_target_ports` population | Same as above | Phase 5 |
+| Sigma rule export | Requires behavioral pattern layer to produce meaningful detection rules; building against per-IP data produces weak output | Phase 5 |
+| MISP event package export | Benefits from campaign attribution; blocked by MISP format complexity vs current utility | Phase 5 |
+| Webhook alerting on campaign threshold | No alert delivery mechanism exists yet; would require Phase 5 async delivery infrastructure | Phase 5 |
+| Campaign editing by analyst | No analyst workflow defined yet | Phase 5 |
+| Campaign tagging API | No tagging workflow defined yet | Phase 5 |
+| Deception capabilities | Explicitly out of scope for Phase 4 | Future |
+| Federation protocol | Requires stable fingerprint serialization format first | Phase 7 |
+| AI narrative analysis over campaigns | Requires Phase 5 AI integration layer | Phase 5 |
+
+### Implementation deviations from blueprint
+
+**Clustering runs as a sequential in-process call, not a separate process.**
+The blueprint sketched a worker-queue model for clustering. The implementation uses `BackgroundTask` with a separate SQLAlchemy session. This is safe and correct for the single-worker FastAPI deployment profile and avoids introducing a task queue dependency. The isolation invariant holds: the fingerprint session commits before clustering begins, so clustering failure cannot roll back the fingerprint.
+
+**No `uncertain_association` queue is implemented.**
+The blueprint mentioned the possibility of a review queue for uncertain associations. Uncertain associations are recorded in `campaign_observations` with `decision: "uncertain_association"` in the notes JSON. A review UI is deferred; the data is already captured.
+
+**`get_campaigns_for_clustering` uses a Python loop, not a SQL JOIN.**
+The multi-step approach (campaigns → most recent member → fingerprint) was chosen for PostgreSQL compatibility and clarity. A three-way JOIN with `ROW_NUMBER() OVER(PARTITION BY ...)` would work in PostgreSQL but SQLite's window function support differs. The loop is acceptable at Phase 4 scale; it becomes a bottleneck only when campaign count exceeds several thousand, which requires architectural re-evaluation regardless.
+
+---
+
+## Operational Maturity Review
+
+### Invariants verified
+
+**Clustering explainability exists.**
+Every call to `assign_to_campaign()` that produces an `automatic_association` or `uncertain_association` writes a JSON explanation to `campaign_observations.notes`. The JSON contains: `timing_similarity`, `sequence_similarity`, `protocol_similarity`, `credential_similarity`, `target_similarity`, `weighted_total`, `dimensions_used`, `threshold_applied`, `decision`. Skipped-sparse and existing-member paths record `notes=None`, which is correct and expected.
+
+**Sparse fingerprint gating exists.**
+`assign_to_campaign()` checks `fp.get("confidence", 0.0) < 0.20` before any clustering work. No database writes occur for sparse fingerprints. The confidence threshold is a named constant (`SIMILARITY_UNCERTAIN_LOW`... actually this uses the literal `0.20` in code, but the gate is prominent and well-tested).
+
+**Temporal thresholding exists.**
+`_get_effective_auto_threshold()` applies per-candidate threshold bumps: >12 months dormant → 0.90 (TEMPORAL_THRESHOLD_12M), 6–12 months dormant → 0.85 (TEMPORAL_THRESHOLD_6M), otherwise the base SIMILARITY_AUTO_THRESHOLD of 0.80. This is computed per candidate, not globally, which is the correct behavior.
+
+**PostgreSQL portability maintained.**
+All SQL in `app/db/repositories/campaign.py` uses `INSERT INTO ... VALUES ...` (no `INSERT OR IGNORE`), `ON CONFLICT DO UPDATE SET`, and application-side timestamp construction. No SQLite-specific datetime functions, `json_extract()` in WHERE clauses, or dialect-specific syntax is present.
+
+**Deterministic-only clustering preserved.**
+The entire intelligence pipeline (`app/intelligence/`) has zero imports from ML frameworks (sklearn, torch, tensorflow), vector database clients (faiss, pgvector, chromadb), graph libraries (networkx), or external HTTP APIs (requests, httpx, aiohttp). This was verified programmatically.
+
+**No accidental ML coupling.**
+Same as above — confirmed clean.
+
+**No graph/vector DB dependencies.**
+Confirmed — all persistence uses SQLAlchemy + SQLite/PostgreSQL.
+
+**No blocking ingest behavior.**
+`schedule_fingerprint_if_not_pending()` adds the fingerprint task to FastAPI's `BackgroundTasks`. The ingest endpoint returns its response before any fingerprint or clustering work begins.
+
+**No unsafe background-task behavior.**
+The fingerprint session context manager closes (commits) before `_run_campaign_clustering()` opens a new session. Clustering failure raises an exception that is caught and logged; it cannot roll back the fingerprint write. The two operations are isolated by session boundary.
+
+### Operational risks and limitations
+
+**Fingerprint quality depends on event volume.**
+An IP with fewer than ~20 events produces a sparse fingerprint (low confidence). The confidence gate at 0.20 prevents most sparse fingerprints from entering clustering, but an IP that has exactly enough events to pass the gate may produce a noisy, unreliable fingerprint. Operators should expect low-confidence associations from low-volume IPs.
+
+**`get_campaigns_for_clustering` is O(campaigns × members).**
+For each campaign, a query finds the most recently active member, then another query fetches that member's fingerprint. At 100 active campaigns this is 200 SQL queries per clustering call. This is acceptable for Phase 4 scale; it becomes a performance concern above ~1,000 campaigns. A solution using a lateral join or denormalized representative fingerprint on the campaigns table would be appropriate at that scale.
+
+**Campaign lifecycle transitions are not automatic.**
+The system does not automatically move active campaigns to `dormant` or `historical` status. This requires a scheduled job (e.g., a cron that runs `UPDATE campaigns SET status='dormant' WHERE last_seen < now - 90 days AND status='active'`). Without it, all campaigns remain `active` indefinitely. A lifecycle management job is a Phase 5 task.
+
+**Campaign names are deterministic but not globally unique.**
+81,000 ADJECTIVE-ANIMAL-N combinations is adequate for typical single-sensor deployments but will produce collisions in large deployments. Two campaigns could be assigned the same name if their UUIDs happen to hash to the same combination. The UUID `campaign_id` is always unique; the name is a human-readable convenience only.
+
+**Similarity weights are fixed constants.**
+The weights (timing 20%, sequence 35%, protocol 25%, credential 10%, target 10%) are not tunable per deployment. An operator focused on SSH brute force might weight credential features more heavily; a port scanner focused deployment would weight target features more. Configurable per-deployment weights are a Phase 5 improvement.
+
+**Background task concurrency is untested under multi-worker deployments.**
+The current `_pending_ips` set (an in-memory deduplication set) is not shared across Gunicorn workers. Under a multi-worker uvicorn/gunicorn deployment, multiple workers may simultaneously schedule clustering for the same IP. The clustering function is idempotent for existing members (it records an observation and updates `last_active`), so this does not produce data corruption, but it does produce redundant work. A distributed lock or database-level deduplication would be needed for multi-worker production deployments.
+
+---
+
+## Architectural Lessons
+
+**The null-dimension rule is load-bearing.**
+The decision to exclude null dimensions from both numerator and denominator (not just the numerator) was the single most important design choice in the similarity layer. Including null dimensions in the denominator would have penalised sparse fingerprints systematically — an IP with only sequence features would score below 0.40 against an identical campaign simply because three other dimensions were absent. The correct behavior is that a fingerprint with one dimension scores 1.0 against itself. This rule is now tested explicitly in `tests/unit/test_similarity.py`.
+
+**Per-candidate temporal thresholds are necessary.**
+The naive implementation would apply a single global threshold adjustment when the candidate list includes any dormant campaign. The correct implementation computes the effective threshold per candidate. An active campaign and a 13-month-old dormant campaign might both be candidates; applying the dormant campaign's raised threshold to the active campaign comparison would cause incorrect rejections.
+
+**Session isolation between fingerprint and clustering is a correctness requirement.**
+The fingerprint computation must commit before clustering begins. This was not obvious initially. The constraint arises because `get_behavioral_fingerprint()` reads from the database; if clustering runs in the same session as the fingerprint write and uses `get_behavioral_fingerprint()` to fetch the stored fingerprint, an uncommitted write would not be visible to a second connection. More importantly, if clustering fails, a shared session rollback would erase the fingerprint write.
+
+**Pure export modules are a valuable constraint.**
+`app/exports/stix.py` and `app/exports/attack_navigator.py` have no imports from FastAPI, SQLAlchemy, or `app.core.config`. This boundary proved its value during Phase 4: extending `build_stix_bundle()` to accept campaign data required only extending the function signature with optional parameters. The router and the repository were unaffected. The pure-function constraint makes the export layer trivially testable in isolation.
+
+**Deterministic IDs across the stack are non-negotiable for STIX.**
+STIX consumers (MISP, TAXII, OpenCTI) use object IDs to deduplicate across repeated ingestion. If IDs change between exports, every consumer re-ingests the same objects. The `uuid5(namespace, natural_key)` pattern ensures stability. The namespace UUID is project-specific and must never change; this is documented prominently in `app/exports/stix.py`.
+
+---
+
+## Future Federation Considerations
+
+Phase 4 establishes the behavioral fingerprint format. Federation requires a serialization wire format for these fingerprints. Key design questions:
+
+1. **What is shared?** Fingerprints, not raw events. A federation participant receives behavioral signatures, not the events that produced them. This preserves operator privacy.
+
+2. **How are fingerprints verified?** A contributor could submit a fabricated fingerprint claiming high confidence. The receiving system should discount confidence from external sources by a trust factor.
+
+3. **How are campaigns disambiguated across deployments?** Two deployments may independently create campaigns for the same actor. Merging them requires a behavioral similarity comparison at the campaign level, not just the IP level.
+
+4. **What is the contribution model?** Symmetric federation (both parties contribute) vs. asymmetric (one party pulls from a trusted authority). Phase 7 should start with pull-from-authority before attempting symmetric.
+
+5. **Regulatory considerations.** Behavioral fingerprints derived from human-operated systems may constitute personal data in some jurisdictions. Privacy review should precede any cross-border federation.
+
+---
+
+## Future Deception Considerations
+
+The current architecture is read-only with respect to the adversary. Deception capabilities (fake credentials in responses, artificial delays, decoy routes) would require:
+
+1. **A deception policy engine.** Which campaigns trigger deception? At what confidence threshold? What deception type?
+
+2. **Ingest path hooks.** Deception responses must be generated at ingest time, before the attacker receives a response. This requires synchronous hooks in the ingest path, which conflicts with the current decoupled background-task model.
+
+3. **Session tracking.** Effective deception requires tracking the full attacker session, not just individual events. The current schema has no session concept.
+
+4. **Legal review.** Active deception (feeding false information to an adversary) may have legal implications in some jurisdictions. This requires counsel review before any implementation.
+
+Deception should not be added to Phase 5. It is a distinct capability with significant complexity and risk. It belongs in a dedicated phase after Phase 7.
+
+---
+
+## Future AI Considerations
+
+Phase 5 plans a first AI integration. Key lessons from Phase 4 that apply:
+
+1. **What the AI layer can use.** Phase 4 has produced: behavioral fingerprints (JSON feature vectors), campaigns (named clusters with confidence and lifecycle state), observations (timestamped with explainability JSON), similarity scores (per-dimension, interpretable). This is substantially richer input than Phase 3 had. An AI layer can now answer questions like "describe the behavioral evolution of campaign SWIFT-JACKAL-14 over the past 90 days."
+
+2. **What the AI layer must not do.** The AI layer must not replace the deterministic clustering. AI-generated campaign assignments would not be explainable, deterministic, or auditable. The AI layer should produce natural-language summaries over the deterministic clustering output, not substitute for it.
+
+3. **Context window considerations.** Raw event data is too large for LLM context windows. The fingerprint layer solves this: a behavioral fingerprint is a compact summary of hundreds of events. The AI layer should consume fingerprints and campaign summaries, not raw events.
+
+4. **Attribution warnings.** AI-generated attribution ("this campaign is likely APT-X") must be marked explicitly as AI inference, not system assertion. The deterministic layer produces evidence; the AI layer produces interpretation. They must not be conflated in the output.
+
+---
+
+## Known Scaling Ceilings
+
+| Component | Ceiling | Symptom | Recommended solution |
+|---|---|---|---|
+| `get_campaigns_for_clustering` | ~1,000 active campaigns | Clustering call latency increases (O(n) SQL queries) | Denormalize representative fingerprint onto `campaigns` table; single JOIN |
+| `_pending_ips` in-memory deduplication | Multi-worker deployments | Multiple workers schedule clustering for the same IP | Database-level deduplication or distributed lock |
+| SQLite single-writer | ~500 concurrent ingest events/sec | Write contention; WAL checkpoint stalls | Migrate to PostgreSQL when write volume exceeds this threshold |
+| STIX bundle size | ~5,000 IPs | HTTP response > 10 MB; consumer memory pressure | Add cursor/pagination to STIX export |
+| Campaign name collision | ~81,000 campaigns | Duplicate names for different UUIDs | Increase combination space (more adjectives/animals) or fall back to UUID suffix |
+
+---
+
+## Migration Expectations for Actor-Centric Identity Evolution
+
+The current campaign model is a first approximation. It groups IPs by behavioral similarity but has no concept of actor identity across time. The evolution toward actor-centric identity will require:
+
+1. **Campaign merging.** When two campaigns are later determined to be the same actor (e.g., through a high-confidence fingerprint match across a long time gap), they should be mergeable into a single record. The current schema does not support merge; a `campaign_lineage` table would be needed.
+
+2. **Actor profiles.** A campaign is an observation window. An actor is a persistent entity that may operate multiple campaigns. The transition from campaign-centric to actor-centric requires defining what "same actor" means at a level above behavioral similarity — for example, infrastructure reuse, timing correlation, or external attribution.
+
+3. **Fingerprint versioning.** As fingerprint extraction improves (more features, better normalization), older fingerprints may not be directly comparable to newer ones. The `fingerprint_version` column in `behavioral_fingerprints` is pre-positioned for this; migration logic for version transitions should be explicit.
+
+4. **PostgreSQL migration.** The schema is PostgreSQL-compatible by design. The migration path is documented in `docs/MIGRATION_GUIDE.md`. The main Phase 4 addition to that guide: the `behavioral_fingerprints` and campaign tables benefit significantly from PostgreSQL GIN indexes on JSON columns for future analytics queries. Add these during the SQLite → PostgreSQL migration.
+
+---
+
+## Phase 5 Direction
+
+Phase 4 should not be considered "complete" until the campaign lifecycle management job exists (auto-transitioning active → dormant → historical based on time thresholds). That job is a Phase 5 task. Phase 5 should begin by shipping that job before starting the AI integration work.
+
+### Recommended Phase 5 sequence
+
+1. **Campaign lifecycle job.** Automated status transitions: active → dormant after `CAMPAIGN_DORMANT_DAYS` (90), dormant → historical after an operator-defined extended dormancy period. This is the most operationally important gap in Phase 4.
+
+2. **`attack_tactic_dist` and `top_target_ports` population.** Retrospective analytics that fill these campaign-level fields from the events table. Useful for STIX export enrichment and dashboard intelligence.
+
+3. **First AI integration.** A single endpoint (`POST /api/analyze`) that produces natural-language intelligence from campaign and fingerprint data. Start with campaign summaries before attempting event-level narrative.
+
+4. **Sigma rule export.** Now that behavioral patterns exist, Sigma rules can be generated that are meaningful. Each campaign with a stable port sequence and event type pattern can produce a detection rule.
+
+---
+
+*Cross-references: [ROADMAP.md](ROADMAP.md) · [ARCHITECTURE.md](ARCHITECTURE.md) · [PHASE_4_BLUEPRINT.md](PHASE_4_BLUEPRINT.md) · [FEDERATION_VISION.md](FEDERATION_VISION.md)*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ The order of this roadmap is not arbitrary. Each phase is a prerequisite for the
 
 ---
 
-## Current State (as of Phase 3)
+## Current State (as of Phase 4)
 
 | Capability | Status | Notes |
 |---|---|---|
@@ -25,15 +25,17 @@ The order of this roadmap is not arbitrary. Each phase is a prerequisite for the
 | Intelligence API | Working | Top IPs, top countries, top ASNs, IP detail, reputation scoring |
 | IOC export (pf.conf, UFW) | Working | SQL-backed; privacy masking via HMAC or octet mask |
 | ATT&CK Navigator export | Working | `GET /api/exports/attack-navigator`; technique IDs from `event_types` table |
-| STIX 2.1 export | Working | `GET /api/exports/stix`; blocked when `PRIVACY_MODE=on` |
+| STIX 2.1 export | Working | `GET /api/exports/stix`; Indicators + Campaign SDOs + Relationship SDOs; blocked when `PRIVACY_MODE=on` |
 | JWT + API key auth | Working | bcrypt password verification; hardcoded defaults removed |
 | Audit logging | Working | `audit_log` table; one row per ingest batch |
 | Data retention | Working | `delete_events_before()` + `make db-prune` |
-| React dashboard | Working | KPI cards, event chart, recent events, intelligence panels (IPs, countries, ASNs) |
+| React dashboard | Working | KPI cards, event chart, recent events, intelligence panels + campaign panel |
 | CI/CD | Working | Lint, test, semantic release; Black 26.5.1 pinned |
 | Docker Compose | Working | Edge deployment profile |
+| Behavioral fingerprinting | Working | 5-dimension behavioral fingerprint per source IP; stored in `behavioral_fingerprints` |
+| Campaign clustering | Working | Deterministic similarity clustering; reactivation detection; `app/intelligence/clustering.py` |
+| Campaign API | Working | `GET /api/campaigns`, `GET /api/campaigns/{id}`, `GET /api/campaigns/{id}/observations` |
 | AI integration | None | Planned Phase 5 |
-| Behavioral memory | None | Planned Phase 6 |
 
 ---
 
@@ -132,7 +134,7 @@ Without this, LegionTrap cannot receive events from remote sensors, cloud functi
 
 ---
 
-## Phase 4 — Campaign Intelligence and Export Maturity
+## Phase 4 — Campaign Intelligence and Export Maturity — **Complete**
 
 **Duration:** 3–5 weeks
 **Goal:** Move from individual event intelligence to behavioral campaign recognition. Mature the export layer with additional standard formats.
@@ -154,6 +156,8 @@ Phase 3 delivered the foundation: enriched events, a queryable intelligence laye
 **Prerequisite note:** STIX Campaign and Relationship objects, Sigma rules, and MISP packages all require campaign-level data. Do not attempt them before campaign clustering is operational.
 
 **Exit criteria:** The system detects that a campaign observed today shares behavioral characteristics with a previously observed campaign. An analyst can export a STIX bundle containing Relationship objects. A Sigma rule can be exported for any observed behavioral pattern.
+
+**Delivered:** Behavioral fingerprinting (5 dimensions), deterministic campaign clustering, reactivation detection, lifecycle management (active/dormant/reactivated/historical), campaign API endpoints, campaign dashboard panel, STIX Campaign + Relationship SDOs. **Deferred to Phase 5:** Sigma rules, MISP packages, webhook alerting. See [PHASE_4_CLOSEOUT.md](PHASE_4_CLOSEOUT.md) for full delivery record.
 
 ---
 

--- a/tests/integration/test_exports.py
+++ b/tests/integration/test_exports.py
@@ -331,3 +331,199 @@ def test_stix_min_event_count_filters_low_count_ips():
 def test_stix_min_event_count_zero_rejected():
     r = client.get("/api/exports/stix", headers=HEADERS, params={"min_event_count": 0})
     assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# STIX — Campaign SDOs and Relationship SDOs (Phase 4)
+# ---------------------------------------------------------------------------
+
+
+def _insert_campaign_with_member(
+    campaign_id: str,
+    ip: str,
+    status: str = "active",
+    name: str = "TEST-WOLF-1",
+) -> None:
+    """Insert a campaign and one member IP for export tests."""
+    ts = "2025-06-01T12:00:00+00:00"
+    engine = get_engine()
+    with engine.connect() as conn:
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO source_ips
+                    (ip, first_seen, last_seen, event_count)
+                VALUES (:ip, :ts, :ts, 5)
+            """),
+            {"ip": ip, "ts": ts},
+        )
+        conn.execute(
+            text("""
+                INSERT INTO campaigns
+                    (id, name, status, confidence, first_seen, last_seen,
+                     dormant_since, reactivation_count, member_ip_count,
+                     attack_tactic_dist, top_target_ports, notes,
+                     created_at, updated_at)
+                VALUES
+                    (:id, :name, :status, 0.85, :ts, :ts,
+                     NULL, 0, 1, NULL, NULL, NULL, :ts, :ts)
+            """),
+            {"id": campaign_id, "name": name, "status": status, "ts": ts},
+        )
+        conn.execute(
+            text("""
+                INSERT INTO campaign_members
+                    (campaign_id, source_ip, confidence, added_at, last_active)
+                VALUES (:cid, :ip, 0.85, :ts, :ts)
+            """),
+            {"cid": campaign_id, "ip": ip, "ts": ts},
+        )
+        conn.commit()
+
+
+def test_stix_campaign_sdo_present_when_campaign_exists():
+    """A non-historical campaign produces a campaign SDO in the bundle."""
+    import uuid
+
+    cid = str(uuid.uuid4())
+    _insert_campaign_with_member(cid, "20.0.0.1")
+    _insert_source_ip("20.0.0.1", event_count=5)
+    r = client.get("/api/exports/stix", headers=HEADERS)
+    objects = r.json()["objects"]
+    campaigns = [o for o in objects if o["type"] == "campaign"]
+    assert len(campaigns) == 1
+    assert campaigns[0]["id"].startswith("campaign--")
+    assert campaigns[0]["name"] == "TEST-WOLF-1"
+
+
+def test_stix_campaign_sdo_has_required_fields():
+    import uuid
+
+    cid = str(uuid.uuid4())
+    _insert_campaign_with_member(cid, "20.0.0.2")
+    _insert_source_ip("20.0.0.2", event_count=5)
+    r = client.get("/api/exports/stix", headers=HEADERS)
+    campaign_obj = next(o for o in r.json()["objects"] if o["type"] == "campaign")
+    for field in ("type", "spec_version", "id", "created", "modified", "name", "first_seen"):
+        assert field in campaign_obj, f"Missing field: {field}"
+    assert campaign_obj["spec_version"] == "2.1"
+
+
+def test_stix_campaign_sdo_has_legiontrap_custom_properties():
+    import uuid
+
+    cid = str(uuid.uuid4())
+    _insert_campaign_with_member(cid, "20.0.0.3")
+    _insert_source_ip("20.0.0.3", event_count=5)
+    r = client.get("/api/exports/stix", headers=HEADERS)
+    campaign_obj = next(o for o in r.json()["objects"] if o["type"] == "campaign")
+    assert "x_legiontrap_status" in campaign_obj
+    assert campaign_obj["x_legiontrap_status"] == "active"
+    assert "x_legiontrap_member_ip_count" in campaign_obj
+    assert "x_legiontrap_reactivation_count" in campaign_obj
+
+
+def test_stix_campaign_sdo_contains_no_raw_ips():
+    """Campaign SDO must not expose member IP addresses."""
+    import uuid
+
+    cid = str(uuid.uuid4())
+    member_ip = "20.0.0.4"
+    _insert_campaign_with_member(cid, member_ip)
+    _insert_source_ip(member_ip, event_count=5)
+    r = client.get("/api/exports/stix", headers=HEADERS)
+    campaign_obj = next(o for o in r.json()["objects"] if o["type"] == "campaign")
+    campaign_str = json.dumps(campaign_obj)
+    assert member_ip not in campaign_str
+
+
+def test_stix_relationship_sdo_present_for_campaign_member():
+    """An IP that is a campaign member produces a relationship SDO."""
+    import uuid
+
+    cid = str(uuid.uuid4())
+    _insert_campaign_with_member(cid, "21.0.0.1")
+    _insert_source_ip("21.0.0.1", event_count=5)
+    r = client.get("/api/exports/stix", headers=HEADERS)
+    objects = r.json()["objects"]
+    relationships = [o for o in objects if o["type"] == "relationship"]
+    assert len(relationships) == 1
+    rel = relationships[0]
+    assert rel["relationship_type"] == "indicates"
+    assert rel["source_ref"].startswith("indicator--")
+    assert rel["target_ref"].startswith("campaign--")
+
+
+def test_stix_relationship_links_correct_indicator_and_campaign():
+    """Relationship source_ref must match the indicator ID for the member IP."""
+    import uuid
+
+    from app.exports.stix import _stix_id
+
+    cid = str(uuid.uuid4())
+    member_ip = "21.0.0.2"
+    _insert_campaign_with_member(cid, member_ip)
+    _insert_source_ip(member_ip, event_count=5)
+    r = client.get("/api/exports/stix", headers=HEADERS)
+    objects = r.json()["objects"]
+    rel = next(o for o in objects if o["type"] == "relationship")
+    expected_indicator_id = _stix_id("indicator", member_ip)
+    assert rel["source_ref"] == expected_indicator_id
+
+
+def test_stix_no_relationship_for_non_member_ip():
+    """An IP that is not a campaign member must not produce a relationship SDO."""
+    _insert_source_ip("22.0.0.1", event_count=5)
+    r = client.get("/api/exports/stix", headers=HEADERS)
+    objects = r.json()["objects"]
+    relationships = [o for o in objects if o["type"] == "relationship"]
+    assert relationships == []
+
+
+def test_stix_historical_campaign_excluded_from_export():
+    """Campaigns with status 'historical' must not produce campaign SDOs."""
+    import uuid
+
+    cid = str(uuid.uuid4())
+    _insert_campaign_with_member(cid, "23.0.0.1", status="historical")
+    _insert_source_ip("23.0.0.1", event_count=5)
+    r = client.get("/api/exports/stix", headers=HEADERS)
+    objects = r.json()["objects"]
+    campaigns = [o for o in objects if o["type"] == "campaign"]
+    relationships = [o for o in objects if o["type"] == "relationship"]
+    assert campaigns == []
+    assert relationships == []
+
+
+def test_stix_dormant_campaign_included_in_export():
+    """Dormant campaigns should still appear in STIX output."""
+    import uuid
+
+    cid = str(uuid.uuid4())
+    _insert_campaign_with_member(cid, "24.0.0.1", status="dormant")
+    _insert_source_ip("24.0.0.1", event_count=5)
+    r = client.get("/api/exports/stix", headers=HEADERS)
+    campaigns = [o for o in r.json()["objects"] if o["type"] == "campaign"]
+    assert len(campaigns) == 1
+    assert campaigns[0]["x_legiontrap_status"] == "dormant"
+
+
+def test_stix_campaign_sdo_deterministic_id():
+    """The same campaign always produces the same STIX object ID."""
+    import uuid
+
+    cid = str(uuid.uuid4())
+    _insert_campaign_with_member(cid, "25.0.0.1")
+    _insert_source_ip("25.0.0.1", event_count=5)
+    r1 = client.get("/api/exports/stix", headers=HEADERS)
+    r2 = client.get("/api/exports/stix", headers=HEADERS)
+    ids1 = {o["id"] for o in r1.json()["objects"] if o["type"] == "campaign"}
+    ids2 = {o["id"] for o in r2.json()["objects"] if o["type"] == "campaign"}
+    assert ids1 == ids2
+
+
+def test_stix_no_campaign_or_relationship_when_no_campaigns():
+    """Bundle without any campaigns contains no campaign or relationship objects."""
+    _insert_source_ip("26.0.0.1", event_count=5)
+    r = client.get("/api/exports/stix", headers=HEADERS)
+    objects = r.json()["objects"]
+    assert not any(o["type"] in ("campaign", "relationship") for o in objects)


### PR DESCRIPTION
## Summary

- **STIX export maturity**: `/api/exports/stix` now includes Campaign SDOs and Relationship SDOs alongside existing Indicators. Campaign SDOs contain no raw IPs; Relationship SDOs link `indicator --indicates--> campaign` using deterministic IDs.
- **Repository methods**: `get_campaigns_for_export()` and `get_campaign_member_ip_map()` added to `CampaignRepository`; historical campaigns excluded at the SQL layer.
- **Backward compatibility**: `build_stix_bundle()` accepts optional `campaigns` and `ip_campaign_map` params; existing call sites that pass neither are unaffected.
- **11 new integration tests**: presence, required fields, custom properties, no-raw-IP invariant, relationship source/target linking, historical exclusion, dormant inclusion, deterministic IDs, and no-campaigns baseline.
- **Phase 4 close-out documentation**: `PHASE_4_CLOSEOUT.md` records full delivery, blueprint compliance, deferred items, architectural lessons, and scaling ceilings. `ROADMAP.md`, `ARCHITECTURE.md`, and `PHASE_4_BLUEPRINT.md` updated to reflect Phase 4 complete.

## Test plan

- [ ] `python -m pytest --tb=short -q` — 573 passed, 3 skipped
- [ ] `pre-commit run --all-files` — clean
- [ ] `GET /api/exports/stix` with active campaign → bundle contains `campaign` and `relationship` objects
- [ ] `GET /api/exports/stix` with historical-only campaigns → no `campaign` or `relationship` objects
- [ ] `GET /api/exports/stix` with `PRIVACY_MODE=on` → HTTP 422 (unchanged behavior)
- [ ] `GET /api/exports/stix` with no campaigns at all → bundle contains only `ipv4-addr` and `indicator` objects (backward-compatible baseline)