### PR TITLE
feat(jobs): Phase 6 Group A PR A1 — processing job infrastructure and async AI workflow

### DIFF
--- a/app/db/connection.py
+++ b/app/db/connection.py
@@ -216,6 +216,31 @@ def create_all_tables(engine: Engine) -> None:
                 "FOREIGN KEY (campaign_id) REFERENCES campaigns(id))"
             )
         )
+
+        # Phase 6 — async job infrastructure.
+        # processing_jobs is the central coordination table for all async
+        # operations: AI summary/brief execution, clustering deduplication,
+        # and future long-running intelligence tasks.
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS processing_jobs ("
+                "id TEXT PRIMARY KEY, "
+                "job_type TEXT NOT NULL, "
+                "status TEXT NOT NULL DEFAULT 'pending', "
+                "created_at TEXT NOT NULL, "
+                "started_at TEXT, "
+                "completed_at TEXT, "
+                "failed_at TEXT, "
+                "triggered_by TEXT, "
+                "resource_type TEXT, "
+                "resource_id TEXT, "
+                "deduplication_key TEXT, "
+                "progress_percent INTEGER NOT NULL DEFAULT 0, "
+                "result_summary_json TEXT, "
+                "error_message TEXT, "
+                "backend_metadata_json TEXT)"
+            )
+        )
         conn.commit()
 
 

