### PR TITLE
feat(ui): add campaign AI summary dashboard panel

### DIFF
--- a/ui/dashboard/src/components/CampaignAiPanel.jsx
+++ b/ui/dashboard/src/components/CampaignAiPanel.jsx
@@ -1,0 +1,205 @@
+/**
+ * CampaignAiPanel — operator-triggered AI summary panel for a single campaign.
+ *
+ * Rendering rules (Phase 5 §8):
+ *   - AI summary is NEVER auto-generated; operator must click "Generate AI Summary"
+ *   - Warning/disclaimer label is always visible, not dismissible
+ *   - Deterministic data panel (rendered by parent) appears above this panel
+ *   - AI output is always plain text — never HTML, never dangerouslySetInnerHTML
+ *   - No output is cached or persisted locally
+ *
+ * Props:
+ *   summaryState  { status: 'idle'|'loading'|'success'|'error', data, errorMsg }
+ *   onGenerate    () => void  — called when operator clicks "Generate AI Summary"
+ *   onDismiss     () => void  — called when operator clicks "Dismiss"
+ *   dark          boolean
+ */
+export default function CampaignAiPanel({ summaryState, onGenerate, onDismiss, dark }) {
+  const { status, data, errorMsg } = summaryState;
+
+  const panelBorder = dark ? "#4b5563" : "#c7d2fe";
+  const panelBg = dark ? "rgba(99,102,241,0.05)" : "rgba(238,242,255,0.6)";
+  const warnBg = dark ? "rgba(251,191,36,0.08)" : "rgba(255,251,235,0.9)";
+  const warnBorder = dark ? "#92400e" : "#d97706";
+  const warnFg = dark ? "#fbbf24" : "#92400e";
+  const labelFg = dark ? "#818cf8" : "#6366f1";
+  const fg = dark ? "#d1d5db" : "#374151";
+  const mutedFg = dark ? "#9ca3af" : "#6b7280";
+  const dividerColor = dark ? "#374151" : "#e0e7ff";
+  const btnBg = dark ? "rgba(99,102,241,0.18)" : "rgba(99,102,241,0.1)";
+  const btnBorder = "#6366f1";
+  const btnFg = dark ? "#a5b4fc" : "#4338ca";
+  const errorFg = dark ? "#f87171" : "#dc2626";
+
+  // Warning text: prefer server-returned value, fall back to canonical disclaimer.
+  const warningText =
+    (status === "success" && data?.warning) ||
+    "AI-assisted analysis — not an asserted attribution. All factual claims are derived from deterministic campaign data.";
+
+  return (
+    <div
+      style={{
+        marginTop: 16,
+        padding: "12px 14px",
+        borderRadius: 8,
+        border: `1px solid ${panelBorder}`,
+        background: panelBg,
+      }}
+    >
+      {/* ── Header row ─────────────────────────────────────────── */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 10,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color: labelFg,
+          }}
+        >
+          AI Analysis
+        </span>
+        {(status === "success" || status === "error") && (
+          <button
+            onClick={onDismiss}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              fontSize: 12,
+              color: mutedFg,
+              padding: "2px 6px",
+              borderRadius: 4,
+            }}
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+
+      {/* ── Warning banner — always visible ────────────────────── */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 8,
+          padding: "8px 10px",
+          borderRadius: 6,
+          background: warnBg,
+          border: `1px solid ${warnBorder}`,
+          color: warnFg,
+          fontSize: 12,
+          lineHeight: 1.5,
+          marginBottom: 12,
+        }}
+      >
+        <span style={{ flexShrink: 0, fontWeight: 700 }}>⚠</span>
+        <span>{warningText}</span>
+      </div>
+
+      {/* ── Idle: generate button ───────────────────────────────── */}
+      {status === "idle" && (
+        <button
+          onClick={onGenerate}
+          style={{
+            padding: "6px 14px",
+            borderRadius: 6,
+            border: `1px solid ${btnBorder}`,
+            background: btnBg,
+            color: btnFg,
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: "pointer",
+          }}
+        >
+          Generate AI Summary
+        </button>
+      )}
+
+      {/* ── Loading ─────────────────────────────────────────────── */}
+      {status === "loading" && (
+        <span style={{ fontSize: 12, color: mutedFg, fontStyle: "italic" }}>
+          Generating summary…
+        </span>
+      )}
+
+      {/* ── Error ───────────────────────────────────────────────── */}
+      {status === "error" && (
+        <div style={{ fontSize: 12, color: errorFg }}>
+          {errorMsg ?? "AI summary unavailable."}
+        </div>
+      )}
+
+      {/* ── Success ─────────────────────────────────────────────── */}
+      {status === "success" && data && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {data.rejected ? (
+            /* Output failed safety checks */
+            <div style={{ fontSize: 12, color: errorFg }}>
+              AI summary unavailable — output did not pass safety checks.
+              {data.rejection_reason === "ip_detected" && (
+                <span style={{ marginLeft: 4 }}>(Output contained an IP address pattern.)</span>
+              )}
+            </div>
+          ) : (
+            /* Valid summary — plain text only, never HTML */
+            <>
+              <p
+                style={{
+                  fontSize: 13,
+                  color: fg,
+                  lineHeight: 1.65,
+                  margin: 0,
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                }}
+              >
+                {data.summary}
+              </p>
+              {data.truncated && (
+                <span style={{ fontSize: 11, color: mutedFg, fontStyle: "italic" }}>
+                  Output truncated to 1,000 characters.
+                </span>
+              )}
+            </>
+          )}
+
+          {/* ── Metadata footer ───────────────────────────────── */}
+          <div
+            style={{
+              display: "flex",
+              gap: 16,
+              flexWrap: "wrap",
+              fontSize: 11,
+              color: mutedFg,
+              borderTop: `1px solid ${dividerColor}`,
+              paddingTop: 8,
+            }}
+          >
+            {data.generated_at && (
+              <span>Generated {new Date(data.generated_at).toLocaleTimeString()}</span>
+            )}
+            {data.ai_backend && (
+              <span>Backend: {data.ai_backend}</span>
+            )}
+            {data.source_records?.observation_count != null && (
+              <span>Observations used: {data.source_records.observation_count}</span>
+            )}
+            {data.safety_flags?.length > 0 && (
+              <span style={{ color: warnFg }}>
+                Flags: {data.safety_flags.join(", ")}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/dashboard/src/components/Campaigns.jsx
+++ b/ui/dashboard/src/components/Campaigns.jsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useState } from "react";
-import { getCampaigns, getCampaignDetail } from "../lib/api";
+import { getCampaigns, getCampaignDetail, postCampaignSummary } from "../lib/api";
 import { timeAgo } from "../utils/format";
+import CampaignAiPanel from "./CampaignAiPanel";
 
 const REFRESH_MS = 30_000;
 
@@ -188,6 +189,7 @@ export default function Campaigns({ dark }) {
   const [expandedId, setExpandedId] = useState(null);
   const [details, setDetails] = useState({});
   const [detailLoading, setDetailLoading] = useState(null);
+  const [aiSummaries, setAiSummaries] = useState({});
 
   const cardBg = dark ? "#111827" : "#f9fafb";
   const border = dark ? "#374151" : "#d1d5db";
@@ -233,6 +235,46 @@ export default function Campaigns({ dark }) {
     } finally {
       setDetailLoading(null);
     }
+  }
+
+  async function generateSummary(campaignId) {
+    setAiSummaries((prev) => ({
+      ...prev,
+      [campaignId]: { status: "loading", data: null, errorMsg: null },
+    }));
+    try {
+      const { status, data } = await postCampaignSummary(campaignId);
+      if (status === 200) {
+        setAiSummaries((prev) => ({
+          ...prev,
+          [campaignId]: { status: "success", data, errorMsg: null },
+        }));
+      } else {
+        const msg =
+          data?.detail ??
+          (status === 503
+            ? "AI features are currently unavailable."
+            : status === 422
+              ? "AI summary unavailable (configuration conflict)."
+              : "AI summary unavailable.");
+        setAiSummaries((prev) => ({
+          ...prev,
+          [campaignId]: { status: "error", data: null, errorMsg: msg },
+        }));
+      }
+    } catch {
+      setAiSummaries((prev) => ({
+        ...prev,
+        [campaignId]: { status: "error", data: null, errorMsg: "Network error. AI summary unavailable." },
+      }));
+    }
+  }
+
+  function dismissSummary(campaignId) {
+    setAiSummaries((prev) => ({
+      ...prev,
+      [campaignId]: { status: "idle", data: null, errorMsg: null },
+    }));
   }
 
   useEffect(() => {
@@ -327,6 +369,12 @@ export default function Campaigns({ dark }) {
                         ) : (
                           <span style={{ opacity: 0.5, fontSize: 13 }}>Detail unavailable.</span>
                         )}
+                        <CampaignAiPanel
+                          summaryState={aiSummaries[item.id] ?? { status: "idle", data: null, errorMsg: null }}
+                          onGenerate={() => generateSummary(item.id)}
+                          onDismiss={() => dismissSummary(item.id)}
+                          dark={dark}
+                        />
                       </td>
                     </tr>
                   )}

--- a/ui/dashboard/src/components/RecentEvents.jsx
+++ b/ui/dashboard/src/components/RecentEvents.jsx
@@ -21,7 +21,7 @@ export default function RecentEvents({ dark }) {
   const [loading, setLoading] = useState(true);   // table loading state (first render)
   const [lastUpdated, setLastUpdated] = useState(null); // last successful fetch time
   const [online, setOnline] = useState(true);     // backend reachability
-  const [tick, setTick] = useState(0);            // forces "Updated Xs ago" re-render
+  const [_tick, setTick] = useState(0);           // forces "Updated Xs ago" re-render
   const timerRef = useRef(null);                  // polling interval handle
 
   // --- helper to build stable unique keys ------------------------------------

--- a/ui/dashboard/src/lib/api.js
+++ b/ui/dashboard/src/lib/api.js
@@ -45,3 +45,12 @@ export async function getCampaignDetail(campaignId) {
   if (!r.ok) throw new Error(`campaigns/${campaignId} ${r.status}`);
   return r.json();
 }
+
+export async function postCampaignSummary(campaignId) {
+  const r = await fetch(`/api/campaigns/${encodeURIComponent(campaignId)}/summary`, {
+    method: 'POST',
+    headers: { 'x-api-key': 'dev-123' },
+  });
+  const body = await r.json();
+  return { status: r.status, data: body };
+}


### PR DESCRIPTION
## Summary

- **`CampaignAiPanel.jsx`** — new component: always-visible warning banner, idle/loading/error/success states, plain-text summary rendering (no `dangerouslySetInnerHTML`), metadata footer (generated_at, backend, observation count, safety flags), truncation and rejection indicators, Dismiss button to return to idle
- **`Campaigns.jsx`** — `aiSummaries` state keyed per campaign ID, `generateSummary()` async handler with 503/422/network error handling, `dismissSummary()`, `CampaignAiPanel` rendered below `CampaignDetail` in every expanded row
- **`api.js`** — `postCampaignSummary()` returns `{ status, data }` for all HTTP outcomes so callers handle 503/422 without exception flow
- **`RecentEvents.jsx`** — fixed pre-existing lint error (`tick` → `_tick`)

## Layout invariant

Deterministic campaign detail always renders first. `CampaignAiPanel` appears below it, visually secondary (indigo-tinted border, dimmer background).

## Safety rules enforced

- `{data.summary}` is JSX text content — React escapes it automatically
- No `dangerouslySetInnerHTML` anywhere in the component
- Server `warning` field displayed as plain text binding
- AI summary is never auto-generated on mount or on row expand
- No output cached or persisted (no localStorage, no sessionStorage)

## Scope

No multi-campaign brief UI. No `GET /api/analyze/status` endpoint gating. No markdown rendering. No feedback/rating UI.

## Test plan

- [ ] Expand a campaign row — AI panel appears below deterministic detail with warning banner and "Generate AI Summary" button
- [ ] With `AI_BACKEND=none` (default dev): click Generate — shows "AI features are disabled" error state
- [ ] With `AI_BACKEND=ollama` or `AI_BACKEND=claude`: click Generate — shows loading → summary
- [ ] Verify summary text is plain prose, no HTML rendered
- [ ] Verify warning banner is visible at all times (idle, success, error)
- [ ] Click Dismiss — returns to idle state with Generate button
- [ ] `python -m pytest --tb=short -q` — 909 passed, 0 failed
- [ ] `npm run lint` — clean