### PR TITLE
feat(ai): Phase 5 Group B PR 4A — AI backend abstraction layer

### DIFF
--- a/app/ai/__init__.py
+++ b/app/ai/__init__.py
@@ -1,0 +1,42 @@
+"""app.ai — AI backend abstraction for Phase 5.
+
+Public API exported here. Callers should import from app.ai, not app.ai.backend.
+
+Example usage (future Phase 5 Group B PRs):
+
+    from app.ai import get_ai_backend, AIDisabledError, MockAIBackend
+
+    # Production use:
+    backend = get_ai_backend()
+    text = backend.generate(prompt)
+
+    # Test use:
+    backend = MockAIBackend(response="Campaign X is active.")
+    text = backend.generate(prompt)
+"""
+
+from app.ai.backend import (
+    AIBackend,
+    AIBackendError,
+    AIBackendUnavailableError,
+    AIDisabledError,
+    AIError,
+    ClaudeAIBackend,
+    DisabledAIBackend,
+    MockAIBackend,
+    OllamaAIBackend,
+    get_ai_backend,
+)
+
+__all__ = [
+    "AIBackend",
+    "AIError",
+    "AIDisabledError",
+    "AIBackendError",
+    "AIBackendUnavailableError",
+    "DisabledAIBackend",
+    "MockAIBackend",
+    "ClaudeAIBackend",
+    "OllamaAIBackend",
+    "get_ai_backend",
+]