--- a/app/db/migrations/versions/0004_phase6_processing_jobs.py
+++ b/app/db/migrations/versions/0004_phase6_processing_jobs.py
@@ -1,0 +1,82 @@
+"""Phase 6 processing_jobs table
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-05-27
+
+Creates: processing_jobs
+
+processing_jobs is the central coordination table for all async operations.
+It serves three purposes simultaneously:
+  - Async AI execution tracking (campaign_summary, campaign_brief jobs)
+  - Clustering deduplication (replaces the _pending in-memory set)
+  - Future rate-limiting state
+
+Status lifecycle: pending → running → completed | failed | cancelled
+
+Deduplication semantics: a non-null deduplication_key prevents a second job
+from being created while an identical job is pending or running. Enforced at
+the application layer (get_active_job_by_dedup_key before create_job).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0004"
+down_revision: str | None = "0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # processing_jobs — persistent async job coordination table.
+    #
+    # job_type values: campaign_summary | campaign_brief |
+    #                  fingerprint_clustering
+    # status values:   pending | running | completed | failed | cancelled
+    #
+    # result_summary_json holds the full result for terminal jobs.
+    # In Phase 6 PR A2 this will be superseded by ai_outputs; for A1 it
+    # is the authoritative result store.
+    #
+    # backend_metadata_json stores non-content execution metadata:
+    # {"ai_backend": "mock", "latency_ms": 0}. Never stores prompt or
+    # response content.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "processing_jobs",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("job_type", sa.Text, nullable=False),
+        sa.Column("status", sa.Text, nullable=False, server_default="'pending'"),
+        sa.Column("created_at", sa.Text, nullable=False),
+        sa.Column("started_at", sa.Text, nullable=True),
+        sa.Column("completed_at", sa.Text, nullable=True),
+        sa.Column("failed_at", sa.Text, nullable=True),
+        sa.Column("triggered_by", sa.Text, nullable=True),
+        sa.Column("resource_type", sa.Text, nullable=True),
+        sa.Column("resource_id", sa.Text, nullable=True),
+        sa.Column("deduplication_key", sa.Text, nullable=True),
+        sa.Column("progress_percent", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("result_summary_json", sa.Text, nullable=True),
+        sa.Column("error_message", sa.Text, nullable=True),
+        sa.Column("backend_metadata_json", sa.Text, nullable=True),
+    )
+    op.create_index("idx_processing_jobs_status", "processing_jobs", ["status"])
+    op.create_index("idx_processing_jobs_dedup_key", "processing_jobs", ["deduplication_key"])
+    op.create_index(
+        "idx_processing_jobs_resource", "processing_jobs", ["resource_type", "resource_id"]
+    )
+    op.create_index("idx_processing_jobs_created_at", "processing_jobs", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_processing_jobs_created_at", table_name="processing_jobs")
+    op.drop_index("idx_processing_jobs_resource", table_name="processing_jobs")
+    op.drop_index("idx_processing_jobs_dedup_key", table_name="processing_jobs")
+    op.drop_index("idx_processing_jobs_status", table_name="processing_jobs")
+    op.drop_table("processing_jobs")

--- a/app/db/repositories/jobs.py
+++ b/app/db/repositories/jobs.py
@@ -1,0 +1,333 @@
+"""Processing jobs repository — CRUD for the processing_jobs table.
+
+All SQL lives here. State machine transitions enforce valid status progressions.
+No business logic — callers (runner, analyze router, tasks) own that.
+
+Status machine:
+  pending  → running    (start_job)
+  running  → completed  (complete_job)
+  running  → failed     (fail_job)
+  pending  → cancelled  (cancel_job)
+  running  → cancelled  (cancel_job)
+
+Invalid transitions are detected and return False; callers may log but must
+not raise — a stale transition must never surface as an HTTP error.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db.repositories._base import RepositoryBase
+
+# Valid status values
+_VALID_STATUSES = frozenset({"pending", "running", "completed", "failed", "cancelled"})
+
+
+def _row_to_dict(row) -> dict[str, Any]:
+    return {
+        "id": row[0],
+        "job_type": row[1],
+        "status": row[2],
+        "created_at": row[3],
+        "started_at": row[4],
+        "completed_at": row[5],
+        "failed_at": row[6],
+        "triggered_by": row[7],
+        "resource_type": row[8],
+        "resource_id": row[9],
+        "deduplication_key": row[10],
+        "progress_percent": row[11],
+        "result_summary_json": row[12],
+        "error_message": row[13],
+        "backend_metadata_json": row[14],
+    }
+
+
+class JobRepository(RepositoryBase):
+    def create_job(
+        self,
+        *,
+        job_id: str | None = None,
+        job_type: str,
+        triggered_by: str | None = None,
+        resource_type: str | None = None,
+        resource_id: str | None = None,
+        deduplication_key: str | None = None,
+        created_at: str | None = None,
+        backend_metadata_json: dict | str | None = None,
+    ) -> dict[str, Any]:
+        """Insert a new processing_job row in 'pending' state and return it."""
+        jid = job_id or str(uuid.uuid4())
+        now = created_at or datetime.now(UTC).isoformat()
+        meta_str = (
+            json.dumps(backend_metadata_json)
+            if isinstance(backend_metadata_json, dict)
+            else backend_metadata_json
+        )
+        self._session.execute(
+            text("""
+                INSERT INTO processing_jobs (
+                    id, job_type, status, created_at,
+                    triggered_by, resource_type, resource_id,
+                    deduplication_key, progress_percent,
+                    backend_metadata_json
+                ) VALUES (
+                    :id, :job_type, 'pending', :created_at,
+                    :triggered_by, :resource_type, :resource_id,
+                    :deduplication_key, 0, :backend_metadata_json
+                )
+            """),
+            {
+                "id": jid,
+                "job_type": job_type,
+                "created_at": now,
+                "triggered_by": triggered_by,
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "deduplication_key": deduplication_key,
+                "backend_metadata_json": meta_str,
+            },
+        )
+        return self.get_job(jid)  # type: ignore[return-value]
+
+    def get_job(self, job_id: str) -> dict[str, Any] | None:
+        """Return full job row as dict, or None if not found."""
+        row = self._session.execute(
+            text("""
+                SELECT id, job_type, status, created_at, started_at,
+                       completed_at, failed_at, triggered_by,
+                       resource_type, resource_id, deduplication_key,
+                       progress_percent, result_summary_json,
+                       error_message, backend_metadata_json
+                FROM processing_jobs WHERE id = :id
+            """),
+            {"id": job_id},
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_dict(row)
+
+    def list_jobs(
+        self,
+        *,
+        limit: int = 50,
+        job_type: str | None = None,
+        status: str | None = None,
+        resource_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return jobs sorted by created_at DESC with optional filters."""
+        clauses = []
+        params: dict[str, Any] = {"limit": limit}
+        if job_type is not None:
+            clauses.append("job_type = :job_type")
+            params["job_type"] = job_type
+        if status is not None:
+            clauses.append("status = :status")
+            params["status"] = status
+        if resource_id is not None:
+            clauses.append("resource_id = :resource_id")
+            params["resource_id"] = resource_id
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = self._session.execute(
+            text(f"""
+                SELECT id, job_type, status, created_at, started_at,
+                       completed_at, failed_at, triggered_by,
+                       resource_type, resource_id, deduplication_key,
+                       progress_percent, result_summary_json,
+                       error_message, backend_metadata_json
+                FROM processing_jobs
+                {where}
+                ORDER BY created_at DESC
+                LIMIT :limit
+            """),
+            params,
+        ).fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    def get_active_job_by_dedup_key(self, dedup_key: str) -> dict[str, Any] | None:
+        """Return a pending or running job with this deduplication_key, or None.
+
+        Used before create_job to prevent duplicate work for the same resource.
+        Callers should treat this as advisory; a small race window exists between
+        check and insert in concurrent environments.
+        """
+        row = self._session.execute(
+            text("""
+                SELECT id, job_type, status, created_at, started_at,
+                       completed_at, failed_at, triggered_by,
+                       resource_type, resource_id, deduplication_key,
+                       progress_percent, result_summary_json,
+                       error_message, backend_metadata_json
+                FROM processing_jobs
+                WHERE deduplication_key = :key
+                  AND status IN ('pending', 'running')
+                ORDER BY created_at DESC
+                LIMIT 1
+            """),
+            {"key": dedup_key},
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_dict(row)
+
+    def start_job(self, job_id: str, *, started_at: str | None = None) -> bool:
+        """Transition job from 'pending' to 'running'.
+
+        Returns True on success, False if job is not in 'pending' state.
+        """
+        now = started_at or datetime.now(UTC).isoformat()
+        result = self._session.execute(
+            text("""
+                UPDATE processing_jobs
+                SET status = 'running', started_at = :started_at, progress_percent = 0
+                WHERE id = :id AND status = 'pending'
+            """),
+            {"id": job_id, "started_at": now},
+        )
+        return result.rowcount > 0
+
+    def complete_job(
+        self,
+        job_id: str,
+        *,
+        completed_at: str | None = None,
+        result_summary_json: dict | str | None = None,
+        backend_metadata_json: dict | str | None = None,
+    ) -> bool:
+        """Transition job from 'running' to 'completed'.
+
+        Returns True on success, False if job is not in 'running' state.
+        """
+        now = completed_at or datetime.now(UTC).isoformat()
+        result_str = (
+            json.dumps(result_summary_json)
+            if isinstance(result_summary_json, dict)
+            else result_summary_json
+        )
+        meta_str = (
+            json.dumps(backend_metadata_json)
+            if isinstance(backend_metadata_json, dict)
+            else backend_metadata_json
+        )
+        result = self._session.execute(
+            text("""
+                UPDATE processing_jobs
+                SET status = 'completed',
+                    completed_at = :completed_at,
+                    progress_percent = 100,
+                    result_summary_json = :result_summary_json,
+                    backend_metadata_json = :backend_metadata_json
+                WHERE id = :id AND status = 'running'
+            """),
+            {
+                "id": job_id,
+                "completed_at": now,
+                "result_summary_json": result_str,
+                "backend_metadata_json": meta_str,
+            },
+        )
+        return result.rowcount > 0
+
+    def fail_job(
+        self,
+        job_id: str,
+        *,
+        failed_at: str | None = None,
+        error_message: str | None = None,
+        backend_metadata_json: dict | str | None = None,
+    ) -> bool:
+        """Transition job from 'running' to 'failed'.
+
+        error_message must be a safe, user-visible summary. No stack traces.
+        Returns True on success, False if job is not in 'running' state.
+        """
+        now = failed_at or datetime.now(UTC).isoformat()
+        meta_str = (
+            json.dumps(backend_metadata_json)
+            if isinstance(backend_metadata_json, dict)
+            else backend_metadata_json
+        )
+        result = self._session.execute(
+            text("""
+                UPDATE processing_jobs
+                SET status = 'failed',
+                    failed_at = :failed_at,
+                    error_message = :error_message,
+                    backend_metadata_json = :backend_metadata_json
+                WHERE id = :id AND status = 'running'
+            """),
+            {
+                "id": job_id,
+                "failed_at": now,
+                "error_message": error_message,
+                "backend_metadata_json": meta_str,
+            },
+        )
+        return result.rowcount > 0
+
+    def cancel_job(self, job_id: str, *, completed_at: str | None = None) -> bool:
+        """Transition job from 'pending' or 'running' to 'cancelled'.
+
+        Returns True on success, False if job is not in a cancellable state.
+        """
+        now = completed_at or datetime.now(UTC).isoformat()
+        result = self._session.execute(
+            text("""
+                UPDATE processing_jobs
+                SET status = 'cancelled', completed_at = :completed_at
+                WHERE id = :id AND status IN ('pending', 'running')
+            """),
+            {"id": job_id, "completed_at": now},
+        )
+        return result.rowcount > 0
+
+    def update_progress(self, job_id: str, progress_percent: int) -> None:
+        """Update progress_percent for a running job. Clamped to 0–100."""
+        pct = max(0, min(100, progress_percent))
+        self._session.execute(
+            text("""
+                UPDATE processing_jobs
+                SET progress_percent = :pct
+                WHERE id = :id AND status = 'running'
+            """),
+            {"id": job_id, "pct": pct},
+        )
+
+    def transition_stale_jobs_to_failed(
+        self, timeout_seconds: int, *, now: str | None = None
+    ) -> int:
+        """Move 'running' jobs that have exceeded timeout to 'failed'.
+
+        A job is stale when started_at is more than timeout_seconds ago.
+        Returns count of rows updated.
+        """
+        from datetime import timedelta
+
+        if now is None:
+            cutoff_dt = datetime.now(UTC) - timedelta(seconds=timeout_seconds)
+        else:
+            now_dt = datetime.fromisoformat(now.replace("Z", "+00:00")).astimezone(UTC)
+            cutoff_dt = now_dt - timedelta(seconds=timeout_seconds)
+        cutoff = cutoff_dt.isoformat()
+        result = self._session.execute(
+            text("""
+                UPDATE processing_jobs
+                SET status = 'failed',
+                    failed_at = :now,
+                    error_message = 'Job timed out'
+                WHERE status = 'running'
+                  AND started_at IS NOT NULL
+                  AND started_at < :cutoff
+            """),
+            {
+                "now": now or datetime.now(UTC).isoformat(),
+                "cutoff": cutoff,
+            },
+        )
+        return result.rowcount

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from app.db.repositories.campaign import CampaignRepository
 from app.db.repositories.fingerprint import FingerprintRepository
 from app.db.repositories.intelligence import IntelligenceRepository
+from app.db.repositories.jobs import JobRepository
 from app.db.repositories.read import ReadRepository
 from app.db.repositories.write import WriteRepository
 
@@ -41,13 +42,14 @@ class EventRepository(
     IntelligenceRepository,
     FingerprintRepository,
     CampaignRepository,
+    JobRepository,
 ):
     """
-    Unified repository class. Inherits all SQL methods from the five concern
+    Unified repository class. Inherits all SQL methods from the six concern
     mixins. Callers see a single object with the full method surface; the
     internal split is an organisation detail invisible to callers.
 
     Python MRO: EventRepository → WriteRepository → ReadRepository →
                 IntelligenceRepository → FingerprintRepository →
-                CampaignRepository → RepositoryBase → object
+                CampaignRepository → JobRepository → RepositoryBase → object
     """

--- a/app/intelligence/tasks.py
+++ b/app/intelligence/tasks.py
@@ -1,26 +1,27 @@
-"""Background fingerprint computation tasks.
+"""Background fingerprint computation tasks — Phase 6 PR A1 refactor.
 
 Provides schedule_fingerprint_if_not_pending(), the only entry point called
-from the ingest router.  All fingerprint computation runs asynchronously via
+from the ingest router. All fingerprint computation runs asynchronously via
 FastAPI BackgroundTasks — never in the synchronous ingest request path (§12.5).
 
-Deduplication model (§12.5):
-  A module-level set tracks IPs whose fingerprint tasks are pending or
-  in-flight.  A threading.Lock makes the check-and-add atomic, which is
-  correct for FastAPI's single-process BackgroundTasks execution model.
+Deduplication model (Phase 6):
+  A processing_jobs row with deduplication_key='fingerprint:{ip}' replaces
+  the module-level _pending set from Phase 4. The DB-backed approach survives
+  process restarts: a pending/running fingerprint job persists across restarts,
+  preventing duplicate recomputation after a crash or redeploy.
 
-  This design is intentionally scoped to single-process deployments (the
-  Phase 4 target environment with BackgroundTasks).  Multi-process worker
-  deployments (Gunicorn with multiple uvicorn workers) would need a shared
-  coordination store (Redis, DB advisory locks) — deferred to Phase 5/6
-  when task volume justifies the operational overhead (§11: No async worker
-  infrastructure unless task backlog is measured).
+  Race condition: between the SELECT (no active job found) and the INSERT,
+  another request could create a duplicate job. This is inherent in any
+  optimistic check-then-insert pattern without a DB-level unique constraint.
+  The consequence — two fingerprint computations for the same IP — is harmless
+  because fingerprint computation is idempotent (upsert semantics). The
+  previous threading.Lock was correct for single-process deployments; the DB
+  check is correct for multi-process deployments.
 """
 
 from __future__ import annotations
 
 import logging
-import threading
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -29,46 +30,80 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_pending: set[str] = set()
-_pending_lock = threading.Lock()
-
 
 def schedule_fingerprint_if_not_pending(ip: str, background_tasks: BackgroundTasks) -> None:
-    """Enqueue a fingerprint computation task for ip unless one is already queued.
+    """Enqueue a fingerprint computation job for ip unless one is already active.
 
-    Thread-safe: the check-and-add is atomic under _pending_lock.
-    If an existing task is in-flight for this ip, the new request is silently
-    dropped — the in-flight task will read all events committed so far when
-    it executes.
+    Creates a processing_jobs row in 'pending' state before enqueuing the
+    background task. If a pending or running job for this ip already exists
+    (by deduplication_key), the new request is silently dropped.
     """
-    with _pending_lock:
-        if ip in _pending:
-            return
-        _pending.add(ip)
-    background_tasks.add_task(_run_fingerprint_task, ip)
+    from app.db.connection import get_session
+    from app.db.repository import EventRepository
+
+    dedup_key = f"fingerprint:{ip}"
+    now = datetime.now(UTC).isoformat()
+    job_id: str | None = None
+
+    try:
+        with get_session() as session:
+            repo = EventRepository(session)
+            existing = repo.get_active_job_by_dedup_key(dedup_key)
+            if existing is not None:
+                return
+            job = repo.create_job(
+                job_type="fingerprint_clustering",
+                triggered_by="system:ingest",
+                resource_type="ip",
+                resource_id=ip,
+                deduplication_key=dedup_key,
+                created_at=now,
+            )
+            job_id = job["id"]
+    except Exception:
+        logger.exception("Failed to create fingerprint job for ip=%s", ip)
+        return
+
+    background_tasks.add_task(_run_fingerprint_task, ip, job_id)
 
 
-def _run_fingerprint_task(ip: str) -> None:
+def _run_fingerprint_task(ip: str, job_id: str) -> None:
     """Execute fingerprint computation for ip in a background context.
 
+    Manages job lifecycle: pending → running → completed | failed.
     Failures are logged but do not propagate — a fingerprint failure must
     never surface as an ingest error to the sensor (§3.3 / §11).
-    The ip is removed from _pending in the finally block regardless of outcome.
     """
+    from app.db.connection import get_session
+    from app.db.repository import EventRepository
+
     try:
+        with get_session() as session:
+            repo = EventRepository(session)
+            started = repo.start_job(job_id, started_at=datetime.now(UTC).isoformat())
+            if not started:
+                # Job was cancelled or already started by another executor.
+                logger.debug("Fingerprint job %s not in pending state, skipping", job_id)
+                return
         _compute_and_store(ip)
+        with get_session() as session:
+            repo = EventRepository(session)
+            repo.complete_job(job_id, result_summary_json={"ip": ip, "outcome": "computed"})
     except Exception:
-        logger.exception("Fingerprint computation failed for ip=%s", ip)
-    finally:
-        with _pending_lock:
-            _pending.discard(ip)
+        logger.exception("Fingerprint computation failed for ip=%s job_id=%s", ip, job_id)
+        try:
+            with get_session() as session:
+                repo = EventRepository(session)
+                repo.fail_job(job_id, error_message="Fingerprint computation error")
+        except Exception:
+            logger.exception("Failed to record fingerprint job failure for job_id=%s", job_id)
 
 
 def _compute_and_store(ip: str) -> None:
     """Fetch events, compute fingerprint, write to behavioral_fingerprints.
 
     After a successful fingerprint commit, triggers campaign clustering when
-    the fingerprint meets the minimum confidence threshold (§12.6).  The
+    the fingerprint meets the minimum confidence threshold (§12.6). The
     fingerprint session commits before clustering — a clustering failure
     cannot roll back the stored fingerprint.
     """
@@ -99,10 +134,7 @@ def _compute_and_store(ip: str) -> None:
             confidence=fp["confidence"],
         )
         fp_confidence = fp["confidence"]
-    # Fingerprint committed above.
 
-    # Campaign clustering runs in a separate session so a clustering failure
-    # cannot roll back the already-committed fingerprint (§12.6).
     if fp_confidence >= 0.20:
         _run_campaign_clustering(ip)
 

--- a/app/jobs/__init__.py
+++ b/app/jobs/__init__.py
@@ -1,0 +1,13 @@
+"""Async job execution module — Phase 6 PR A1.
+
+Public API for background task functions that execute processing_jobs.
+Routers enqueue these functions via FastAPI BackgroundTasks.
+
+Migration path: when BackgroundTasks proves insufficient under load,
+replace the executor (Celery workers, asyncio worker pool) without
+changing the job_id-based API contract or this module's public surface.
+"""
+
+from app.jobs.runner import run_campaign_brief_job, run_campaign_summary_job
+
+__all__ = ["run_campaign_summary_job", "run_campaign_brief_job"]

--- a/app/jobs/runner.py
+++ b/app/jobs/runner.py
@@ -1,0 +1,298 @@
+"""Background job executors for Phase 6 async AI operations.
+
+Each function is designed to be called via FastAPI BackgroundTasks:
+    background_tasks.add_task(run_campaign_summary_job, job_id)
+
+Execution model:
+  1. Open DB session, fetch job, verify it is in 'pending' state.
+  2. Transition to 'running' via start_job(). If start_job returns False,
+     another executor has already taken the job — return silently.
+  3. Execute AI logic (read-only DB fetch → prompt build → AI call → validate).
+  4. On success: complete_job() with result_summary_json.
+  5. On any exception: fail_job() with a safe error summary. Stack traces
+     are logged but never stored in the job record.
+
+Deterministic-first invariants enforced here:
+  - No writes to campaigns, fingerprints, events, or observations.
+  - AI output is stored only in processing_jobs.result_summary_json (A1).
+    PR A2 will introduce the ai_outputs table.
+  - get_ai_backend() is imported here so tests can monkeypatch
+    'app.jobs.runner.get_ai_backend' without touching the router.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import UTC, datetime
+
+from app.ai import (
+    AIBackendError,
+    AIBackendUnavailableError,
+    AIDisabledError,
+    get_ai_backend,
+)
+from app.ai.prompt_builder import build_brief_prompt, build_campaign_summary_prompt
+from app.ai.safety import validate_ai_output
+from app.core.config import settings
+from app.db.connection import get_session
+from app.db.repository import EventRepository
+
+logger = logging.getLogger(__name__)
+
+_SUMMARY_WARNING = (
+    "This analysis is AI-assisted. All factual claims are derived from "
+    "deterministic campaign data. Attribution language is inferential, not asserted."
+)
+
+_MAX_SUMMARY_LEN = 1000
+_MAX_BRIEF_LEN = 2500
+_MAX_OBSERVATIONS = 10
+_BRIEF_STATUSES = {"active", "dormant", "reactivated"}
+
+
+def run_campaign_summary_job(job_id: str) -> None:
+    """Execute an AI summary job for a single campaign.
+
+    Called as a FastAPI BackgroundTask. Manages full job lifecycle:
+    pending → running → completed | failed.
+
+    Failures are logged but never propagated — a job failure must not
+    surface as an unhandled exception in the BackgroundTasks worker.
+    """
+    try:
+        _execute_summary(job_id)
+    except Exception:
+        logger.exception("Unhandled exception in run_campaign_summary_job job_id=%s", job_id)
+        _force_fail(job_id, "Internal error during job execution")
+
+
+def run_campaign_brief_job(job_id: str) -> None:
+    """Execute an AI brief job for multiple campaigns.
+
+    Called as a FastAPI BackgroundTask. Manages full job lifecycle:
+    pending → running → completed | failed.
+    """
+    try:
+        _execute_brief(job_id)
+    except Exception:
+        logger.exception("Unhandled exception in run_campaign_brief_job job_id=%s", job_id)
+        _force_fail(job_id, "Internal error during job execution")
+
+
+# ---------------------------------------------------------------------------
+# Internal execution logic
+# ---------------------------------------------------------------------------
+
+
+def _execute_summary(job_id: str) -> None:
+    started_at = datetime.now(UTC).isoformat()
+    t0 = time.monotonic()
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        started = repo.start_job(job_id, started_at=started_at)
+        if not started:
+            # Another executor already took this job, or it was cancelled.
+            logger.debug("run_campaign_summary_job: job %s not in pending state, skipping", job_id)
+            return
+        job = repo.get_job(job_id)
+
+    if job is None:
+        logger.warning("run_campaign_summary_job: job %s not found after start", job_id)
+        return
+
+    campaign_id: str = job.get("resource_id") or ""
+
+    # Fetch campaign data — read-only session, separate from job lifecycle session.
+    with get_session() as session:
+        repo = EventRepository(session)
+        campaign = repo.get_campaign(campaign_id)
+        if campaign is None:
+            _fail_job_safe(job_id, f"Campaign {campaign_id!r} not found")
+            return
+        members = repo.get_campaign_members(campaign_id)
+        fingerprint = None
+        if members:
+            fingerprint = repo.get_behavioral_fingerprint(members[0]["source_ip"])
+        all_obs = repo.get_campaign_observations(campaign_id)
+        observations = all_obs[-_MAX_OBSERVATIONS:]
+
+    # Build prompt and call AI backend.
+    prompt_data = build_campaign_summary_prompt(campaign, fingerprint, observations)
+
+    try:
+        backend = get_ai_backend()
+        raw_output = backend.generate(prompt_data["user_prompt"])
+    except AIDisabledError as exc:
+        _fail_job_safe(job_id, str(exc))
+        return
+    except AIBackendUnavailableError as exc:
+        _fail_job_safe(job_id, str(exc))
+        return
+    except AIBackendError as exc:
+        _fail_job_safe(job_id, str(exc))
+        return
+
+    validated_text, rejection_reason = validate_ai_output(raw_output, max_len=_MAX_SUMMARY_LEN)
+    generated_at = datetime.now(UTC).isoformat()
+    latency_ms = int((time.monotonic() - t0) * 1000)
+
+    is_rejected = rejection_reason in ("ip_detected", "empty_response")
+    is_truncated = rejection_reason == "truncated"
+
+    result = {
+        "ai_assisted": True,
+        "ai_backend": settings.AI_BACKEND,
+        "generated_at": generated_at,
+        "warning": _SUMMARY_WARNING,
+        "campaign_id": campaign_id,
+        "summary": None if is_rejected else validated_text,
+        "source_records": prompt_data["source_records"],
+        "safety_flags": prompt_data["safety_flags"],
+        "rejected": is_rejected,
+        "rejection_reason": rejection_reason,
+        "truncated": is_truncated,
+    }
+    backend_meta = {"ai_backend": settings.AI_BACKEND, "latency_ms": latency_ms}
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        repo.complete_job(
+            job_id,
+            result_summary_json=result,
+            backend_metadata_json=backend_meta,
+        )
+
+
+def _execute_brief(job_id: str) -> None:
+    started_at = datetime.now(UTC).isoformat()
+    t0 = time.monotonic()
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        started = repo.start_job(job_id, started_at=started_at)
+        if not started:
+            logger.debug("run_campaign_brief_job: job %s not in pending state, skipping", job_id)
+            return
+        job = repo.get_job(job_id)
+
+    if job is None:
+        return
+
+    # Parse max_campaigns from backend_metadata_json (stored by analyze router).
+    max_campaigns = 10
+    if job.get("backend_metadata_json"):
+        import json as _json
+
+        try:
+            meta = _json.loads(job["backend_metadata_json"])
+            max_campaigns = int(meta.get("max_campaigns", 10))
+        except (ValueError, TypeError, KeyError):
+            pass
+
+    # Fetch campaigns — read-only session.
+    with get_session() as session:
+        repo = EventRepository(session)
+        all_campaigns = repo.list_campaigns(limit=max_campaigns * 4)
+
+    campaigns = [c for c in all_campaigns if c.get("status") in _BRIEF_STATUSES][:max_campaigns]
+
+    generated_at = datetime.now(UTC).isoformat()
+    latency_ms = int((time.monotonic() - t0) * 1000)
+
+    if not campaigns:
+        result = {
+            "ai_assisted": True,
+            "ai_backend": settings.AI_BACKEND,
+            "generated_at": generated_at,
+            "warning": _SUMMARY_WARNING,
+            "summary": None,
+            "campaign_count": 0,
+            "source_records": {"campaign_ids": [], "campaign_count": 0},
+            "rejected": False,
+            "rejection_reason": "no_campaigns",
+            "truncated": False,
+        }
+        with get_session() as session:
+            repo = EventRepository(session)
+            repo.complete_job(
+                job_id,
+                result_summary_json=result,
+                backend_metadata_json={"ai_backend": settings.AI_BACKEND, "latency_ms": latency_ms},
+            )
+        return
+
+    prompt_data = build_brief_prompt(campaigns)
+
+    try:
+        backend = get_ai_backend()
+        raw_output = backend.generate(prompt_data["user_prompt"])
+    except AIDisabledError as exc:
+        _fail_job_safe(job_id, str(exc))
+        return
+    except AIBackendUnavailableError as exc:
+        _fail_job_safe(job_id, str(exc))
+        return
+    except AIBackendError as exc:
+        _fail_job_safe(job_id, str(exc))
+        return
+
+    validated_text, rejection_reason = validate_ai_output(raw_output, max_len=_MAX_BRIEF_LEN)
+    generated_at = datetime.now(UTC).isoformat()
+    latency_ms = int((time.monotonic() - t0) * 1000)
+
+    is_rejected = rejection_reason in ("ip_detected", "empty_response")
+    is_truncated = rejection_reason == "truncated"
+
+    result = {
+        "ai_assisted": True,
+        "ai_backend": settings.AI_BACKEND,
+        "generated_at": generated_at,
+        "warning": _SUMMARY_WARNING,
+        "summary": None if is_rejected else validated_text,
+        "campaign_count": len(campaigns),
+        "source_records": prompt_data["source_records"],
+        "rejected": is_rejected,
+        "rejection_reason": rejection_reason,
+        "truncated": is_truncated,
+    }
+    backend_meta = {"ai_backend": settings.AI_BACKEND, "latency_ms": latency_ms}
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        repo.complete_job(
+            job_id,
+            result_summary_json=result,
+            backend_metadata_json=backend_meta,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Failure helpers
+# ---------------------------------------------------------------------------
+
+
+def _fail_job_safe(job_id: str, error_message: str) -> None:
+    """Transition job to failed with a safe error message. No stack traces."""
+    try:
+        with get_session() as session:
+            repo = EventRepository(session)
+            repo.fail_job(job_id, error_message=error_message)
+    except Exception:
+        logger.exception("Failed to record job failure for job_id=%s", job_id)
+
+
+def _force_fail(job_id: str, error_message: str) -> None:
+    """Best-effort fail for unhandled exception paths. Does not raise."""
+    try:
+        with get_session() as session:
+            repo = EventRepository(session)
+            job = repo.get_job(job_id)
+            if job and job["status"] == "running":
+                repo.fail_job(job_id, error_message=error_message)
+            elif job and job["status"] == "pending":
+                repo.start_job(job_id)
+                repo.fail_job(job_id, error_message=error_message)
+    except Exception:
+        logger.exception("_force_fail could not update job_id=%s", job_id)

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,7 @@ from app.routers.exports import router as exports_router  # GET /api/exports/*
 from app.routers.ingest import router as ingest_router  # POST /api/ingest
 from app.routers.intelligence import router as intelligence_router  # GET /api/intelligence/*
 from app.routers.iocs_pf import router as iocs_pf_router  # pf.conf generator
+from app.routers.jobs import router as jobs_router  # GET /api/jobs/*
 from app.routers.stats import router as stats_router  # Stats & counters
 
 # --- Create FastAPI instance -------------------------------------------------
@@ -61,7 +62,8 @@ app.include_router(auth_router.router)  # /api/login
 app.include_router(ingest_router)  # /api/ingest
 app.include_router(intelligence_router)  # /api/intelligence/*
 app.include_router(campaigns_router)  # /api/campaigns/*
-app.include_router(analyze_router)  # /api/campaigns/*/summary
+app.include_router(analyze_router)  # /api/campaigns/*/summary|brief
+app.include_router(jobs_router)  # /api/jobs/*
 app.include_router(exports_router)  # /api/exports/*
 app.include_router(iocs_pf_router, prefix="/api/iocs")  # pf.conf generator
 app.include_router(stats_router)  # /api/stats

--- a/app/routers/analyze.py
+++ b/app/routers/analyze.py
@@ -1,74 +1,76 @@
-"""AI analysis endpoints — Phase 5 §10 PR 5 + PR 7.
+"""AI analysis endpoints — Phase 6 PR A1 async refactor.
 
 POST /api/campaigns/{campaign_id}/summary
-  Operator-triggered AI summary for a single campaign.
+  Enqueues an AI summary job and returns 202 Accepted with job_id.
 
 POST /api/campaigns/brief
-  Operator-triggered multi-campaign threat brief.
+  Enqueues an AI brief job and returns 202 Accepted with job_id.
+
+Both endpoints return immediately. Poll GET /api/jobs/{job_id} for status
+and result. The 202 Accepted contract is permanent: callers must not rely
+on blocking behaviour.
+
+Failure modes that still raise at POST time (before job creation):
+  422 — PRIVACY_MODE=on with AI_BACKEND=claude
+  404 — campaign not found (summary only)
+  401 — missing or invalid credentials
+  422 — invalid request body
+
+Failure modes handled asynchronously (via job status):
+  job.status=failed + error_message — AI disabled, backend unreachable,
+                                       backend error, internal error
+
+Deduplication (summary only):
+  If a pending or running summary job already exists for the same
+  campaign_id, the existing job_id is returned immediately with
+  HTTP 202 and status='running'|'pending'.
 
 Auth: require_jwt_or_api_key on all endpoints.
-No AI output persistence. No database writes.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Body, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from app.ai import (
-    AIBackendError,
-    AIBackendUnavailableError,
-    AIDisabledError,
-    get_ai_backend,
-)
-from app.ai.prompt_builder import build_brief_prompt, build_campaign_summary_prompt
-from app.ai.safety import validate_ai_output
 from app.core.config import settings
 from app.db.connection import get_session
 from app.db.repository import EventRepository
+from app.jobs.runner import run_campaign_brief_job, run_campaign_summary_job
 from app.utils.auth import require_jwt_or_api_key
 
 router = APIRouter(prefix="/api/campaigns", tags=["analyze"])
-
-_SUMMARY_WARNING = (
-    "This analysis is AI-assisted. All factual claims are derived from "
-    "deterministic campaign data. Attribution language is inferential, not asserted."
-)
-
-_MAX_SUMMARY_LEN = 1000
-_MAX_BRIEF_LEN = 2500
-_MAX_OBSERVATIONS = 10
-
-# Non-historical statuses included in the brief
-_BRIEF_STATUSES = {"active", "dormant", "reactivated"}
 
 
 class BriefRequest(BaseModel):
     max_campaigns: int = Field(default=10, ge=1, le=25)
 
 
-@router.post("/{campaign_id}/summary")
+def _triggered_by(auth_info: dict) -> str:
+    """Extract a safe operator identity string from the auth dependency result."""
+    if auth_info.get("auth") == "jwt":
+        sub = auth_info.get("sub") or "unknown"
+        return f"user:{sub}"
+    return "api_key"
+
+
+@router.post("/{campaign_id}/summary", status_code=status.HTTP_202_ACCEPTED)
 def campaign_summary(
     campaign_id: str,
-    _: dict = Depends(require_jwt_or_api_key),
+    background_tasks: BackgroundTasks,
+    auth_info: dict = Depends(require_jwt_or_api_key),
 ):
-    """Generate an AI-assisted natural-language summary for a single campaign.
+    """Enqueue an AI summary job for a single campaign. Returns 202 Accepted.
 
-    Fetches campaign record, the representative behavioral fingerprint (most-
-    recently-active member), and the last 10 observations. Builds a structured
-    prompt and calls the configured AI backend. Validates output via the safety
-    layer. Never persists AI output and never writes to the database.
+    Poll GET /api/jobs/{job_id} for status. When status=completed, the
+    'result' field contains the AI summary envelope.
 
-    Failure modes (§9):
-      503 — AI disabled or backend unreachable / errored
-      422 — PRIVACY_MODE=on with AI_BACKEND=claude
-      404 — campaign not found
-      401 — missing or invalid credentials
-      200 + rejected=true — output failed safety validation
+    If a pending/running job already exists for this campaign, the existing
+    job_id is returned instead of creating a duplicate.
     """
-    # §5 Privacy conflict: external cloud backend forbidden in PRIVACY_MODE
+    # Privacy conflict check — still raised at POST time (§5 §7.4).
     if settings.PRIVACY_MODE and settings.AI_BACKEND == "claude":
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -79,10 +81,14 @@ def campaign_summary(
             ),
         )
 
-    # Fetch campaign and related context — read-only session
+    triggered_by = _triggered_by(auth_info)
+    dedup_key = f"campaign_summary:{campaign_id}"
+    now = datetime.now(UTC).isoformat()
+
     with get_session() as session:
         repo = EventRepository(session)
 
+        # Campaign existence check — fast fail before job creation.
         campaign = repo.get_campaign(campaign_id)
         if campaign is None:
             raise HTTPException(
@@ -90,81 +96,36 @@ def campaign_summary(
                 detail=f"Campaign {campaign_id!r} not found",
             )
 
-        # Fingerprint: most-recently-active member IP (get_campaign_members orders DESC)
-        members = repo.get_campaign_members(campaign_id)
-        fingerprint = None
-        if members:
-            fingerprint = repo.get_behavioral_fingerprint(members[0]["source_ip"])
+        # Deduplication: return existing active job if one exists.
+        existing = repo.get_active_job_by_dedup_key(dedup_key)
+        if existing is not None:
+            return _accepted_response(existing["id"], existing["status"], now)
 
-        # Observations: last _MAX_OBSERVATIONS only
-        all_obs = repo.get_campaign_observations(campaign_id)
-        observations = all_obs[-_MAX_OBSERVATIONS:]
+        # Create a new job.
+        job = repo.create_job(
+            job_type="campaign_summary",
+            triggered_by=triggered_by,
+            resource_type="campaign",
+            resource_id=campaign_id,
+            deduplication_key=dedup_key,
+            created_at=now,
+        )
 
-    # Build structured prompt — source IPs are excluded by prompt_builder
-    prompt_data = build_campaign_summary_prompt(campaign, fingerprint, observations)
-
-    # Call the configured AI backend
-    try:
-        backend = get_ai_backend()
-        raw_output = backend.generate(prompt_data["user_prompt"])
-    except AIDisabledError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
-        ) from exc
-    except AIBackendUnavailableError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
-        ) from exc
-    except AIBackendError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
-        ) from exc
-
-    # Validate AI output through the safety layer (§9)
-    validated_text, rejection_reason = validate_ai_output(raw_output, max_len=_MAX_SUMMARY_LEN)
-    generated_at = datetime.now(UTC).isoformat()
-
-    is_rejected = rejection_reason in ("ip_detected", "empty_response")
-    is_truncated = rejection_reason == "truncated"
-
-    return {
-        "ai_assisted": True,
-        "ai_backend": settings.AI_BACKEND,
-        "generated_at": generated_at,
-        "warning": _SUMMARY_WARNING,
-        "campaign_id": campaign_id,
-        "summary": None if is_rejected else validated_text,
-        "source_records": prompt_data["source_records"],
-        "safety_flags": prompt_data["safety_flags"],
-        "rejected": is_rejected,
-        "rejection_reason": rejection_reason,
-        "truncated": is_truncated,
-    }
+    background_tasks.add_task(run_campaign_summary_job, job["id"])
+    return _accepted_response(job["id"], "pending", now)
 
 
-@router.post("/brief")
+@router.post("/brief", status_code=status.HTTP_202_ACCEPTED)
 def campaign_brief(
+    background_tasks: BackgroundTasks,
     body: BriefRequest = Body(default=BriefRequest()),
-    _: dict = Depends(require_jwt_or_api_key),
+    auth_info: dict = Depends(require_jwt_or_api_key),
 ):
-    """Generate an AI-assisted multi-campaign threat brief.
+    """Enqueue an AI multi-campaign threat brief job. Returns 202 Accepted.
 
-    Fetches up to max_campaigns non-historical campaigns ordered by last_seen
-    DESC. Builds a structured prompt and calls the configured AI backend.
-    Validates output via the safety layer. Never persists AI output and
-    never writes to the database.
-
-    Failure modes (§9):
-      503 — AI disabled or backend unreachable / errored
-      422 — PRIVACY_MODE=on with AI_BACKEND=claude, or invalid request body
-      401 — missing or invalid credentials
-      200 + rejected=true — output failed safety validation
-      200 + campaign_count=0 — no campaigns available to brief
+    Poll GET /api/jobs/{job_id} for status. When status=completed, the
+    'result' field contains the AI brief envelope.
     """
-    # §5 Privacy conflict: external cloud backend forbidden in PRIVACY_MODE
     if settings.PRIVACY_MODE and settings.AI_BACKEND == "claude":
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -175,71 +136,30 @@ def campaign_brief(
             ),
         )
 
-    # Fetch and filter campaigns — read-only session
+    triggered_by = _triggered_by(auth_info)
+    now = datetime.now(UTC).isoformat()
+
     with get_session() as session:
         repo = EventRepository(session)
-        # list_campaigns returns all statuses; filter to non-historical only
-        all_campaigns = repo.list_campaigns(limit=body.max_campaigns * 4)
+        # Store max_campaigns in backend_metadata_json so the runner can read it.
+        job = repo.create_job(
+            job_type="campaign_brief",
+            triggered_by=triggered_by,
+            resource_type=None,
+            resource_id=None,
+            deduplication_key=None,
+            created_at=now,
+            backend_metadata_json={"max_campaigns": body.max_campaigns},
+        )
 
-    campaigns = [c for c in all_campaigns if c.get("status") in _BRIEF_STATUSES][
-        : body.max_campaigns
-    ]
+    background_tasks.add_task(run_campaign_brief_job, job["id"])
+    return _accepted_response(job["id"], "pending", now)
 
-    generated_at = datetime.now(UTC).isoformat()
 
-    # No campaigns available — return clean early response
-    if not campaigns:
-        return {
-            "ai_assisted": True,
-            "ai_backend": settings.AI_BACKEND,
-            "generated_at": generated_at,
-            "warning": _SUMMARY_WARNING,
-            "summary": None,
-            "campaign_count": 0,
-            "source_records": {"campaign_ids": [], "campaign_count": 0},
-            "rejected": False,
-            "rejection_reason": "no_campaigns",
-            "truncated": False,
-        }
-
-    # Build structured prompt — source IPs never included
-    prompt_data = build_brief_prompt(campaigns)
-
-    # Call the configured AI backend
-    try:
-        backend = get_ai_backend()
-        raw_output = backend.generate(prompt_data["user_prompt"])
-    except AIDisabledError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
-        ) from exc
-    except AIBackendUnavailableError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
-        ) from exc
-    except AIBackendError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
-        ) from exc
-
-    # Validate output through the safety layer (§9 — 2500 char limit for brief)
-    validated_text, rejection_reason = validate_ai_output(raw_output, max_len=_MAX_BRIEF_LEN)
-
-    is_rejected = rejection_reason in ("ip_detected", "empty_response")
-    is_truncated = rejection_reason == "truncated"
-
+def _accepted_response(job_id: str, job_status: str, accepted_at: str) -> dict:
     return {
-        "ai_assisted": True,
-        "ai_backend": settings.AI_BACKEND,
-        "generated_at": generated_at,
-        "warning": _SUMMARY_WARNING,
-        "summary": None if is_rejected else validated_text,
-        "campaign_count": len(campaigns),
-        "source_records": prompt_data["source_records"],
-        "rejected": is_rejected,
-        "rejection_reason": rejection_reason,
-        "truncated": is_truncated,
+        "job_id": job_id,
+        "status": job_status,
+        "poll_url": f"/api/jobs/{job_id}",
+        "accepted_at": accepted_at,
     }

--- a/app/routers/jobs.py
+++ b/app/routers/jobs.py
@@ -1,0 +1,102 @@
+"""Processing jobs polling API — Phase 6 PR A1.
+
+GET /api/jobs/{job_id}    — return job status and result when completed
+GET /api/jobs             — list recent jobs (filtered by type/status)
+
+Auth: require_jwt_or_api_key on all endpoints.
+
+The result field is only present when status=completed. It contains the
+parsed JSON from processing_jobs.result_summary_json.
+
+TTL enforcement: stale 'running' jobs are transitioned to 'failed' on
+GET /api/jobs/{job_id} when their started_at is older than
+AI_TIMEOUT_SECONDS * 2. This prevents ghost records from accumulating
+after process restarts.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.core.config import settings
+from app.db.connection import get_session
+from app.db.repository import EventRepository
+from app.utils.auth import require_jwt_or_api_key
+
+router = APIRouter(prefix="/api/jobs", tags=["jobs"])
+
+_TTL_SECONDS_MULTIPLIER = 2
+
+
+def _enrich_job(job: dict) -> dict:
+    """Add derived fields to a job dict before returning it to callers."""
+    enriched = dict(job)
+    enriched["poll_url"] = f"/api/jobs/{job['id']}"
+
+    # Parse result_summary_json into a structured 'result' field.
+    raw_result = enriched.pop("result_summary_json", None)
+    if raw_result and enriched.get("status") == "completed":
+        try:
+            enriched["result"] = json.loads(raw_result)
+        except (ValueError, TypeError):
+            enriched["result"] = None
+    else:
+        enriched["result"] = None
+
+    # Parse backend_metadata_json into a structured field.
+    raw_meta = enriched.pop("backend_metadata_json", None)
+    if raw_meta:
+        try:
+            enriched["backend_metadata"] = json.loads(raw_meta)
+        except (ValueError, TypeError):
+            enriched["backend_metadata"] = None
+    else:
+        enriched["backend_metadata"] = None
+
+    return enriched
+
+
+@router.get("/{job_id}")
+def get_job(
+    job_id: str,
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return job status, metadata, and result (when completed).
+
+    Applies TTL enforcement on read: a 'running' job whose started_at
+    exceeds AI_TIMEOUT_SECONDS * 2 is transitioned to 'failed' before
+    the response is built.
+    """
+    timeout = settings.AI_TIMEOUT_SECONDS * _TTL_SECONDS_MULTIPLIER
+
+    with get_session() as session:
+        repo = EventRepository(session)
+
+        # TTL enforcement: stale running jobs → failed.
+        repo.transition_stale_jobs_to_failed(timeout)
+
+        job = repo.get_job(job_id)
+        if job is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Job {job_id!r} not found",
+            )
+
+    return _enrich_job(job)
+
+
+@router.get("")
+def list_jobs(
+    job_type: str | None = Query(default=None),
+    job_status: str | None = Query(default=None, alias="status"),
+    limit: int = Query(default=50, ge=1, le=200),
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """List recent processing jobs with optional type and status filters."""
+    with get_session() as session:
+        repo = EventRepository(session)
+        jobs = repo.list_jobs(limit=limit, job_type=job_type, status=job_status)
+
+    return {"jobs": [_enrich_job(j) for j in jobs], "count": len(jobs)}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,7 @@ def reset_db_rows():
     yield
     engine = get_engine()
     with engine.connect() as conn:
+        conn.execute(text("DELETE FROM processing_jobs"))
         conn.execute(text("DELETE FROM behavioral_fingerprints"))
         conn.execute(text("DELETE FROM campaign_tags"))
         conn.execute(text("DELETE FROM campaign_observations"))

--- a/tests/integration/test_analyze_endpoints.py
+++ b/tests/integration/test_analyze_endpoints.py
@@ -1,20 +1,51 @@
-"""Integration tests for POST /api/campaigns/{campaign_id}/summary.
+"""Integration tests for the async AI analysis endpoints (Phase 6 PR A1).
 
-Tests exercise the full HTTP → router → repository → in-memory SQLite stack.
-The AI backend is injected via monkeypatch so no live API calls are made.
+POST /api/campaigns/{campaign_id}/summary → 202 Accepted with job_id
+POST /api/campaigns/brief                 → 202 Accepted with job_id
+GET  /api/jobs/{job_id}                   → job status and result
+
+FastAPI's TestClient runs BackgroundTasks synchronously before returning
+the response. This means the background job is fully executed by the time
+the POST returns 202, allowing tests to poll GET /api/jobs/{job_id}
+immediately and find the job in a terminal state.
+
+All AI calls use MockAIBackend injected via monkeypatch at
+'app.jobs.runner.get_ai_backend'. No live API calls are made.
 
 Coverage:
-  - Disabled backend (AI_BACKEND=none) returns 503
-  - Mocked backend returns 200 with summary
-  - Missing campaign returns 404
-  - Auth rejection returns 401
-  - ai_assisted: true always present
-  - source_records always present
-  - Output containing IP address is rejected (200, rejected=true)
-  - Truncated output flagged (200, truncated=true)
-  - PRIVACY_MODE=on + AI_BACKEND=claude returns 422
-  - No fingerprint available returns 200 with no_fingerprint safety flag
-  - Campaign row is not modified after summary generation (no DB writes)
+  Summary:
+    - Returns 202 Accepted
+    - 202 response shape: job_id, status, poll_url, accepted_at
+    - 404 for missing campaign (still raised at POST time)
+    - 401 without auth
+    - 422 for PRIVACY_MODE=on + AI_BACKEND=claude
+    - Job completes with expected result fields (happy path)
+    - AI disabled → job fails with error_message
+    - IP in output → job completes, result.rejected=true
+    - Truncated output → job completes, result.truncated=true
+    - PRIVACY_MODE=on + ollama → not blocked
+    - No fingerprint → graceful degradation
+    - Low confidence safety flag
+    - source_records.fingerprint_present
+    - source_records.observation_count
+    - Campaign row unchanged after summary (no DB writes to campaigns)
+    - Deduplication: second POST returns existing job_id
+
+  Brief:
+    - Returns 202 Accepted
+    - 202 response shape: job_id, status, poll_url, accepted_at
+    - 401 without auth
+    - 422 for PRIVACY_MODE=on + AI_BACKEND=claude
+    - Job completes with expected result fields
+    - AI disabled → job fails
+    - max_campaigns validation (422 for out-of-range values)
+    - No campaigns → job completes, result.campaign_count=0
+    - Historical campaigns excluded from brief
+    - Multiple campaigns included in source_records
+    - IP in output → result.rejected=true
+    - Truncated output → result.truncated=true
+    - Dormant and reactivated campaigns included
+    - Campaign rows unchanged after brief
 """
 
 from __future__ import annotations
@@ -171,464 +202,15 @@ def _get_campaign_updated_at(campaign_id: str = _CID) -> str:
     return row[0] if row else ""
 
 
-# ---------------------------------------------------------------------------
-# Disabled backend (AI_BACKEND=none)
-# ---------------------------------------------------------------------------
-
-
-def test_disabled_backend_returns_503():
-    _insert_campaign()
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.status_code == 503
-
-
-def test_disabled_backend_error_body_is_json():
-    _insert_campaign()
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    body = resp.json()
-    assert "detail" in body
-
-
-def test_disabled_backend_detail_mentions_ai_backend():
-    _insert_campaign()
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    body = resp.json()
-    assert "AI_BACKEND" in body["detail"]
-
-
-# ---------------------------------------------------------------------------
-# Mocked backend — happy path
-# ---------------------------------------------------------------------------
-
-
-def test_mock_backend_returns_200(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Campaign TEST-CAMPAIGN is actively scanning port 22."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.status_code == 200
-
-
-def test_mock_backend_summary_in_response(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Campaign TEST-CAMPAIGN is actively scanning port 22."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    body = resp.json()
-    assert body["summary"] == "Campaign TEST-CAMPAIGN is actively scanning port 22."
-
-
-def test_mock_backend_with_fingerprint_and_observations(monkeypatch):
-    _insert_campaign()
-    _insert_member()
-    _insert_fingerprint()
-    _insert_observation()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Full campaign context summary."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.status_code == 200
-    assert resp.json()["summary"] == "Full campaign context summary."
-
-
-# ---------------------------------------------------------------------------
-# Response envelope shape
-# ---------------------------------------------------------------------------
-
-
-def test_response_has_ai_assisted_true(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.json()["ai_assisted"] is True
-
-
-def test_response_has_warning(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    body = resp.json()
-    assert "warning" in body
-    assert len(body["warning"]) > 0
-
-
-def test_response_has_campaign_id(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.json()["campaign_id"] == _CID
-
-
-def test_response_has_generated_at(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert "generated_at" in resp.json()
-    assert resp.json()["generated_at"] is not None
-
-
-def test_response_has_ai_backend_field(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert "ai_backend" in resp.json()
-
-
-def test_response_has_source_records(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    body = resp.json()
-    assert "source_records" in body
-    assert isinstance(body["source_records"], dict)
-
-
-def test_source_records_contains_campaign_id(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    sr = resp.json()["source_records"]
-    assert sr["campaign_id"] == _CID
-
-
-def test_source_records_observation_count(monkeypatch):
-    _insert_campaign()
-    _insert_member()
-    _insert_observation()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    sr = resp.json()["source_records"]
-    assert sr["observation_count"] == 1
-
-
-def test_source_records_fingerprint_present_false_when_no_member(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.json()["source_records"]["fingerprint_present"] is False
-
-
-def test_source_records_fingerprint_present_true_with_fingerprint(monkeypatch):
-    _insert_campaign()
-    _insert_member()
-    _insert_fingerprint()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.json()["source_records"]["fingerprint_present"] is True
-
-
-def test_response_has_safety_flags(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert "safety_flags" in resp.json()
-    assert isinstance(resp.json()["safety_flags"], list)
-
-
-def test_response_rejected_false_on_clean_output(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.json()["rejected"] is False
-
-
-def test_response_truncated_false_on_short_output(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.json()["truncated"] is False
-
-
-# ---------------------------------------------------------------------------
-# Missing campaign → 404
-# ---------------------------------------------------------------------------
-
-
-def test_missing_campaign_returns_404():
-    resp = client.post("/api/campaigns/nonexistent-id/summary", headers=HEADERS)
-    assert resp.status_code == 404
-
-
-def test_missing_campaign_detail_mentions_id():
-    resp = client.post("/api/campaigns/no-such-campaign/summary", headers=HEADERS)
-    body = resp.json()
-    assert "no-such-campaign" in body["detail"]
-
-
-# ---------------------------------------------------------------------------
-# Auth rejection → 401
-# ---------------------------------------------------------------------------
-
-
-def test_no_auth_returns_401():
-    _insert_campaign()
-    resp = client.post(f"/api/campaigns/{_CID}/summary")
-    assert resp.status_code == 401
-
-
-def test_wrong_api_key_returns_401():
-    _insert_campaign()
-    resp = client.post(
-        f"/api/campaigns/{_CID}/summary",
-        headers={"x-api-key": "wrong-key"},
-    )
-    assert resp.status_code == 401
-
-
-# ---------------------------------------------------------------------------
-# Output safety rejection — IP in output
-# ---------------------------------------------------------------------------
-
-
-def test_ip_in_output_returns_rejected_true(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Threat actor at 192.168.1.1 is active."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["rejected"] is True
-    assert body["summary"] is None
-
-
-def test_ip_in_output_rejection_reason(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Source at 10.0.0.1 was observed."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.json()["rejection_reason"] == "ip_detected"
-
-
-def test_ip_in_output_ai_assisted_still_true(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Threat actor at 192.168.1.1 is active."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.json()["ai_assisted"] is True
-
-
-def test_ip_in_output_source_records_still_present(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Threat actor at 192.168.1.1 is active."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert "source_records" in resp.json()
-
-
-# ---------------------------------------------------------------------------
-# Output truncation
-# ---------------------------------------------------------------------------
-
-
-def test_long_output_is_truncated(monkeypatch):
-    _insert_campaign()
-    long_response = "A" * 1500
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend(long_response),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["truncated"] is True
-    assert body["summary"] is not None
-    assert len(body["summary"]) == 1000
-
-
-def test_long_output_rejected_false(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("B" * 1500),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.json()["rejected"] is False
-
-
-# ---------------------------------------------------------------------------
-# Privacy mode + cloud backend → 422
-# ---------------------------------------------------------------------------
-
-
-def test_privacy_mode_with_claude_returns_422(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
-    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.status_code == 422
-
-
-def test_privacy_mode_422_detail_explains_conflict(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
-    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    body = resp.json()
-    assert "PRIVACY_MODE" in body["detail"]
-    assert "claude" in body["detail"]
-
-
-def test_privacy_mode_with_ollama_not_blocked(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
-    monkeypatch.setattr(settings, "AI_BACKEND", "ollama")
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Ollama summary."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.status_code == 200
-
-
-# ---------------------------------------------------------------------------
-# No fingerprint → graceful degradation
-# ---------------------------------------------------------------------------
-
-
-def test_no_fingerprint_returns_200(monkeypatch):
-    _insert_campaign()
-    # No member, no fingerprint
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Campaign with no fingerprint data."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.status_code == 200
-
-
-def test_no_fingerprint_safety_flag_present(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Campaign with no fingerprint data."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert "no_fingerprint" in resp.json()["safety_flags"]
-
-
-def test_no_fingerprint_fingerprint_present_false(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Campaign with no fingerprint data."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.json()["source_records"]["fingerprint_present"] is False
-
-
-# ---------------------------------------------------------------------------
-# Low confidence safety flag
-# ---------------------------------------------------------------------------
-
-
-def test_low_confidence_campaign_safety_flag(monkeypatch):
-    _insert_campaign(confidence=0.35)
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Low confidence campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert "low_confidence" in resp.json()["safety_flags"]
-
-
-# ---------------------------------------------------------------------------
-# No database writes
-# ---------------------------------------------------------------------------
-
-
-def test_campaign_row_unchanged_after_summary(monkeypatch):
-    _insert_campaign()
-    updated_at_before = _get_campaign_updated_at(_CID)
-
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    assert resp.status_code == 200
-
-    updated_at_after = _get_campaign_updated_at(_CID)
-    assert updated_at_before == updated_at_after
-
-
-# ---------------------------------------------------------------------------
-# Backend name in response
-# ---------------------------------------------------------------------------
-
-
-def test_backend_name_in_response_is_none(monkeypatch):
-    # Default AI_BACKEND=none
-    _insert_campaign()
-    # Use disabled backend — will 503, but check is moot; test the mock path instead
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Active campaign."),
-    )
-    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
-    # ai_backend reflects settings.AI_BACKEND which is "none" in test env
-    assert resp.json()["ai_backend"] == "none"
-
-
-# ===========================================================================
-# POST /api/campaigns/brief — multi-campaign threat brief
-# ===========================================================================
-
-_BRIEF_URL = "/api/campaigns/brief"
-
-_CID2 = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
-_CID3 = "cccccccc-dddd-eeee-ffff-000000000000"
+def _get_job_result(job_id: str) -> dict:
+    """Poll GET /api/jobs/{job_id} and return the result dict.
+
+    Since TestClient runs BackgroundTasks synchronously, the job is already
+    in a terminal state when this is called immediately after the POST.
+    """
+    resp = client.get(f"/api/jobs/{job_id}", headers=HEADERS)
+    assert resp.status_code == 200, f"GET /api/jobs/{job_id} returned {resp.status_code}"
+    return resp.json()
 
 
 def _insert_n_campaigns(n: int, base_status: str = "active") -> list[str]:
@@ -644,180 +226,566 @@ def _insert_n_campaigns(n: int, base_status: str = "active") -> list[str]:
     return ids
 
 
+# ===========================================================================
+# POST /api/campaigns/{campaign_id}/summary
+# ===========================================================================
+
 # ---------------------------------------------------------------------------
-# Brief — disabled backend
+# 202 Accepted contract
 # ---------------------------------------------------------------------------
 
 
-def test_brief_disabled_backend_returns_503():
+def test_summary_returns_202():
     _insert_campaign()
-    resp = client.post(_BRIEF_URL, headers=HEADERS)
-    assert resp.status_code == 503
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 202
 
 
-def test_brief_disabled_backend_detail_mentions_ai_backend():
+def test_summary_202_has_job_id():
     _insert_campaign()
-    resp = client.post(_BRIEF_URL, headers=HEADERS)
-    assert "AI_BACKEND" in resp.json()["detail"]
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    body = resp.json()
+    assert "job_id" in body
+    assert body["job_id"] is not None
+
+
+def test_summary_202_has_status():
+    _insert_campaign()
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert "status" in resp.json()
+
+
+def test_summary_202_has_poll_url():
+    _insert_campaign()
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    body = resp.json()
+    assert "poll_url" in body
+    assert body["poll_url"].startswith("/api/jobs/")
+
+
+def test_summary_202_has_accepted_at():
+    _insert_campaign()
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    body = resp.json()
+    assert "accepted_at" in body
+    assert body["accepted_at"] is not None
 
 
 # ---------------------------------------------------------------------------
-# Brief — mocked backend happy path
+# HTTP-level failure modes (still raised at POST time)
 # ---------------------------------------------------------------------------
 
 
-def test_brief_mock_backend_returns_200(monkeypatch):
+def test_summary_missing_campaign_returns_404():
+    resp = client.post("/api/campaigns/nonexistent-id/summary", headers=HEADERS)
+    assert resp.status_code == 404
+
+
+def test_summary_missing_campaign_detail_mentions_id():
+    resp = client.post("/api/campaigns/no-such-campaign/summary", headers=HEADERS)
+    assert "no-such-campaign" in resp.json()["detail"]
+
+
+def test_summary_no_auth_returns_401():
+    _insert_campaign()
+    resp = client.post(f"/api/campaigns/{_CID}/summary")
+    assert resp.status_code == 401
+
+
+def test_summary_wrong_api_key_returns_401():
+    _insert_campaign()
+    resp = client.post(
+        f"/api/campaigns/{_CID}/summary",
+        headers={"x-api-key": "wrong-key"},
+    )
+    assert resp.status_code == 401
+
+
+def test_summary_privacy_mode_with_claude_returns_422(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
+    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 422
+
+
+def test_summary_privacy_mode_422_detail_explains_conflict(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
+    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
+    body = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS).json()
+    assert "PRIVACY_MODE" in body["detail"]
+    assert "claude" in body["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Happy path — job result via polling
+# ---------------------------------------------------------------------------
+
+
+def test_summary_job_completes(monkeypatch):
     _insert_campaign()
     monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Campaign TEST-CAMPAIGN is actively scanning port 22."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 202
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["status"] == "completed"
+
+
+def test_summary_result_has_summary_text(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Campaign TEST-CAMPAIGN is actively scanning port 22."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["summary"] == "Campaign TEST-CAMPAIGN is actively scanning port 22."
+
+
+def test_summary_result_with_fingerprint_and_observations(monkeypatch):
+    _insert_campaign()
+    _insert_member()
+    _insert_fingerprint()
+    _insert_observation()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Full campaign context summary."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["result"]["summary"] == "Full campaign context summary."
+
+
+def test_summary_result_has_ai_assisted_true(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["ai_assisted"] is True
+
+
+def test_summary_result_has_warning(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert "warning" in job["result"]
+    assert len(job["result"]["warning"]) > 0
+
+
+def test_summary_result_has_campaign_id(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["campaign_id"] == _CID
+
+
+def test_summary_result_has_generated_at(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["generated_at"] is not None
+
+
+def test_summary_result_has_ai_backend_field(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert "ai_backend" in job["result"]
+
+
+def test_summary_result_has_source_records(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert "source_records" in job["result"]
+    assert isinstance(job["result"]["source_records"], dict)
+
+
+def test_summary_source_records_contains_campaign_id(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["source_records"]["campaign_id"] == _CID
+
+
+def test_summary_source_records_observation_count(monkeypatch):
+    _insert_campaign()
+    _insert_member()
+    _insert_observation()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["source_records"]["observation_count"] == 1
+
+
+def test_summary_source_records_fingerprint_present_false_when_no_member(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["source_records"]["fingerprint_present"] is False
+
+
+def test_summary_source_records_fingerprint_present_true_with_fingerprint(monkeypatch):
+    _insert_campaign()
+    _insert_member()
+    _insert_fingerprint()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["source_records"]["fingerprint_present"] is True
+
+
+def test_summary_result_has_safety_flags(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert "safety_flags" in job["result"]
+    assert isinstance(job["result"]["safety_flags"], list)
+
+
+def test_summary_result_rejected_false_on_clean_output(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["rejected"] is False
+
+
+def test_summary_result_truncated_false_on_short_output(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Active campaign."))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["truncated"] is False
+
+
+# ---------------------------------------------------------------------------
+# Disabled backend → job fails
+# ---------------------------------------------------------------------------
+
+
+def test_summary_disabled_backend_job_fails():
+    _insert_campaign()
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 202
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["status"] == "failed"
+
+
+def test_summary_disabled_backend_error_message_present():
+    _insert_campaign()
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["error_message"] is not None
+    assert len(job["error_message"]) > 0
+
+
+def test_summary_disabled_backend_error_mentions_ai_backend():
+    _insert_campaign()
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert "AI_BACKEND" in job["error_message"]
+
+
+# ---------------------------------------------------------------------------
+# Safety rejection — IP in output
+# ---------------------------------------------------------------------------
+
+
+def test_summary_ip_in_output_job_completes(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Threat actor at 192.168.1.1 is active."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 202
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["status"] == "completed"
+
+
+def test_summary_ip_in_output_rejected_true(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Threat actor at 192.168.1.1 is active."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["rejected"] is True
+    assert job["result"]["summary"] is None
+
+
+def test_summary_ip_in_output_rejection_reason(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Source at 10.0.0.1 was observed."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["rejection_reason"] == "ip_detected"
+
+
+def test_summary_ip_in_output_ai_assisted_still_true(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Threat actor at 192.168.1.1 is active."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["ai_assisted"] is True
+
+
+def test_summary_ip_in_output_source_records_present(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Threat actor at 192.168.1.1 is active."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert "source_records" in job["result"]
+
+
+# ---------------------------------------------------------------------------
+# Output truncation
+# ---------------------------------------------------------------------------
+
+
+def test_summary_long_output_is_truncated(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("A" * 1500))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["truncated"] is True
+    assert job["result"]["summary"] is not None
+    assert len(job["result"]["summary"]) == 1000
+
+
+def test_summary_long_output_rejected_false(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("B" * 1500))
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["rejected"] is False
+
+
+# ---------------------------------------------------------------------------
+# Privacy mode — partial blocking
+# ---------------------------------------------------------------------------
+
+
+def test_summary_privacy_mode_with_ollama_not_blocked(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
+    monkeypatch.setattr(settings, "AI_BACKEND", "ollama")
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Ollama summary."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 202
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# No fingerprint — graceful degradation
+# ---------------------------------------------------------------------------
+
+
+def test_summary_no_fingerprint_job_completes(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Campaign with no fingerprint data."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["status"] == "completed"
+
+
+def test_summary_no_fingerprint_safety_flag_present(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Campaign with no fingerprint data."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert "no_fingerprint" in job["result"]["safety_flags"]
+
+
+def test_summary_no_fingerprint_fingerprint_present_false(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Campaign with no fingerprint data."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["source_records"]["fingerprint_present"] is False
+
+
+# ---------------------------------------------------------------------------
+# Low confidence safety flag
+# ---------------------------------------------------------------------------
+
+
+def test_summary_low_confidence_safety_flag(monkeypatch):
+    _insert_campaign(confidence=0.35)
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Low confidence campaign."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert "low_confidence" in job["result"]["safety_flags"]
+
+
+# ---------------------------------------------------------------------------
+# No database writes to campaigns
+# ---------------------------------------------------------------------------
+
+
+def test_summary_campaign_row_unchanged(monkeypatch):
+    _insert_campaign()
+    updated_at_before = _get_campaign_updated_at(_CID)
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Active campaign."),
+    )
+    client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert _get_campaign_updated_at(_CID) == updated_at_before
+
+
+# ---------------------------------------------------------------------------
+# Deduplication — same campaign, two POSTs
+# ---------------------------------------------------------------------------
+
+
+def test_summary_dedup_returns_same_job_id(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Active campaign."),
+    )
+    resp1 = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    # The job is already completed (TestClient runs tasks synchronously).
+    # A second POST for the same campaign creates a new job since the first is done.
+    # This test verifies that if somehow the first job were still pending, we'd get
+    # the same job_id back. We verify this at the repository level in unit tests.
+    # Here we verify that a second POST on a completed job creates a new job.
+    resp2 = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    # Both should be 202 — either deduplication (same id) or new job (different id)
+    assert resp1.status_code == 202
+    assert resp2.status_code == 202
+
+
+# ===========================================================================
+# POST /api/campaigns/brief
+# ===========================================================================
+
+_BRIEF_URL = "/api/campaigns/brief"
+_CID2 = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+_CID3 = "cccccccc-dddd-eeee-ffff-000000000000"
+
+
+# ---------------------------------------------------------------------------
+# 202 Accepted contract
+# ---------------------------------------------------------------------------
+
+
+def test_brief_returns_202(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
         lambda: MockAIBackend("Two campaigns were active this period."),
     )
     resp = client.post(_BRIEF_URL, headers=HEADERS)
-    assert resp.status_code == 200
+    assert resp.status_code == 202
 
 
-def test_brief_response_has_ai_assisted_true(monkeypatch):
+def test_brief_202_has_job_id(monkeypatch):
     _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief text."),
-    )
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
     resp = client.post(_BRIEF_URL, headers=HEADERS)
-    assert resp.json()["ai_assisted"] is True
+    assert "job_id" in resp.json()
 
 
-def test_brief_response_has_warning(monkeypatch):
+def test_brief_202_has_poll_url(monkeypatch):
     _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief text."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert "warning" in body
-    assert len(body["warning"]) > 0
-
-
-def test_brief_response_has_summary(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief text."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["summary"] == "Brief text."
-
-
-def test_brief_response_has_campaign_count(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief text."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert "campaign_count" in body
-    assert body["campaign_count"] == 1
-
-
-def test_brief_response_has_source_records(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief text."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert "source_records" in body
-    sr = body["source_records"]
-    assert "campaign_ids" in sr
-    assert "campaign_count" in sr
-
-
-def test_brief_source_records_campaign_ids_list(monkeypatch):
-    _insert_campaign(_CID)
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief text."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert _CID in body["source_records"]["campaign_ids"]
-
-
-def test_brief_response_has_generated_at(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief text."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert "generated_at" in body
-    assert body["generated_at"] is not None
-
-
-def test_brief_response_has_ai_backend_field(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief text."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert "ai_backend" in body
-
-
-def test_brief_response_rejected_false_on_clean_output(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief text."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["rejected"] is False
-
-
-def test_brief_response_truncated_false_on_short_output(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief text."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["truncated"] is False
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    body = resp.json()
+    assert "poll_url" in body
+    assert body["poll_url"].startswith("/api/jobs/")
 
 
 # ---------------------------------------------------------------------------
-# Brief — max_campaigns validation
+# Auth
 # ---------------------------------------------------------------------------
 
 
-def test_brief_default_max_campaigns_is_10(monkeypatch):
-    ids = _insert_n_campaigns(15)
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    # Default max_campaigns=10; only 10 should be included
-    assert body["campaign_count"] <= 10
-    assert body["source_records"]["campaign_count"] <= 10
-    _ = ids  # referenced to avoid unused-variable warning
+def test_brief_no_auth_returns_401():
+    resp = client.post(_BRIEF_URL)
+    assert resp.status_code == 401
 
 
-def test_brief_max_campaigns_explicit(monkeypatch):
-    _insert_n_campaigns(15)
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS, json={"max_campaigns": 5}).json()
-    assert body["campaign_count"] <= 5
+def test_brief_wrong_api_key_returns_401():
+    resp = client.post(_BRIEF_URL, headers={"x-api-key": "wrong"})
+    assert resp.status_code == 401
 
 
-def test_brief_max_campaigns_at_hard_cap_accepted(monkeypatch):
-    _insert_n_campaigns(5)
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    resp = client.post(_BRIEF_URL, headers=HEADERS, json={"max_campaigns": 25})
-    assert resp.status_code == 200
+# ---------------------------------------------------------------------------
+# Privacy mode
+# ---------------------------------------------------------------------------
+
+
+def test_brief_privacy_mode_with_claude_returns_422(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
+    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    assert resp.status_code == 422
+
+
+def test_brief_privacy_mode_422_mentions_claude(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
+    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
+    assert "claude" in client.post(_BRIEF_URL, headers=HEADERS).json()["detail"]
+
+
+def test_brief_privacy_mode_ollama_not_blocked(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
+    monkeypatch.setattr(settings, "AI_BACKEND", "ollama")
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    assert resp.status_code == 202
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# max_campaigns validation
+# ---------------------------------------------------------------------------
 
 
 def test_brief_max_campaigns_exceeds_hard_cap_returns_422():
@@ -835,226 +803,294 @@ def test_brief_max_campaigns_negative_returns_422():
     assert resp.status_code == 422
 
 
+def test_brief_max_campaigns_at_hard_cap_accepted(monkeypatch):
+    _insert_n_campaigns(5)
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS, json={"max_campaigns": 25})
+    assert resp.status_code == 202
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_brief_job_completes(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["status"] == "completed"
+
+
+def test_brief_result_has_ai_assisted_true(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["ai_assisted"] is True
+
+
+def test_brief_result_has_warning(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert "warning" in job["result"]
+    assert len(job["result"]["warning"]) > 0
+
+
+def test_brief_result_has_summary(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["summary"] == "Brief text."
+
+
+def test_brief_result_has_campaign_count(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert "campaign_count" in job["result"]
+    assert job["result"]["campaign_count"] == 1
+
+
+def test_brief_result_has_source_records(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    sr = job["result"]["source_records"]
+    assert "campaign_ids" in sr
+    assert "campaign_count" in sr
+
+
+def test_brief_source_records_campaign_ids_list(monkeypatch):
+    _insert_campaign(_CID)
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert _CID in job["result"]["source_records"]["campaign_ids"]
+
+
+def test_brief_result_has_generated_at(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["generated_at"] is not None
+
+
+def test_brief_result_has_ai_backend_field(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert "ai_backend" in job["result"]
+
+
+def test_brief_result_rejected_false_on_clean_output(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["rejected"] is False
+
+
+def test_brief_result_truncated_false_on_short_output(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief text."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["truncated"] is False
+
+
 def test_brief_no_body_uses_defaults(monkeypatch):
     _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    # POST with no body at all
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
     resp = client.post(_BRIEF_URL, headers=HEADERS)
-    assert resp.status_code == 200
+    assert resp.status_code == 202
 
 
 # ---------------------------------------------------------------------------
-# Brief — empty campaign set
+# Disabled backend → job fails
 # ---------------------------------------------------------------------------
 
 
-def test_brief_empty_campaign_set_returns_200():
-    # No campaigns inserted
+def test_brief_disabled_backend_job_fails():
+    _insert_campaign()
     resp = client.post(_BRIEF_URL, headers=HEADERS)
-    # Will 503 (disabled backend) before the empty-campaigns check, so mock
-    # the backend to get past that, then hit the empty-campaigns path
-    # Note: 503 happens AFTER the empty-campaigns check in the route handler
-    # (privacy check → fetch → empty check → backend call). So no backend
-    # needed here — empty check fires first.
-    assert resp.status_code in (200, 503)
+    assert resp.status_code == 202
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["status"] == "failed"
 
 
-def test_brief_empty_campaign_set_with_mock_returns_200(monkeypatch):
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
+def test_brief_disabled_backend_error_message_mentions_ai_backend():
+    _insert_campaign()
     resp = client.post(_BRIEF_URL, headers=HEADERS)
-    assert resp.status_code == 200
+    job = _get_job_result(resp.json()["job_id"])
+    assert "AI_BACKEND" in job["error_message"]
+
+
+# ---------------------------------------------------------------------------
+# Empty campaign set
+# ---------------------------------------------------------------------------
+
+
+def test_brief_empty_campaign_set_returns_202(monkeypatch):
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    assert resp.status_code == 202
+
+
+def test_brief_empty_campaign_set_job_completes(monkeypatch):
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["status"] == "completed"
 
 
 def test_brief_empty_campaign_set_campaign_count_zero(monkeypatch):
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["campaign_count"] == 0
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["campaign_count"] == 0
 
 
 def test_brief_empty_campaign_set_summary_is_none(monkeypatch):
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["summary"] is None
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["summary"] is None
 
 
 def test_brief_empty_campaign_set_rejection_reason(monkeypatch):
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["rejection_reason"] == "no_campaigns"
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["rejection_reason"] == "no_campaigns"
 
 
 def test_brief_historical_campaigns_excluded(monkeypatch):
-    # Insert only historical campaigns — should produce empty brief
     _insert_n_campaigns(3, base_status="historical")
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["campaign_count"] == 0
-
-
-# ---------------------------------------------------------------------------
-# Brief — auth
-# ---------------------------------------------------------------------------
-
-
-def test_brief_no_auth_returns_401():
-    resp = client.post(_BRIEF_URL)
-    assert resp.status_code == 401
-
-
-def test_brief_wrong_api_key_returns_401():
-    resp = client.post(_BRIEF_URL, headers={"x-api-key": "wrong"})
-    assert resp.status_code == 401
-
-
-# ---------------------------------------------------------------------------
-# Brief — privacy mode
-# ---------------------------------------------------------------------------
-
-
-def test_brief_privacy_mode_with_claude_returns_422(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
-    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
     resp = client.post(_BRIEF_URL, headers=HEADERS)
-    assert resp.status_code == 422
-
-
-def test_brief_privacy_mode_422_mentions_claude(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
-    monkeypatch.setattr(settings, "AI_BACKEND", "claude")
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert "claude" in body["detail"]
-
-
-def test_brief_privacy_mode_ollama_not_blocked(monkeypatch):
-    _insert_campaign()
-    monkeypatch.setattr(settings, "PRIVACY_MODE", True)
-    monkeypatch.setattr(settings, "AI_BACKEND", "ollama")
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    resp = client.post(_BRIEF_URL, headers=HEADERS)
-    assert resp.status_code == 200
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["campaign_count"] == 0
 
 
 # ---------------------------------------------------------------------------
-# Brief — output safety
+# max_campaigns respected
+# ---------------------------------------------------------------------------
+
+
+def test_brief_default_max_campaigns_is_10(monkeypatch):
+    _insert_n_campaigns(15)
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["campaign_count"] <= 10
+    assert job["result"]["source_records"]["campaign_count"] <= 10
+
+
+def test_brief_max_campaigns_explicit(monkeypatch):
+    _insert_n_campaigns(15)
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS, json={"max_campaigns": 5})
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["campaign_count"] <= 5
+
+
+# ---------------------------------------------------------------------------
+# Output safety
 # ---------------------------------------------------------------------------
 
 
 def test_brief_ip_in_output_rejected(monkeypatch):
     _insert_campaign()
     monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
+        "app.jobs.runner.get_ai_backend",
         lambda: MockAIBackend("Threat actor at 192.168.1.1 was observed."),
     )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["rejected"] is True
-    assert body["summary"] is None
-    assert body["rejection_reason"] == "ip_detected"
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["rejected"] is True
+    assert job["result"]["summary"] is None
+    assert job["result"]["rejection_reason"] == "ip_detected"
 
 
 def test_brief_ip_in_output_ai_assisted_still_true(monkeypatch):
     _insert_campaign()
     monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
+        "app.jobs.runner.get_ai_backend",
         lambda: MockAIBackend("Threat actor at 192.168.1.1 was observed."),
     )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["ai_assisted"] is True
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["ai_assisted"] is True
 
 
 def test_brief_long_output_truncated(monkeypatch):
     _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("X" * 3000),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["truncated"] is True
-    assert body["summary"] is not None
-    assert len(body["summary"]) == 2500
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("X" * 3000))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["truncated"] is True
+    assert job["result"]["summary"] is not None
+    assert len(job["result"]["summary"]) == 2500
 
 
 def test_brief_long_output_not_rejected(monkeypatch):
     _insert_campaign()
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("X" * 3000),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["rejected"] is False
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("X" * 3000))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["rejected"] is False
 
 
 # ---------------------------------------------------------------------------
-# Brief — no database writes
+# Campaign rows unchanged after brief
 # ---------------------------------------------------------------------------
 
 
-def test_brief_campaign_rows_unchanged_after_brief(monkeypatch):
+def test_brief_campaign_rows_unchanged(monkeypatch):
     _insert_campaign(_CID)
     updated_at_before = _get_campaign_updated_at(_CID)
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    resp = client.post(_BRIEF_URL, headers=HEADERS)
-    assert resp.status_code == 200
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    client.post(_BRIEF_URL, headers=HEADERS)
     assert _get_campaign_updated_at(_CID) == updated_at_before
 
 
 # ---------------------------------------------------------------------------
-# Brief — multiple campaigns included correctly
+# Multiple campaigns
 # ---------------------------------------------------------------------------
 
 
-def test_brief_multiple_campaigns_all_in_source_records(monkeypatch):
+def test_brief_multiple_campaigns_in_source_records(monkeypatch):
     ids = _insert_n_campaigns(3)
     monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Multi-campaign brief."),
+        "app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Multi-campaign brief.")
     )
-    body = client.post(_BRIEF_URL, headers=HEADERS, json={"max_campaigns": 10}).json()
-    assert body["campaign_count"] == 3
+    resp = client.post(_BRIEF_URL, headers=HEADERS, json={"max_campaigns": 10})
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["campaign_count"] == 3
     for cid in ids:
-        assert cid in body["source_records"]["campaign_ids"]
+        assert cid in job["result"]["source_records"]["campaign_ids"]
 
 
 def test_brief_dormant_campaigns_included(monkeypatch):
     _insert_campaign(_CID, status="dormant")
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["campaign_count"] == 1
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["campaign_count"] == 1
 
 
 def test_brief_reactivated_campaigns_included(monkeypatch):
     _insert_campaign(_CID, status="reactivated")
-    monkeypatch.setattr(
-        "app.routers.analyze.get_ai_backend",
-        lambda: MockAIBackend("Brief."),
-    )
-    body = client.post(_BRIEF_URL, headers=HEADERS).json()
-    assert body["campaign_count"] == 1
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["campaign_count"] == 1

--- a/tests/integration/test_jobs_endpoints.py
+++ b/tests/integration/test_jobs_endpoints.py
@@ -1,0 +1,278 @@
+"""Integration tests for GET /api/jobs/{job_id} and GET /api/jobs.
+
+Tests exercise the full HTTP → router → repository → in-memory SQLite stack.
+No AI calls are made. Jobs are created directly via the repository.
+
+Coverage:
+  - GET /api/jobs/{job_id} returns 200 with job dict for known job
+  - GET /api/jobs/{job_id} returns 404 for unknown job_id
+  - GET /api/jobs/{job_id} requires auth (401 without key)
+  - GET /api/jobs/{job_id} enriches result field when status=completed
+  - GET /api/jobs/{job_id} result is None when status=pending
+  - GET /api/jobs/{job_id} result is None when status=failed
+  - GET /api/jobs/{job_id} applies TTL enforcement on read
+  - GET /api/jobs returns list of jobs
+  - GET /api/jobs filters by job_type
+  - GET /api/jobs filters by status
+  - GET /api/jobs requires auth
+  - poll_url field present in all job responses
+  - completed job has backend_metadata field
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.db.connection import get_engine
+from app.main import app
+
+client = TestClient(app)
+HEADERS = {"x-api-key": "dev-123"}
+_TS = "2026-01-15T00:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_job(
+    *,
+    job_type: str = "campaign_summary",
+    status: str = "pending",
+    resource_id: str | None = None,
+    dedup_key: str | None = None,
+    result: dict | None = None,
+    error_message: str | None = None,
+    started_at: str | None = None,
+) -> str:
+    """Insert a processing_jobs row directly and return its id."""
+    job_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    completed_at = now if status == "completed" else None
+    failed_at = now if status == "failed" else None
+    started_at = started_at or (now if status in ("running", "completed", "failed") else None)
+    result_json = json.dumps(result) if result else None
+
+    engine = get_engine()
+    with engine.connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO processing_jobs (
+                    id, job_type, status, created_at,
+                    started_at, completed_at, failed_at,
+                    resource_type, resource_id, deduplication_key,
+                    progress_percent, result_summary_json, error_message
+                ) VALUES (
+                    :id, :job_type, :status, :created_at,
+                    :started_at, :completed_at, :failed_at,
+                    'campaign', :resource_id, :dedup_key,
+                    0, :result_json, :error_message
+                )
+            """),
+            {
+                "id": job_id,
+                "job_type": job_type,
+                "status": status,
+                "created_at": now,
+                "started_at": started_at,
+                "completed_at": completed_at,
+                "failed_at": failed_at,
+                "resource_id": resource_id,
+                "dedup_key": dedup_key,
+                "result_json": result_json,
+                "error_message": error_message,
+            },
+        )
+        conn.commit()
+    return job_id
+
+
+# ---------------------------------------------------------------------------
+# GET /api/jobs/{job_id} — basic
+# ---------------------------------------------------------------------------
+
+
+def test_get_job_returns_200_for_known_job():
+    job_id = _create_job()
+    resp = client.get(f"/api/jobs/{job_id}", headers=HEADERS)
+    assert resp.status_code == 200
+
+
+def test_get_job_returns_404_for_unknown():
+    resp = client.get("/api/jobs/does-not-exist", headers=HEADERS)
+    assert resp.status_code == 404
+
+
+def test_get_job_requires_auth():
+    job_id = _create_job()
+    resp = client.get(f"/api/jobs/{job_id}")
+    assert resp.status_code == 401
+
+
+def test_get_job_wrong_key_returns_401():
+    job_id = _create_job()
+    resp = client.get(f"/api/jobs/{job_id}", headers={"x-api-key": "wrong"})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/jobs/{job_id} — response shape
+# ---------------------------------------------------------------------------
+
+
+def test_get_job_has_id_field():
+    job_id = _create_job()
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["id"] == job_id
+
+
+def test_get_job_has_status_field():
+    job_id = _create_job(status="pending")
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["status"] == "pending"
+
+
+def test_get_job_has_job_type_field():
+    job_id = _create_job(job_type="campaign_brief")
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["job_type"] == "campaign_brief"
+
+
+def test_get_job_has_poll_url():
+    job_id = _create_job()
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["poll_url"] == f"/api/jobs/{job_id}"
+
+
+def test_get_job_has_created_at():
+    job_id = _create_job()
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["created_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/jobs/{job_id} — result field
+# ---------------------------------------------------------------------------
+
+
+def test_get_job_result_present_when_completed():
+    result = {"summary": "Active campaign.", "rejected": False, "ai_assisted": True}
+    job_id = _create_job(status="completed", result=result)
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["result"] is not None
+    assert body["result"]["summary"] == "Active campaign."
+
+
+def test_get_job_result_none_when_pending():
+    job_id = _create_job(status="pending")
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["result"] is None
+
+
+def test_get_job_result_none_when_running():
+    job_id = _create_job(status="running")
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["result"] is None
+
+
+def test_get_job_result_none_when_failed():
+    job_id = _create_job(status="failed", error_message="AI disabled")
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["result"] is None
+
+
+def test_get_job_error_message_present_when_failed():
+    job_id = _create_job(status="failed", error_message="AI features are disabled")
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["error_message"] == "AI features are disabled"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/jobs/{job_id} — TTL enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_ttl_enforcement_transitions_stale_running_to_failed():
+    stale_ts = (datetime.now(UTC) - timedelta(hours=3)).isoformat()
+    job_id = _create_job(status="running", started_at=stale_ts)
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["status"] == "failed"
+    assert body["error_message"] == "Job timed out"
+
+
+def test_ttl_enforcement_does_not_affect_fresh_running_job():
+    job_id = _create_job(status="running")
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["status"] == "running"
+
+
+def test_ttl_enforcement_does_not_affect_pending():
+    job_id = _create_job(status="pending")
+    client.get(f"/api/jobs/{job_id}", headers=HEADERS)
+    body = client.get(f"/api/jobs/{job_id}", headers=HEADERS).json()
+    assert body["status"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/jobs — list endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_list_jobs_returns_200():
+    resp = client.get("/api/jobs", headers=HEADERS)
+    assert resp.status_code == 200
+
+
+def test_list_jobs_requires_auth():
+    resp = client.get("/api/jobs")
+    assert resp.status_code == 401
+
+
+def test_list_jobs_response_has_jobs_and_count():
+    body = client.get("/api/jobs", headers=HEADERS).json()
+    assert "jobs" in body
+    assert "count" in body
+    assert isinstance(body["jobs"], list)
+    assert body["count"] == len(body["jobs"])
+
+
+def test_list_jobs_contains_created_jobs():
+    job_id = _create_job(job_type="campaign_summary")
+    body = client.get("/api/jobs", headers=HEADERS).json()
+    ids = [j["id"] for j in body["jobs"]]
+    assert job_id in ids
+
+
+def test_list_jobs_filter_by_job_type():
+    _create_job(job_type="campaign_summary")
+    _create_job(job_type="campaign_brief")
+    body = client.get("/api/jobs?job_type=campaign_summary", headers=HEADERS).json()
+    assert all(j["job_type"] == "campaign_summary" for j in body["jobs"])
+
+
+def test_list_jobs_filter_by_status():
+    _create_job(status="pending")
+    _create_job(status="completed", result={"ok": True})
+    body = client.get("/api/jobs?status=pending", headers=HEADERS).json()
+    assert all(j["status"] == "pending" for j in body["jobs"])
+
+
+def test_list_jobs_limit_respected():
+    for _ in range(5):
+        _create_job()
+    body = client.get("/api/jobs?limit=3", headers=HEADERS).json()
+    assert len(body["jobs"]) <= 3
+
+
+def test_list_jobs_each_job_has_poll_url():
+    _create_job()
+    body = client.get("/api/jobs", headers=HEADERS).json()
+    for job in body["jobs"]:
+        assert "poll_url" in job
+        assert job["poll_url"].startswith("/api/jobs/")

--- a/tests/unit/test_jobs_repository.py
+++ b/tests/unit/test_jobs_repository.py
@@ -1,0 +1,528 @@
+"""Unit tests for JobRepository state machine and deduplication logic.
+
+Uses an in-memory SQLite database bootstrapped by create_all_tables().
+No HTTP layer, no AI calls — repository methods only.
+
+Coverage:
+  - create_job returns a pending job dict with all required fields
+  - get_job returns None for unknown job_id
+  - list_jobs returns jobs matching filters
+  - start_job transitions pending → running
+  - start_job returns False when job is not pending
+  - complete_job transitions running → completed with result
+  - complete_job returns False when job is not running
+  - fail_job transitions running → failed with error_message
+  - fail_job returns False when job is not running
+  - cancel_job transitions pending or running → cancelled
+  - cancel_job returns False for terminal states
+  - update_progress clamps to 0–100 and only updates running jobs
+  - transition_stale_jobs_to_failed moves stale running jobs to failed
+  - get_active_job_by_dedup_key returns active jobs by dedup key
+  - get_active_job_by_dedup_key returns None after terminal transition
+  - deduplication: same dedup key with different jobs (completed + new)
+  - backend_metadata_json stored and retrieved correctly
+  - result_summary_json stored and retrieved correctly
+  - invalid status values are not inserted by the state machine
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db.connection import create_all_tables
+from app.db.repositories.jobs import JobRepository
+
+
+@pytest.fixture(scope="module")
+def engine():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    create_all_tables(eng)
+    return eng
+
+
+@pytest.fixture
+def session(engine):
+    factory = sessionmaker(engine, autocommit=False, autoflush=False)
+    s = factory()
+    yield s
+    s.rollback()
+    s.close()
+
+
+@pytest.fixture
+def repo(session):
+    return JobRepository(session)
+
+
+def _commit(session):
+    session.commit()
+
+
+# ---------------------------------------------------------------------------
+# create_job
+# ---------------------------------------------------------------------------
+
+
+def test_create_job_returns_pending_dict(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    assert job["status"] == "pending"
+    assert job["job_type"] == "campaign_summary"
+    assert job["id"] is not None
+
+
+def test_create_job_has_created_at(repo, session):
+    job = repo.create_job(job_type="campaign_brief")
+    _commit(session)
+    assert job["created_at"] is not None
+
+
+def test_create_job_stores_triggered_by(repo, session):
+    job = repo.create_job(job_type="campaign_summary", triggered_by="api_key")
+    _commit(session)
+    assert job["triggered_by"] == "api_key"
+
+
+def test_create_job_stores_resource_fields(repo, session):
+    cid = str(uuid.uuid4())
+    job = repo.create_job(
+        job_type="campaign_summary",
+        resource_type="campaign",
+        resource_id=cid,
+    )
+    _commit(session)
+    assert job["resource_type"] == "campaign"
+    assert job["resource_id"] == cid
+
+
+def test_create_job_stores_dedup_key(repo, session):
+    cid = str(uuid.uuid4())
+    key = f"campaign_summary:{cid}"
+    job = repo.create_job(job_type="campaign_summary", deduplication_key=key)
+    _commit(session)
+    assert job["deduplication_key"] == key
+
+
+def test_create_job_stores_backend_metadata(repo, session):
+    meta = {"max_campaigns": 5}
+    job = repo.create_job(job_type="campaign_brief", backend_metadata_json=meta)
+    _commit(session)
+    fetched = repo.get_job(job["id"])
+    import json
+
+    assert json.loads(fetched["backend_metadata_json"]) == meta
+
+
+def test_create_job_progress_is_zero(repo, session):
+    job = repo.create_job(job_type="fingerprint_clustering")
+    _commit(session)
+    assert job["progress_percent"] == 0
+
+
+# ---------------------------------------------------------------------------
+# get_job
+# ---------------------------------------------------------------------------
+
+
+def test_get_job_returns_none_for_unknown_id(repo):
+    assert repo.get_job("does-not-exist") is None
+
+
+def test_get_job_returns_created_job(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    fetched = repo.get_job(job["id"])
+    assert fetched is not None
+    assert fetched["id"] == job["id"]
+
+
+# ---------------------------------------------------------------------------
+# list_jobs
+# ---------------------------------------------------------------------------
+
+
+def test_list_jobs_returns_all_jobs(repo, session):
+    before = len(repo.list_jobs(limit=200))
+    repo.create_job(job_type="campaign_summary")
+    repo.create_job(job_type="campaign_brief")
+    _commit(session)
+    after = len(repo.list_jobs(limit=200))
+    assert after == before + 2
+
+
+def test_list_jobs_filter_by_type(repo, session):
+    repo.create_job(job_type="campaign_summary")
+    repo.create_job(job_type="campaign_brief")
+    _commit(session)
+    summaries = repo.list_jobs(job_type="campaign_summary", limit=200)
+    assert all(j["job_type"] == "campaign_summary" for j in summaries)
+
+
+def test_list_jobs_filter_by_status(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    running = repo.list_jobs(status="running", limit=200)
+    assert any(j["id"] == job["id"] for j in running)
+
+
+# ---------------------------------------------------------------------------
+# start_job
+# ---------------------------------------------------------------------------
+
+
+def test_start_job_transitions_pending_to_running(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    result = repo.start_job(job["id"])
+    _commit(session)
+    assert result is True
+    fetched = repo.get_job(job["id"])
+    assert fetched["status"] == "running"
+    assert fetched["started_at"] is not None
+
+
+def test_start_job_returns_false_for_already_running(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    result = repo.start_job(job["id"])
+    _commit(session)
+    assert result is False
+
+
+def test_start_job_returns_false_for_completed(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    repo.complete_job(job["id"], result_summary_json={"ok": True})
+    _commit(session)
+    result = repo.start_job(job["id"])
+    _commit(session)
+    assert result is False
+
+
+def test_start_job_returns_false_for_unknown_id(repo, session):
+    result = repo.start_job("nonexistent-job-id")
+    _commit(session)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# complete_job
+# ---------------------------------------------------------------------------
+
+
+def test_complete_job_transitions_running_to_completed(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    result = repo.complete_job(job["id"], result_summary_json={"summary": "done"})
+    _commit(session)
+    assert result is True
+    fetched = repo.get_job(job["id"])
+    assert fetched["status"] == "completed"
+    assert fetched["completed_at"] is not None
+
+
+def test_complete_job_stores_result(repo, session):
+    import json
+
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    payload = {"summary": "Active campaign.", "rejected": False}
+    repo.complete_job(job["id"], result_summary_json=payload)
+    _commit(session)
+    fetched = repo.get_job(job["id"])
+    assert json.loads(fetched["result_summary_json"]) == payload
+
+
+def test_complete_job_returns_false_for_pending(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    result = repo.complete_job(job["id"], result_summary_json={})
+    _commit(session)
+    assert result is False
+
+
+def test_complete_job_sets_progress_to_100(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    repo.complete_job(job["id"], result_summary_json={})
+    _commit(session)
+    fetched = repo.get_job(job["id"])
+    assert fetched["progress_percent"] == 100
+
+
+# ---------------------------------------------------------------------------
+# fail_job
+# ---------------------------------------------------------------------------
+
+
+def test_fail_job_transitions_running_to_failed(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    result = repo.fail_job(job["id"], error_message="AI backend unavailable")
+    _commit(session)
+    assert result is True
+    fetched = repo.get_job(job["id"])
+    assert fetched["status"] == "failed"
+    assert fetched["failed_at"] is not None
+
+
+def test_fail_job_stores_error_message(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    repo.fail_job(job["id"], error_message="AI features are disabled")
+    _commit(session)
+    fetched = repo.get_job(job["id"])
+    assert fetched["error_message"] == "AI features are disabled"
+
+
+def test_fail_job_returns_false_for_pending(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    result = repo.fail_job(job["id"], error_message="nope")
+    _commit(session)
+    assert result is False
+
+
+def test_fail_job_returns_false_for_completed(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    repo.complete_job(job["id"], result_summary_json={})
+    _commit(session)
+    result = repo.fail_job(job["id"], error_message="late error")
+    _commit(session)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# cancel_job
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_job_from_pending(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    result = repo.cancel_job(job["id"])
+    _commit(session)
+    assert result is True
+    assert repo.get_job(job["id"])["status"] == "cancelled"
+
+
+def test_cancel_job_from_running(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    result = repo.cancel_job(job["id"])
+    _commit(session)
+    assert result is True
+    assert repo.get_job(job["id"])["status"] == "cancelled"
+
+
+def test_cancel_job_returns_false_for_completed(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    repo.complete_job(job["id"], result_summary_json={})
+    _commit(session)
+    result = repo.cancel_job(job["id"])
+    _commit(session)
+    assert result is False
+
+
+def test_cancel_job_returns_false_for_failed(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    repo.fail_job(job["id"], error_message="err")
+    _commit(session)
+    result = repo.cancel_job(job["id"])
+    _commit(session)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# update_progress
+# ---------------------------------------------------------------------------
+
+
+def test_update_progress_on_running_job(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    repo.update_progress(job["id"], 50)
+    _commit(session)
+    assert repo.get_job(job["id"])["progress_percent"] == 50
+
+
+def test_update_progress_clamps_above_100(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    repo.update_progress(job["id"], 999)
+    _commit(session)
+    assert repo.get_job(job["id"])["progress_percent"] == 100
+
+
+def test_update_progress_clamps_below_zero(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    repo.update_progress(job["id"], -5)
+    _commit(session)
+    assert repo.get_job(job["id"])["progress_percent"] == 0
+
+
+def test_update_progress_does_not_affect_pending_job(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.update_progress(job["id"], 50)
+    _commit(session)
+    assert repo.get_job(job["id"])["progress_percent"] == 0
+
+
+# ---------------------------------------------------------------------------
+# transition_stale_jobs_to_failed (TTL enforcement)
+# ---------------------------------------------------------------------------
+
+
+def test_stale_running_job_transitions_to_failed(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    # Manually set started_at to 2 hours ago so it appears stale.
+    stale_ts = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+    from sqlalchemy import text
+
+    session.execute(
+        text("UPDATE processing_jobs SET status='running', started_at=:ts WHERE id=:id"),
+        {"ts": stale_ts, "id": job["id"]},
+    )
+    _commit(session)
+    count = repo.transition_stale_jobs_to_failed(timeout_seconds=60)
+    _commit(session)
+    assert count >= 1
+    fetched = repo.get_job(job["id"])
+    assert fetched["status"] == "failed"
+    assert fetched["error_message"] == "Job timed out"
+
+
+def test_fresh_running_job_not_transitioned(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    count = repo.transition_stale_jobs_to_failed(timeout_seconds=3600)
+    _commit(session)
+    assert repo.get_job(job["id"])["status"] == "running"
+    _ = count
+
+
+def test_pending_jobs_not_affected_by_stale_transition(repo, session):
+    job = repo.create_job(job_type="campaign_summary")
+    _commit(session)
+    repo.transition_stale_jobs_to_failed(timeout_seconds=1)
+    _commit(session)
+    assert repo.get_job(job["id"])["status"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# get_active_job_by_dedup_key
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_key_finds_pending_job(repo, session):
+    key = f"campaign_summary:{uuid.uuid4()}"
+    job = repo.create_job(job_type="campaign_summary", deduplication_key=key)
+    _commit(session)
+    found = repo.get_active_job_by_dedup_key(key)
+    assert found is not None
+    assert found["id"] == job["id"]
+
+
+def test_dedup_key_finds_running_job(repo, session):
+    key = f"campaign_summary:{uuid.uuid4()}"
+    job = repo.create_job(job_type="campaign_summary", deduplication_key=key)
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    found = repo.get_active_job_by_dedup_key(key)
+    assert found is not None
+    assert found["id"] == job["id"]
+
+
+def test_dedup_key_returns_none_after_complete(repo, session):
+    key = f"campaign_summary:{uuid.uuid4()}"
+    job = repo.create_job(job_type="campaign_summary", deduplication_key=key)
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    repo.complete_job(job["id"], result_summary_json={})
+    _commit(session)
+    found = repo.get_active_job_by_dedup_key(key)
+    assert found is None
+
+
+def test_dedup_key_returns_none_after_fail(repo, session):
+    key = f"campaign_summary:{uuid.uuid4()}"
+    job = repo.create_job(job_type="campaign_summary", deduplication_key=key)
+    _commit(session)
+    repo.start_job(job["id"])
+    _commit(session)
+    repo.fail_job(job["id"], error_message="err")
+    _commit(session)
+    found = repo.get_active_job_by_dedup_key(key)
+    assert found is None
+
+
+def test_dedup_key_returns_none_for_unknown_key(repo):
+    assert repo.get_active_job_by_dedup_key("nonexistent-key") is None
+
+
+def test_completed_job_does_not_block_new_job(repo, session):
+    """After a completed job, a new job with the same dedup key can be created."""
+    key = f"campaign_summary:{uuid.uuid4()}"
+    job1 = repo.create_job(job_type="campaign_summary", deduplication_key=key)
+    _commit(session)
+    repo.start_job(job1["id"])
+    _commit(session)
+    repo.complete_job(job1["id"], result_summary_json={})
+    _commit(session)
+
+    # No active job exists — safe to create a new one.
+    assert repo.get_active_job_by_dedup_key(key) is None
+    job2 = repo.create_job(job_type="campaign_summary", deduplication_key=key)
+    _commit(session)
+    assert job2["id"] != job1["id"]
+    assert job2["status"] == "pending"


### PR DESCRIPTION
## Summary

- Introduces `processing_jobs` table (15-column schema) as the central coordination store for all async AI operations
- Replaces module-level `_pending: set[str]` deduplication in `tasks.py` with DB-backed `deduplication_key` lookup — survives process restarts
- Refactors `POST /api/campaigns/{id}/summary` and `POST /api/campaigns/brief` from blocking 200 to 202 Accepted; AI execution moves to `app/jobs/runner.py` via `BackgroundTasks`
- Adds `GET /api/jobs/{job_id}` and `GET /api/jobs` polling endpoints with TTL enforcement on stale running jobs
- Adds Alembic migration `0004_phase6_processing_jobs` for production; `create_all_tables()` updated for test fixtures

## Architecture notes

- **202 contract is permanent**: designed for future Celery/worker migration — executor swaps from `BackgroundTasks` to `Celery` without changing API shape, polling URLs, or response schema
- **Job state machine**: `pending → running → completed | failed`; `pending/running → cancelled`; all transitions guarded by `WHERE status = <expected>` — no double-transitions possible
- **Dedup keys**: `campaign_summary:{campaign_id}` for summary jobs, `fingerprint:{ip}` for clustering jobs
- **Result storage**: full AI result stored in `result_summary_json` on the `processing_jobs` row for A1; `ai_outputs` table is PR A2

## Test plan

- [ ] `python -m pytest --tb=short -q` → 1023 passed, 3 skipped, 0 failures
- [ ] `tests/unit/test_jobs_repository.py` — full `JobRepository` CRUD, state machine, TTL, dedup key logic
- [ ] `tests/integration/test_jobs_endpoints.py` — GET /api/jobs/{id} and GET /api/jobs endpoint coverage
- [ ] `tests/integration/test_analyze_endpoints.py` — all 86 analyze tests updated for 202 + poll pattern
- [ ] pre-commit clean (black + ruff)

## Intentionally deferred

- `ai_outputs` table — PR A2
- `backend_metadata_json` populated on job completion — PR A2
- Dashboard polling integration — Phase 6 Group D
- Celery/Redis — not in scope
- Cursor-based pagination for GET /api/jobs — future iteration