--- a/app/ai/backend.py
+++ b/app/ai/backend.py
@@ -1,0 +1,251 @@
+"""AI backend abstraction layer for Phase 5.
+
+Provides a uniform generate(prompt) → str interface over multiple AI backends.
+The active backend is selected at startup via the AI_BACKEND setting:
+
+  AI_BACKEND=none    → DisabledAIBackend (default; raises AIDisabledError)
+  AI_BACKEND=ollama  → OllamaAIBackend (local inference; no data leaves system)
+  AI_BACKEND=claude  → ClaudeAIBackend (cloud; requires ANTHROPIC_API_KEY)
+
+Rules enforced here (Phase 5 §3, §12):
+  - No AI backend is ever called from the ingest path.
+  - No AI backend writes to the database.
+  - No AI backend calls external URLs except the configured AI endpoint.
+  - External SDK imports (anthropic, httpx) are lazy so startup is never
+    blocked by a missing optional dependency.
+
+MockAIBackend is provided for dependency injection in tests. It must never be
+instantiated in production code.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class AIError(Exception):
+    """Base class for all AI backend errors."""
+
+
+class AIDisabledError(AIError):
+    """Raised when AI_BACKEND=none and generate() is called."""
+
+
+class AIBackendError(AIError):
+    """Raised on backend configuration, connectivity, or runtime failures."""
+
+
+class AIBackendUnavailableError(AIBackendError):
+    """Raised when the configured backend is reachable but currently offline.
+
+    Distinct from AIBackendError so callers can return HTTP 503 vs HTTP 500.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Abstract base
+# ---------------------------------------------------------------------------
+
+
+class AIBackend(abc.ABC):
+    """Uniform interface for all AI backends.
+
+    Subclasses must implement generate(). All implementations must be
+    stateless with respect to the database — they read a prompt string
+    and return a response string, with no side effects.
+    """
+
+    @abc.abstractmethod
+    def generate(self, prompt: str) -> str:
+        """Generate a response for the given prompt.
+
+        Raises:
+            AIDisabledError: if AI features are disabled (DisabledAIBackend).
+            AIBackendUnavailableError: if the backend is offline.
+            AIBackendError: for all other backend failures.
+        """
+
+
+# ---------------------------------------------------------------------------
+# DisabledAIBackend
+# ---------------------------------------------------------------------------
+
+
+class DisabledAIBackend(AIBackend):
+    """Backend used when AI_BACKEND=none.
+
+    generate() always raises AIDisabledError with a clear message. This is
+    the default backend and the safe fallback for misconfigured deployments.
+    """
+
+    def generate(self, prompt: str) -> str:
+        raise AIDisabledError(
+            "AI features are disabled. " "Set AI_BACKEND=claude or AI_BACKEND=ollama to enable."
+        )
+
+
+# ---------------------------------------------------------------------------
+# MockAIBackend (tests only)
+# ---------------------------------------------------------------------------
+
+
+class MockAIBackend(AIBackend):
+    """Deterministic AI backend for dependency injection in tests.
+
+    Returns a fixed response string on every generate() call.
+    Never makes network calls. Must not be used in production code.
+    """
+
+    def __init__(self, response: str = "Mock AI response.") -> None:
+        self._response = response
+
+    def generate(self, prompt: str) -> str:
+        return self._response
+
+
+# ---------------------------------------------------------------------------
+# OllamaAIBackend
+# ---------------------------------------------------------------------------
+
+
+class OllamaAIBackend(AIBackend):
+    """Backend for local Ollama inference.
+
+    Calls the Ollama REST API at OLLAMA_HOST. No data leaves the system.
+    httpx is imported lazily so startup is not blocked if httpx is absent.
+    """
+
+    def __init__(self, host: str, model: str, timeout: int = 30) -> None:
+        self._host = host.rstrip("/")
+        self._model = model
+        self._timeout = timeout
+
+    def generate(self, prompt: str) -> str:
+        try:
+            import httpx
+        except ImportError as exc:
+            raise AIBackendError("httpx package is not installed. Run: pip install httpx") from exc
+
+        url = f"{self._host}/api/generate"
+        try:
+            response = httpx.post(
+                url,
+                json={"model": self._model, "prompt": prompt, "stream": False},
+                timeout=self._timeout,
+            )
+            response.raise_for_status()
+            return response.json()["response"]
+        except httpx.ConnectError as exc:
+            raise AIBackendUnavailableError(
+                f"Ollama unreachable at {self._host}. "
+                "Ensure Ollama is running and OLLAMA_HOST is correct."
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise AIBackendError(f"Ollama request timed out after {self._timeout}s.") from exc
+        except httpx.HTTPStatusError as exc:
+            raise AIBackendError(f"Ollama returned HTTP {exc.response.status_code}.") from exc
+
+
+# ---------------------------------------------------------------------------
+# ClaudeAIBackend
+# ---------------------------------------------------------------------------
+
+
+class ClaudeAIBackend(AIBackend):
+    """Backend for Anthropic Claude API (cloud).
+
+    anthropic SDK is imported lazily so startup is not blocked if the package
+    is absent. All requests to this backend send data to Anthropic's servers;
+    use DisabledAIBackend or OllamaAIBackend when PRIVACY_MODE=on.
+    """
+
+    def __init__(self, api_key: str, model: str, timeout: int = 30) -> None:
+        self._api_key = api_key
+        self._model = model
+        self._timeout = timeout
+
+    def generate(self, prompt: str) -> str:
+        try:
+            import anthropic
+        except ImportError as exc:
+            raise AIBackendError(
+                "anthropic package is not installed. Run: pip install anthropic"
+            ) from exc
+
+        client = anthropic.Anthropic(api_key=self._api_key)
+        try:
+            message = client.messages.create(
+                model=self._model,
+                max_tokens=1024,
+                messages=[{"role": "user", "content": prompt}],
+                timeout=self._timeout,
+            )
+            return message.content[0].text
+        except anthropic.APITimeoutError as exc:
+            raise AIBackendError(f"Claude API timed out after {self._timeout}s.") from exc
+        except anthropic.APIConnectionError as exc:
+            raise AIBackendUnavailableError(
+                "Claude API unreachable. Check network connectivity."
+            ) from exc
+        except anthropic.AuthenticationError as exc:
+            raise AIBackendError(
+                "Claude API authentication failed. Check ANTHROPIC_API_KEY."
+            ) from exc
+        except anthropic.APIError as exc:
+            raise AIBackendError(f"Claude API error: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def get_ai_backend() -> AIBackend:
+    """Create and return the configured AI backend instance.
+
+    Reads AI_BACKEND from settings. Raises AIBackendError if the configuration
+    is insufficient for the chosen backend (e.g. AI_BACKEND=claude with no key).
+
+    Returns:
+        DisabledAIBackend  when AI_BACKEND=none (default)
+        OllamaAIBackend    when AI_BACKEND=ollama
+        ClaudeAIBackend    when AI_BACKEND=claude
+    """
+    from app.core.config import settings
+
+    backend = settings.AI_BACKEND
+
+    if backend == "none":
+        return DisabledAIBackend()
+
+    if backend == "claude":
+        if not settings.ANTHROPIC_API_KEY:
+            raise AIBackendError(
+                "AI_BACKEND=claude requires ANTHROPIC_API_KEY to be set in the environment."
+            )
+        model = settings.AI_MODEL or "claude-haiku-4-5-20251001"
+        return ClaudeAIBackend(
+            api_key=settings.ANTHROPIC_API_KEY,
+            model=model,
+            timeout=settings.AI_TIMEOUT_SECONDS,
+        )
+
+    if backend == "ollama":
+        model = settings.AI_MODEL or "llama3.2"
+        return OllamaAIBackend(
+            host=settings.OLLAMA_HOST,
+            model=model,
+            timeout=settings.AI_TIMEOUT_SECONDS,
+        )
+
+    # Unreachable when settings validation is working; defensive fallback.
+    raise AIBackendError(f"Unrecognized AI_BACKEND: {backend!r}. Must be none, claude, or ollama.")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -34,6 +34,16 @@ class Settings(BaseSettings):
     CAMPAIGN_ACTIVE_DAYS: int = 7
     CAMPAIGN_DORMANT_DAYS: int = 90
 
+    # ---------------------------------------------------------------------------
+    # AI backend configuration (Phase 5)
+    # ---------------------------------------------------------------------------
+    AI_BACKEND: str = "none"  # none | ollama | claude
+    ANTHROPIC_API_KEY: str | None = None
+    OLLAMA_HOST: str = "http://localhost:11434"
+    AI_MODEL: str | None = None
+    AI_TIMEOUT_SECONDS: int = 30
+    AI_MAX_REQUESTS_PER_MINUTE: int = 10
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     @field_validator(
@@ -64,6 +74,22 @@ class Settings(BaseSettings):
     @field_validator("MIN_EVENTS_FOR_CLUSTERING", "CAMPAIGN_ACTIVE_DAYS", "CAMPAIGN_DORMANT_DAYS")
     @classmethod
     def positive_int(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError(f"Value must be >= 1; got {v}")
+        return v
+
+    @field_validator("AI_BACKEND")
+    @classmethod
+    def ai_backend_valid(cls, v: str) -> str:
+        allowed = {"none", "ollama", "claude"}
+        normalized = v.lower()
+        if normalized not in allowed:
+            raise ValueError(f"AI_BACKEND must be one of {sorted(allowed)}; got {v!r}")
+        return normalized
+
+    @field_validator("AI_TIMEOUT_SECONDS", "AI_MAX_REQUESTS_PER_MINUTE")
+    @classmethod
+    def positive_ai_int(cls, v: int) -> int:
         if v < 1:
             raise ValueError(f"Value must be >= 1; got {v}")
         return v

--- a/tests/unit/test_ai_backend.py
+++ b/tests/unit/test_ai_backend.py
@@ -1,0 +1,423 @@
+"""Unit tests for the AI backend abstraction layer.
+
+Verifies:
+  - Default backend is DisabledAIBackend (AI_BACKEND=none)
+  - DisabledAIBackend raises AIDisabledError with a clear message
+  - MockAIBackend returns configured responses without network calls
+  - ClaudeAIBackend raises AIBackendError when anthropic is not installed
+  - OllamaAIBackend raises the correct errors when httpx fails (monkeypatched)
+  - get_ai_backend() factory selects the correct implementation
+  - Settings validation rejects invalid AI_BACKEND values
+  - No live network calls occur in any test
+"""
+
+from __future__ import annotations
+
+import builtins
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai import (
+    AIBackend,
+    AIBackendError,
+    AIBackendUnavailableError,
+    AIDisabledError,
+    ClaudeAIBackend,
+    DisabledAIBackend,
+    MockAIBackend,
+    OllamaAIBackend,
+    get_ai_backend,
+)
+from app.core.config import Settings, settings
+
+_REQUIRED_FIELDS = {"API_KEY": "test-key", "FEED_SALT": "test-salt"}
+
+
+# ---------------------------------------------------------------------------
+# AIBackend ABC
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_backend_is_ai_backend_instance():
+    assert isinstance(DisabledAIBackend(), AIBackend)
+
+
+def test_mock_backend_is_ai_backend_instance():
+    assert isinstance(MockAIBackend(), AIBackend)
+
+
+def test_claude_backend_is_ai_backend_instance():
+    assert isinstance(ClaudeAIBackend(api_key="k", model="m"), AIBackend)
+
+
+def test_ollama_backend_is_ai_backend_instance():
+    assert isinstance(OllamaAIBackend(host="http://localhost:11434", model="llama3.2"), AIBackend)
+
+
+# ---------------------------------------------------------------------------
+# DisabledAIBackend
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_backend_raises_ai_disabled_error():
+    with pytest.raises(AIDisabledError):
+        DisabledAIBackend().generate("any prompt")
+
+
+def test_disabled_backend_error_message_mentions_enable():
+    with pytest.raises(AIDisabledError, match="AI_BACKEND=claude or AI_BACKEND=ollama"):
+        DisabledAIBackend().generate("prompt")
+
+
+def test_disabled_backend_raises_regardless_of_prompt():
+    backend = DisabledAIBackend()
+    for prompt in ["", "hello", "x" * 1000]:
+        with pytest.raises(AIDisabledError):
+            backend.generate(prompt)
+
+
+def test_disabled_backend_ai_disabled_error_is_ai_backend_error():
+    """AIDisabledError is a subtype of AIError but callers may catch AIBackendError."""
+    from app.ai import AIError
+
+    with pytest.raises(AIError):
+        DisabledAIBackend().generate("prompt")
+
+
+# ---------------------------------------------------------------------------
+# MockAIBackend
+# ---------------------------------------------------------------------------
+
+
+def test_mock_backend_returns_default_response():
+    result = MockAIBackend().generate("any prompt")
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_mock_backend_returns_configured_response():
+    expected = "Campaign SWIFT-JACKAL-14 is actively scanning port 22."
+    result = MockAIBackend(response=expected).generate("summarise campaign")
+    assert result == expected
+
+
+def test_mock_backend_returns_same_response_for_different_prompts():
+    backend = MockAIBackend(response="fixed")
+    assert backend.generate("prompt A") == "fixed"
+    assert backend.generate("prompt B") == "fixed"
+
+
+def test_mock_backend_does_not_raise():
+    MockAIBackend().generate("test")
+
+
+def test_mock_backend_empty_response_allowed():
+    backend = MockAIBackend(response="")
+    assert backend.generate("prompt") == ""
+
+
+# ---------------------------------------------------------------------------
+# ClaudeAIBackend — anthropic not installed
+# ---------------------------------------------------------------------------
+
+
+def test_claude_backend_can_be_instantiated():
+    backend = ClaudeAIBackend(api_key="sk-test", model="claude-haiku-4-5-20251001")
+    assert backend is not None
+
+
+def test_claude_backend_raises_when_anthropic_missing(monkeypatch):
+    """generate() raises AIBackendError with an install hint when anthropic is absent."""
+    real_import = builtins.__import__
+
+    def _block_anthropic(name, *args, **kwargs):
+        if name == "anthropic":
+            raise ImportError("No module named 'anthropic'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_anthropic)
+
+    backend = ClaudeAIBackend(api_key="sk-test", model="claude-haiku-4-5-20251001")
+    with pytest.raises(AIBackendError, match="anthropic package"):
+        backend.generate("test prompt")
+
+
+def test_claude_backend_stores_model():
+    backend = ClaudeAIBackend(api_key="key", model="claude-sonnet-4-6")
+    assert backend._model == "claude-sonnet-4-6"
+
+
+def test_claude_backend_stores_timeout():
+    backend = ClaudeAIBackend(api_key="key", model="m", timeout=15)
+    assert backend._timeout == 15
+
+
+# ---------------------------------------------------------------------------
+# OllamaAIBackend — httpx is installed but we monkeypatch it
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_backend_can_be_instantiated():
+    backend = OllamaAIBackend(host="http://localhost:11434", model="llama3.2")
+    assert backend is not None
+
+
+def test_ollama_backend_strips_trailing_slash_from_host():
+    backend = OllamaAIBackend(host="http://localhost:11434/", model="llama3.2")
+    assert not backend._host.endswith("/")
+
+
+def test_ollama_backend_raises_unavailable_on_connect_error(monkeypatch):
+    import httpx
+
+    def _connect_error(*args, **kwargs):
+        raise httpx.ConnectError("Connection refused")
+
+    monkeypatch.setattr(httpx, "post", _connect_error)
+
+    backend = OllamaAIBackend(host="http://localhost:11434", model="llama3.2")
+    with pytest.raises(AIBackendUnavailableError, match="unreachable"):
+        backend.generate("test prompt")
+
+
+def test_ollama_backend_raises_backend_error_on_timeout(monkeypatch):
+    import httpx
+
+    def _timeout(*args, **kwargs):
+        raise httpx.TimeoutException("Timed out")
+
+    monkeypatch.setattr(httpx, "post", _timeout)
+
+    backend = OllamaAIBackend(host="http://localhost:11434", model="llama3.2")
+    with pytest.raises(AIBackendError, match="timed out"):
+        backend.generate("test prompt")
+
+
+def test_ollama_backend_raises_backend_error_on_http_error(monkeypatch):
+    import httpx
+
+    def _http_error(*args, **kwargs):
+        response = httpx.Response(status_code=500)
+        raise httpx.HTTPStatusError("server error", request=None, response=response)
+
+    monkeypatch.setattr(httpx, "post", _http_error)
+
+    backend = OllamaAIBackend(host="http://localhost:11434", model="llama3.2")
+    with pytest.raises(AIBackendError, match="HTTP 500"):
+        backend.generate("test prompt")
+
+
+def test_ollama_backend_returns_response_field(monkeypatch):
+    import httpx
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"response": "Ollama says hello.", "done": True}
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **kw: _FakeResponse())
+
+    backend = OllamaAIBackend(host="http://localhost:11434", model="llama3.2")
+    result = backend.generate("prompt")
+    assert result == "Ollama says hello."
+
+
+def test_ollama_backend_raises_when_httpx_missing(monkeypatch):
+    real_import = builtins.__import__
+
+    def _block_httpx(name, *args, **kwargs):
+        if name == "httpx":
+            raise ImportError("No module named 'httpx'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_httpx)
+
+    backend = OllamaAIBackend(host="http://localhost:11434", model="llama3.2")
+    with pytest.raises(AIBackendError, match="httpx package"):
+        backend.generate("test prompt")
+
+
+# ---------------------------------------------------------------------------
+# get_ai_backend() factory
+# ---------------------------------------------------------------------------
+
+
+def test_get_ai_backend_default_returns_disabled():
+    backend = get_ai_backend()
+    assert isinstance(backend, DisabledAIBackend)
+
+
+def test_get_ai_backend_default_settings_is_none():
+    assert settings.AI_BACKEND == "none"
+
+
+def test_get_ai_backend_none_backend_raises_on_generate():
+    backend = get_ai_backend()
+    with pytest.raises(AIDisabledError):
+        backend.generate("prompt")
+
+
+def test_get_ai_backend_ollama_returns_ollama_instance(monkeypatch):
+    monkeypatch.setattr(settings, "AI_BACKEND", "ollama")
+    backend = get_ai_backend()
+    assert isinstance(backend, OllamaAIBackend)
+
+
+def test_get_ai_backend_ollama_uses_ollama_host(monkeypatch):
+    monkeypatch.setattr(settings, "AI_BACKEND", "ollama")
+    monkeypatch.setattr(settings, "OLLAMA_HOST", "http://custom-host:11434")
+    backend = get_ai_backend()
+    assert "custom-host" in backend._host
+
+
+def test_get_ai_backend_ollama_default_model(monkeypatch):
+    monkeypatch.setattr(settings, "AI_BACKEND", "ollama")
+    monkeypatch.setattr(settings, "AI_MODEL", None)
+    backend = get_ai_backend()
+    assert backend._model == "llama3.2"
+
+
+def test_get_ai_backend_ollama_custom_model(monkeypatch):
+    monkeypatch.setattr(settings, "AI_BACKEND", "ollama")
+    monkeypatch.setattr(settings, "AI_MODEL", "mistral")
+    backend = get_ai_backend()
+    assert backend._model == "mistral"
+
+
+def test_get_ai_backend_claude_without_key_raises(monkeypatch):
+    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", None)
+    with pytest.raises(AIBackendError, match="ANTHROPIC_API_KEY"):
+        get_ai_backend()
+
+
+def test_get_ai_backend_claude_with_key_returns_claude_instance(monkeypatch):
+    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "sk-test-key")
+    backend = get_ai_backend()
+    assert isinstance(backend, ClaudeAIBackend)
+
+
+def test_get_ai_backend_claude_default_model(monkeypatch):
+    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "sk-test-key")
+    monkeypatch.setattr(settings, "AI_MODEL", None)
+    backend = get_ai_backend()
+    assert backend._model == "claude-haiku-4-5-20251001"
+
+
+def test_get_ai_backend_claude_custom_model(monkeypatch):
+    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "sk-test-key")
+    monkeypatch.setattr(settings, "AI_MODEL", "claude-sonnet-4-6")
+    backend = get_ai_backend()
+    assert backend._model == "claude-sonnet-4-6"
+
+
+def test_get_ai_backend_uses_configured_timeout(monkeypatch):
+    monkeypatch.setattr(settings, "AI_BACKEND", "ollama")
+    monkeypatch.setattr(settings, "AI_TIMEOUT_SECONDS", 45)
+    backend = get_ai_backend()
+    assert backend._timeout == 45
+
+
+# ---------------------------------------------------------------------------
+# Settings validation — AI_BACKEND field
+# ---------------------------------------------------------------------------
+
+
+def test_settings_ai_backend_default_is_none():
+    assert settings.AI_BACKEND == "none"
+
+
+def test_settings_accepts_none_backend():
+    s = Settings(**{**_REQUIRED_FIELDS, "AI_BACKEND": "none"})
+    assert s.AI_BACKEND == "none"
+
+
+def test_settings_accepts_ollama_backend():
+    s = Settings(**{**_REQUIRED_FIELDS, "AI_BACKEND": "ollama"})
+    assert s.AI_BACKEND == "ollama"
+
+
+def test_settings_accepts_claude_backend():
+    s = Settings(**{**_REQUIRED_FIELDS, "AI_BACKEND": "claude"})
+    assert s.AI_BACKEND == "claude"
+
+
+def test_settings_normalizes_ai_backend_to_lowercase():
+    s = Settings(**{**_REQUIRED_FIELDS, "AI_BACKEND": "NONE"})
+    assert s.AI_BACKEND == "none"
+
+
+def test_settings_normalizes_claude_uppercase():
+    s = Settings(**{**_REQUIRED_FIELDS, "AI_BACKEND": "Claude"})
+    assert s.AI_BACKEND == "claude"
+
+
+def test_settings_rejects_invalid_ai_backend():
+    with pytest.raises(ValidationError, match="AI_BACKEND"):
+        Settings(**{**_REQUIRED_FIELDS, "AI_BACKEND": "openai"})
+
+
+def test_settings_rejects_empty_ai_backend():
+    with pytest.raises(ValidationError):
+        Settings(**{**_REQUIRED_FIELDS, "AI_BACKEND": ""})
+
+
+def test_settings_rejects_arbitrary_ai_backend():
+    with pytest.raises(ValidationError):
+        Settings(**{**_REQUIRED_FIELDS, "AI_BACKEND": "gpt4"})
+
+
+# ---------------------------------------------------------------------------
+# Settings validation — AI timeout and rate limit
+# ---------------------------------------------------------------------------
+
+
+def test_settings_ai_timeout_default():
+    assert settings.AI_TIMEOUT_SECONDS == 30
+
+
+def test_settings_ai_max_requests_default():
+    assert settings.AI_MAX_REQUESTS_PER_MINUTE == 10
+
+
+def test_settings_rejects_zero_timeout():
+    with pytest.raises(ValidationError):
+        Settings(**{**_REQUIRED_FIELDS, "AI_TIMEOUT_SECONDS": 0})
+
+
+def test_settings_rejects_negative_timeout():
+    with pytest.raises(ValidationError):
+        Settings(**{**_REQUIRED_FIELDS, "AI_TIMEOUT_SECONDS": -1})
+
+
+def test_settings_rejects_zero_rate_limit():
+    with pytest.raises(ValidationError):
+        Settings(**{**_REQUIRED_FIELDS, "AI_MAX_REQUESTS_PER_MINUTE": 0})
+
+
+def test_settings_accepts_valid_timeout():
+    s = Settings(**{**_REQUIRED_FIELDS, "AI_TIMEOUT_SECONDS": 60})
+    assert s.AI_TIMEOUT_SECONDS == 60
+
+
+# ---------------------------------------------------------------------------
+# Settings — other AI fields
+# ---------------------------------------------------------------------------
+
+
+def test_settings_anthropic_api_key_defaults_to_none():
+    assert settings.ANTHROPIC_API_KEY is None
+
+
+def test_settings_ollama_host_has_default():
+    assert settings.OLLAMA_HOST == "http://localhost:11434"
+
+
+def test_settings_ai_model_defaults_to_none():
+    assert settings.AI_MODEL is None


### PR DESCRIPTION
## Summary

- Adds `app/ai/backend.py` with `AIBackend` ABC, four concrete implementations, and a `get_ai_backend()` factory
- Adds `app/ai/__init__.py` re-exporting the full public API
- Extends `app/core/config.py` Settings with 6 AI configuration fields and pydantic validators

## What's in this PR

**Error hierarchy**: `AIError` → `AIDisabledError` | `AIBackendError` → `AIBackendUnavailableError` (distinct types let future routers return HTTP 503 vs 500)

**Backends**:
- `DisabledAIBackend` — always raises `AIDisabledError`; the default when `AI_BACKEND=none`
- `MockAIBackend` — returns a fixed string; for test dependency injection only
- `OllamaAIBackend` — calls `OLLAMA_HOST/api/generate` via `httpx` (lazy import); maps `ConnectError` → `AIBackendUnavailableError`
- `ClaudeAIBackend` — calls Anthropic API via `anthropic` SDK (lazy import; not yet in requirements.txt); maps SDK exceptions to the error hierarchy

**Factory**: `get_ai_backend()` reads `settings.AI_BACKEND`; raises `AIBackendError` if `AI_BACKEND=claude` with no `ANTHROPIC_API_KEY`

**Settings** (all with defaults, no pytest.ini changes needed):
- `AI_BACKEND: str = "none"` — validated to `none|ollama|claude`, normalized to lowercase
- `ANTHROPIC_API_KEY: str | None = None`
- `OLLAMA_HOST: str = "http://localhost:11434"`
- `AI_MODEL: str | None = None`
- `AI_TIMEOUT_SECONDS: int = 30`
- `AI_MAX_REQUESTS_PER_MINUTE: int = 10`

## Test plan

- [ ] 54 unit tests in `tests/unit/test_ai_backend.py` — all passing, zero network calls
- [ ] Ollama error paths tested via `monkeypatch` on `httpx.post`
- [ ] Claude import path tested via `monkeypatch` on `builtins.__import__`
- [ ] 755 total tests passing, 3 skipped
- [ ] Pre-commit clean (black + ruff)
- [ ] No prompt builder, no AI endpoints, no dashboard changes, no `anthropic` added to requirements.txt