### PR TITLE
feat(ai): Phase 6 Group A PR A2 — immutable AI output persistence

### DIFF
--- a/app/ai/backend.py
+++ b/app/ai/backend.py
@@ -64,6 +64,11 @@ class AIBackend(abc.ABC):
     and return a response string, with no side effects.
     """
 
+    @property
+    def model_name(self) -> str:
+        """The specific model identifier used by this backend instance."""
+        return "unknown"
+
     @abc.abstractmethod
     def generate(self, prompt: str) -> str:
         """Generate a response for the given prompt.
@@ -87,6 +92,10 @@ class DisabledAIBackend(AIBackend):
     the default backend and the safe fallback for misconfigured deployments.
     """
 
+    @property
+    def model_name(self) -> str:
+        return "none"
+
     def generate(self, prompt: str) -> str:
         raise AIDisabledError(
             "AI features are disabled. " "Set AI_BACKEND=claude or AI_BACKEND=ollama to enable."
@@ -108,6 +117,10 @@ class MockAIBackend(AIBackend):
     def __init__(self, response: str = "Mock AI response.") -> None:
         self._response = response
 
+    @property
+    def model_name(self) -> str:
+        return "mock"
+
     def generate(self, prompt: str) -> str:
         return self._response
 
@@ -128,6 +141,10 @@ class OllamaAIBackend(AIBackend):
         self._host = host.rstrip("/")
         self._model = model
         self._timeout = timeout
+
+    @property
+    def model_name(self) -> str:
+        return self._model
 
     def generate(self, prompt: str) -> str:
         try:
@@ -172,6 +189,10 @@ class ClaudeAIBackend(AIBackend):
         self._api_key = api_key
         self._model = model
         self._timeout = timeout
+
+    @property
+    def model_name(self) -> str:
+        return self._model
 
     def generate(self, prompt: str) -> str:
         try:

--- a/app/db/connection.py
+++ b/app/db/connection.py
@@ -238,7 +238,33 @@ def create_all_tables(engine: Engine) -> None:
                 "progress_percent INTEGER NOT NULL DEFAULT 0, "
                 "result_summary_json TEXT, "
                 "error_message TEXT, "
-                "backend_metadata_json TEXT)"
+                "backend_metadata_json TEXT, "
+                "ai_output_id TEXT)"
+            )
+        )
+
+        # Phase 6 PR A2 — immutable AI output records.
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS ai_outputs ("
+                "id TEXT PRIMARY KEY, "
+                "job_id TEXT NOT NULL, "
+                "output_type TEXT NOT NULL, "
+                "resource_type TEXT, "
+                "resource_id TEXT, "
+                "content TEXT, "
+                "backend TEXT NOT NULL, "
+                "model_name TEXT NOT NULL, "
+                "prompt_hash TEXT NOT NULL, "
+                "payload_bytes INTEGER NOT NULL, "
+                "source_records_json TEXT NOT NULL, "
+                "safety_flags_json TEXT, "
+                "rejected INTEGER NOT NULL DEFAULT 0, "
+                "rejection_reason TEXT, "
+                "truncated INTEGER NOT NULL DEFAULT 0, "
+                "data_quality_score REAL, "
+                "generated_at TEXT NOT NULL, "
+                "triggered_by TEXT)"
             )
         )
         conn.commit()

--- a/app/db/migrations/versions/0005_phase6_ai_outputs.py
+++ b/app/db/migrations/versions/0005_phase6_ai_outputs.py
@@ -1,0 +1,88 @@
+"""Phase 6 ai_outputs table and ai_output_id on processing_jobs
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-05-27
+
+Creates: ai_outputs
+Alters:  processing_jobs — adds ai_output_id column
+
+ai_outputs is an immutable provenance record for every AI-generated artifact.
+Write-once semantics enforced at the application layer (no UPDATE path).
+Corrections create new rows; old rows are never modified.
+
+Columns align with §8.2 of the Phase 6 blueprint, using the resource_type /
+resource_id pattern for consistency with processing_jobs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # ai_outputs — immutable AI-generated artifact records.
+    #
+    # output_type:         campaign_summary | campaign_brief
+    # resource_type:       campaign (summaries) | null (briefs)
+    # resource_id:         campaign_id (summaries) | null (briefs)
+    # content:             AI text; null when rejected=1
+    # backend:             claude | ollama | none | mock
+    # model_name:          the specific model identifier (indexed)
+    # prompt_hash:         SHA-256 of user_prompt; no prompt content stored
+    # payload_bytes:       byte count of user_prompt for audit
+    # source_records_json: provenance metadata snapshot at generation time
+    # safety_flags_json:   flags from prompt_builder (e.g. low_confidence)
+    # rejected:            1 when output failed safety validation
+    # rejection_reason:    ip_detected | empty_response | null
+    # truncated:           1 when output was cut to the length limit
+    # data_quality_score:  composite score from confidence/obs/fp completeness
+    # generated_at:        when the AI call completed (not when job was created)
+    # triggered_by:        api_key | user:{sub} | system:ingest
+    # ------------------------------------------------------------------
+    op.create_table(
+        "ai_outputs",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("job_id", sa.Text, nullable=False),
+        sa.Column("output_type", sa.Text, nullable=False),
+        sa.Column("resource_type", sa.Text, nullable=True),
+        sa.Column("resource_id", sa.Text, nullable=True),
+        sa.Column("content", sa.Text, nullable=True),
+        sa.Column("backend", sa.Text, nullable=False),
+        sa.Column("model_name", sa.Text, nullable=False),
+        sa.Column("prompt_hash", sa.Text, nullable=False),
+        sa.Column("payload_bytes", sa.Integer, nullable=False),
+        sa.Column("source_records_json", sa.Text, nullable=False),
+        sa.Column("safety_flags_json", sa.Text, nullable=True),
+        sa.Column("rejected", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("rejection_reason", sa.Text, nullable=True),
+        sa.Column("truncated", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("data_quality_score", sa.Real, nullable=True),
+        sa.Column("generated_at", sa.Text, nullable=False),
+        sa.Column("triggered_by", sa.Text, nullable=True),
+    )
+    op.create_index("idx_ai_outputs_job_id", "ai_outputs", ["job_id"])
+    op.create_index("idx_ai_outputs_resource", "ai_outputs", ["resource_type", "resource_id"])
+    op.create_index("idx_ai_outputs_generated_at", "ai_outputs", ["generated_at"])
+    op.create_index("idx_ai_outputs_model_name", "ai_outputs", ["model_name"])
+
+    # Add ai_output_id to processing_jobs so the polling endpoint can expose it.
+    op.add_column("processing_jobs", sa.Column("ai_output_id", sa.Text, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_index("idx_ai_outputs_model_name", table_name="ai_outputs")
+    op.drop_index("idx_ai_outputs_generated_at", table_name="ai_outputs")
+    op.drop_index("idx_ai_outputs_resource", table_name="ai_outputs")
+    op.drop_index("idx_ai_outputs_job_id", table_name="ai_outputs")
+    op.drop_table("ai_outputs")
+    op.drop_column("processing_jobs", "ai_output_id")

--- a/app/db/repositories/ai_outputs.py
+++ b/app/db/repositories/ai_outputs.py
@@ -1,0 +1,193 @@
+"""AI outputs repository — write-once CRUD for the ai_outputs table.
+
+All SQL lives here. No mutation methods are provided: ai_outputs are
+immutable historical records. Corrections create new rows; old rows are
+never modified or deleted by application code.
+
+Write-once invariant: create_ai_output() is the only write method.
+There is no update_ai_output() and no delete_ai_output().
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db.repositories._base import RepositoryBase
+
+
+def _row_to_dict(row) -> dict[str, Any]:
+    return {
+        "id": row[0],
+        "job_id": row[1],
+        "output_type": row[2],
+        "resource_type": row[3],
+        "resource_id": row[4],
+        "content": row[5],
+        "backend": row[6],
+        "model_name": row[7],
+        "prompt_hash": row[8],
+        "payload_bytes": row[9],
+        "source_records_json": row[10],
+        "safety_flags_json": row[11],
+        "rejected": bool(row[12]),
+        "rejection_reason": row[13],
+        "truncated": bool(row[14]),
+        "data_quality_score": row[15],
+        "generated_at": row[16],
+        "triggered_by": row[17],
+    }
+
+
+_SELECT_COLS = """
+    SELECT id, job_id, output_type, resource_type, resource_id,
+           content, backend, model_name, prompt_hash, payload_bytes,
+           source_records_json, safety_flags_json, rejected,
+           rejection_reason, truncated, data_quality_score,
+           generated_at, triggered_by
+    FROM ai_outputs
+"""
+
+
+class AiOutputRepository(RepositoryBase):
+    def create_ai_output(
+        self,
+        *,
+        output_id: str | None = None,
+        job_id: str,
+        output_type: str,
+        resource_type: str | None = None,
+        resource_id: str | None = None,
+        content: str | None = None,
+        backend: str,
+        model_name: str,
+        prompt_hash: str,
+        payload_bytes: int,
+        source_records_json: dict | list | str,
+        safety_flags_json: list | str | None = None,
+        rejected: bool = False,
+        rejection_reason: str | None = None,
+        truncated: bool = False,
+        data_quality_score: float | None = None,
+        generated_at: str | None = None,
+        triggered_by: str | None = None,
+    ) -> dict[str, Any]:
+        """Insert an immutable ai_outputs row and return it.
+
+        This is the only write method. There is no update path.
+        """
+        oid = output_id or str(uuid.uuid4())
+        now = generated_at or datetime.now(UTC).isoformat()
+        src_str = (
+            json.dumps(source_records_json)
+            if not isinstance(source_records_json, str)
+            else source_records_json
+        )
+        flags_str = (
+            json.dumps(safety_flags_json)
+            if safety_flags_json is not None and not isinstance(safety_flags_json, str)
+            else safety_flags_json
+        )
+        self._session.execute(
+            text("""
+                INSERT INTO ai_outputs (
+                    id, job_id, output_type, resource_type, resource_id,
+                    content, backend, model_name, prompt_hash, payload_bytes,
+                    source_records_json, safety_flags_json, rejected,
+                    rejection_reason, truncated, data_quality_score,
+                    generated_at, triggered_by
+                ) VALUES (
+                    :id, :job_id, :output_type, :resource_type, :resource_id,
+                    :content, :backend, :model_name, :prompt_hash, :payload_bytes,
+                    :source_records_json, :safety_flags_json, :rejected,
+                    :rejection_reason, :truncated, :data_quality_score,
+                    :generated_at, :triggered_by
+                )
+            """),
+            {
+                "id": oid,
+                "job_id": job_id,
+                "output_type": output_type,
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "content": content,
+                "backend": backend,
+                "model_name": model_name,
+                "prompt_hash": prompt_hash,
+                "payload_bytes": payload_bytes,
+                "source_records_json": src_str,
+                "safety_flags_json": flags_str,
+                "rejected": 1 if rejected else 0,
+                "rejection_reason": rejection_reason,
+                "truncated": 1 if truncated else 0,
+                "data_quality_score": data_quality_score,
+                "generated_at": now,
+                "triggered_by": triggered_by,
+            },
+        )
+        return self.get_ai_output(oid)  # type: ignore[return-value]
+
+    def get_ai_output(self, output_id: str) -> dict[str, Any] | None:
+        """Return an ai_outputs row by id, or None if not found."""
+        row = self._session.execute(
+            text(_SELECT_COLS + "WHERE id = :id"),
+            {"id": output_id},
+        ).fetchone()
+        return _row_to_dict(row) if row is not None else None
+
+    def list_ai_outputs_for_resource(
+        self,
+        resource_type: str,
+        resource_id: str,
+        *,
+        output_type: str | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Return ai_outputs for a resource, newest first.
+
+        Optionally filtered by output_type (e.g. 'campaign_summary').
+        """
+        params: dict[str, Any] = {
+            "resource_type": resource_type,
+            "resource_id": resource_id,
+            "limit": limit,
+        }
+        type_clause = ""
+        if output_type is not None:
+            type_clause = "AND output_type = :output_type"
+            params["output_type"] = output_type
+        rows = self._session.execute(
+            text(
+                _SELECT_COLS
+                + "WHERE resource_type = :resource_type "
+                + "AND resource_id = :resource_id "
+                + type_clause
+                + " ORDER BY generated_at DESC LIMIT :limit"
+            ),
+            params,
+        ).fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    def list_ai_outputs_for_job(self, job_id: str) -> list[dict[str, Any]]:
+        """Return all ai_outputs produced by a given job, newest first."""
+        rows = self._session.execute(
+            text(_SELECT_COLS + "WHERE job_id = :job_id ORDER BY generated_at DESC"),
+            {"job_id": job_id},
+        ).fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    def get_latest_ai_output_for_resource(
+        self,
+        resource_type: str,
+        resource_id: str,
+        output_type: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Return the most recently generated ai_output for a resource, or None."""
+        results = self.list_ai_outputs_for_resource(
+            resource_type, resource_id, output_type=output_type, limit=1
+        )
+        return results[0] if results else None

--- a/app/db/repositories/jobs.py
+++ b/app/db/repositories/jobs.py
@@ -46,6 +46,7 @@ def _row_to_dict(row) -> dict[str, Any]:
         "result_summary_json": row[12],
         "error_message": row[13],
         "backend_metadata_json": row[14],
+        "ai_output_id": row[15] if len(row) > 15 else None,
     }
 
 
@@ -104,7 +105,7 @@ class JobRepository(RepositoryBase):
                        completed_at, failed_at, triggered_by,
                        resource_type, resource_id, deduplication_key,
                        progress_percent, result_summary_json,
-                       error_message, backend_metadata_json
+                       error_message, backend_metadata_json, ai_output_id
                 FROM processing_jobs WHERE id = :id
             """),
             {"id": job_id},
@@ -140,7 +141,7 @@ class JobRepository(RepositoryBase):
                        completed_at, failed_at, triggered_by,
                        resource_type, resource_id, deduplication_key,
                        progress_percent, result_summary_json,
-                       error_message, backend_metadata_json
+                       error_message, backend_metadata_json, ai_output_id
                 FROM processing_jobs
                 {where}
                 ORDER BY created_at DESC
@@ -163,7 +164,7 @@ class JobRepository(RepositoryBase):
                        completed_at, failed_at, triggered_by,
                        resource_type, resource_id, deduplication_key,
                        progress_percent, result_summary_json,
-                       error_message, backend_metadata_json
+                       error_message, backend_metadata_json, ai_output_id
                 FROM processing_jobs
                 WHERE deduplication_key = :key
                   AND status IN ('pending', 'running')
@@ -199,10 +200,12 @@ class JobRepository(RepositoryBase):
         completed_at: str | None = None,
         result_summary_json: dict | str | None = None,
         backend_metadata_json: dict | str | None = None,
+        ai_output_id: str | None = None,
     ) -> bool:
         """Transition job from 'running' to 'completed'.
 
         Returns True on success, False if job is not in 'running' state.
+        ai_output_id links to the persisted ai_outputs row (set in PR A2+).
         """
         now = completed_at or datetime.now(UTC).isoformat()
         result_str = (
@@ -222,7 +225,8 @@ class JobRepository(RepositoryBase):
                     completed_at = :completed_at,
                     progress_percent = 100,
                     result_summary_json = :result_summary_json,
-                    backend_metadata_json = :backend_metadata_json
+                    backend_metadata_json = :backend_metadata_json,
+                    ai_output_id = :ai_output_id
                 WHERE id = :id AND status = 'running'
             """),
             {
@@ -230,6 +234,7 @@ class JobRepository(RepositoryBase):
                 "completed_at": now,
                 "result_summary_json": result_str,
                 "backend_metadata_json": meta_str,
+                "ai_output_id": ai_output_id,
             },
         )
         return result.rowcount > 0

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -28,6 +28,7 @@ No FastAPI, router, or application imports belong in the sub-modules.
 
 from __future__ import annotations
 
+from app.db.repositories.ai_outputs import AiOutputRepository
 from app.db.repositories.campaign import CampaignRepository
 from app.db.repositories.fingerprint import FingerprintRepository
 from app.db.repositories.intelligence import IntelligenceRepository
@@ -43,13 +44,15 @@ class EventRepository(
     FingerprintRepository,
     CampaignRepository,
     JobRepository,
+    AiOutputRepository,
 ):
     """
-    Unified repository class. Inherits all SQL methods from the six concern
+    Unified repository class. Inherits all SQL methods from the seven concern
     mixins. Callers see a single object with the full method surface; the
     internal split is an organisation detail invisible to callers.
 
     Python MRO: EventRepository → WriteRepository → ReadRepository →
                 IntelligenceRepository → FingerprintRepository →
-                CampaignRepository → JobRepository → RepositoryBase → object
+                CampaignRepository → JobRepository →
+                AiOutputRepository → RepositoryBase → object
     """

--- a/app/jobs/runner.py
+++ b/app/jobs/runner.py
@@ -8,22 +8,26 @@ Execution model:
   2. Transition to 'running' via start_job(). If start_job returns False,
      another executor has already taken the job — return silently.
   3. Execute AI logic (read-only DB fetch → prompt build → AI call → validate).
-  4. On success: complete_job() with result_summary_json.
+  4. On success: write ai_outputs row, then complete_job() with ai_output_id.
   5. On any exception: fail_job() with a safe error summary. Stack traces
      are logged but never stored in the job record.
 
 Deterministic-first invariants enforced here:
   - No writes to campaigns, fingerprints, events, or observations.
-  - AI output is stored only in processing_jobs.result_summary_json (A1).
-    PR A2 will introduce the ai_outputs table.
+  - AI outputs are stored in ai_outputs (PR A2) and result_summary_json
+    on processing_jobs is retained for polling continuity.
   - get_ai_backend() is imported here so tests can monkeypatch
     'app.jobs.runner.get_ai_backend' without touching the router.
+  - AI outputs are never used as prompt inputs (§3, §10 Rule 1).
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import time
+import uuid
 from datetime import UTC, datetime
 
 from app.ai import (
@@ -93,7 +97,6 @@ def _execute_summary(job_id: str) -> None:
         repo = EventRepository(session)
         started = repo.start_job(job_id, started_at=started_at)
         if not started:
-            # Another executor already took this job, or it was cancelled.
             logger.debug("run_campaign_summary_job: job %s not in pending state, skipping", job_id)
             return
         job = repo.get_job(job_id)
@@ -103,6 +106,7 @@ def _execute_summary(job_id: str) -> None:
         return
 
     campaign_id: str = job.get("resource_id") or ""
+    triggered_by: str | None = job.get("triggered_by")
 
     # Fetch campaign data — read-only session, separate from job lifecycle session.
     with get_session() as session:
@@ -120,10 +124,14 @@ def _execute_summary(job_id: str) -> None:
 
     # Build prompt and call AI backend.
     prompt_data = build_campaign_summary_prompt(campaign, fingerprint, observations)
+    user_prompt = prompt_data["user_prompt"]
+    prompt_hash = _prompt_hash(user_prompt)
+    payload_bytes = len(user_prompt.encode("utf-8"))
+    data_quality_score = _compute_data_quality_score(campaign, fingerprint, observations)
 
     try:
         backend = get_ai_backend()
-        raw_output = backend.generate(prompt_data["user_prompt"])
+        raw_output = backend.generate(user_prompt)
     except AIDisabledError as exc:
         _fail_job_safe(job_id, str(exc))
         return
@@ -156,12 +164,38 @@ def _execute_summary(job_id: str) -> None:
     }
     backend_meta = {"ai_backend": settings.AI_BACKEND, "latency_ms": latency_ms}
 
+    # Write ai_output BEFORE completing the job.
+    output_id = str(uuid.uuid4())
+    with get_session() as session:
+        repo = EventRepository(session)
+        repo.create_ai_output(
+            output_id=output_id,
+            job_id=job_id,
+            output_type="campaign_summary",
+            resource_type="campaign",
+            resource_id=campaign_id,
+            content=None if is_rejected else validated_text,
+            backend=settings.AI_BACKEND,
+            model_name=backend.model_name,
+            prompt_hash=prompt_hash,
+            payload_bytes=payload_bytes,
+            source_records_json=prompt_data["source_records"],
+            safety_flags_json=prompt_data["safety_flags"],
+            rejected=is_rejected,
+            rejection_reason=rejection_reason,
+            truncated=is_truncated,
+            data_quality_score=data_quality_score,
+            generated_at=generated_at,
+            triggered_by=triggered_by,
+        )
+
     with get_session() as session:
         repo = EventRepository(session)
         repo.complete_job(
             job_id,
             result_summary_json=result,
             backend_metadata_json=backend_meta,
+            ai_output_id=output_id,
         )
 
 
@@ -180,13 +214,13 @@ def _execute_brief(job_id: str) -> None:
     if job is None:
         return
 
+    triggered_by: str | None = job.get("triggered_by")
+
     # Parse max_campaigns from backend_metadata_json (stored by analyze router).
     max_campaigns = 10
     if job.get("backend_metadata_json"):
-        import json as _json
-
         try:
-            meta = _json.loads(job["backend_metadata_json"])
+            meta = json.loads(job["backend_metadata_json"])
             max_campaigns = int(meta.get("max_campaigns", 10))
         except (ValueError, TypeError, KeyError):
             pass
@@ -224,10 +258,14 @@ def _execute_brief(job_id: str) -> None:
         return
 
     prompt_data = build_brief_prompt(campaigns)
+    user_prompt = prompt_data["user_prompt"]
+    prompt_hash = _prompt_hash(user_prompt)
+    payload_bytes = len(user_prompt.encode("utf-8"))
+    data_quality_score = round(min(len(campaigns) / 10.0, 1.0), 3)
 
     try:
         backend = get_ai_backend()
-        raw_output = backend.generate(prompt_data["user_prompt"])
+        raw_output = backend.generate(user_prompt)
     except AIDisabledError as exc:
         _fail_job_safe(job_id, str(exc))
         return
@@ -259,13 +297,77 @@ def _execute_brief(job_id: str) -> None:
     }
     backend_meta = {"ai_backend": settings.AI_BACKEND, "latency_ms": latency_ms}
 
+    # Write ai_output BEFORE completing the job.
+    output_id = str(uuid.uuid4())
+    with get_session() as session:
+        repo = EventRepository(session)
+        repo.create_ai_output(
+            output_id=output_id,
+            job_id=job_id,
+            output_type="campaign_brief",
+            resource_type=None,
+            resource_id=None,
+            content=None if is_rejected else validated_text,
+            backend=settings.AI_BACKEND,
+            model_name=backend.model_name,
+            prompt_hash=prompt_hash,
+            payload_bytes=payload_bytes,
+            source_records_json=prompt_data["source_records"],
+            safety_flags_json=None,
+            rejected=is_rejected,
+            rejection_reason=rejection_reason,
+            truncated=is_truncated,
+            data_quality_score=data_quality_score,
+            generated_at=generated_at,
+            triggered_by=triggered_by,
+        )
+
     with get_session() as session:
         repo = EventRepository(session)
         repo.complete_job(
             job_id,
             result_summary_json=result,
             backend_metadata_json=backend_meta,
+            ai_output_id=output_id,
         )
+
+
+# ---------------------------------------------------------------------------
+# Provenance helpers
+# ---------------------------------------------------------------------------
+
+
+def _prompt_hash(prompt_text: str) -> str:
+    """Return SHA-256 hex digest of the prompt. No prompt content is stored."""
+    return hashlib.sha256(prompt_text.encode("utf-8")).hexdigest()
+
+
+def _compute_data_quality_score(
+    campaign: dict,
+    fingerprint: dict | None,
+    observations: list,
+) -> float:
+    """Composite data quality score: confidence 40%, obs 30%, fp 20%, recency 10%."""
+    confidence = float(campaign.get("confidence") or 0.5)
+
+    obs_score = min(len(observations) / 10.0, 1.0)
+
+    fp_score = 0.0
+    if fingerprint:
+        dims = [
+            "timing_features",
+            "sequence_features",
+            "protocol_features",
+            "credential_features",
+            "target_features",
+        ]
+        present = sum(1 for d in dims if fingerprint.get(d))
+        fp_score = present / 5.0
+
+    recency = 1.0 if observations else 0.0
+
+    score = confidence * 0.4 + obs_score * 0.3 + fp_score * 0.2 + recency * 0.1
+    return round(score, 3)
 
 
 # ---------------------------------------------------------------------------

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ from app.routers import (
     events,  # Event listing endpoint
 )
 from app.routers.admin import router as admin_router  # POST /api/admin/*
+from app.routers.ai_outputs import router as ai_outputs_router  # GET /api/ai/outputs/*
 from app.routers.analyze import router as analyze_router  # POST /api/campaigns/*/summary
 from app.routers.campaigns import router as campaigns_router  # GET /api/campaigns/*
 from app.routers.exports import router as exports_router  # GET /api/exports/*
@@ -64,6 +65,7 @@ app.include_router(intelligence_router)  # /api/intelligence/*
 app.include_router(campaigns_router)  # /api/campaigns/*
 app.include_router(analyze_router)  # /api/campaigns/*/summary|brief
 app.include_router(jobs_router)  # /api/jobs/*
+app.include_router(ai_outputs_router)  # /api/ai/outputs/* + /api/campaigns/*/ai-outputs
 app.include_router(exports_router)  # /api/exports/*
 app.include_router(iocs_pf_router, prefix="/api/iocs")  # pf.conf generator
 app.include_router(stats_router)  # /api/stats

--- a/app/routers/ai_outputs.py
+++ b/app/routers/ai_outputs.py
@@ -1,0 +1,93 @@
+"""AI output retrieval endpoints — Phase 6 PR A2.
+
+GET /api/ai/outputs/{output_id}
+  Retrieve a single AI output record by ID.
+
+GET /api/campaigns/{campaign_id}/ai-outputs
+  List all AI output records for a campaign, newest first.
+
+Rules:
+  - Auth required on all endpoints.
+  - Read-only: no generation, no mutation, no delete.
+  - AI outputs are never fed back into the prompt builder (§3, §10 Rule 1).
+  - Prompt content is never stored or exposed; only prompt_hash.
+  - source_records_json is visible for provenance and audit.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.db.connection import get_session
+from app.db.repository import EventRepository
+from app.utils.auth import require_jwt_or_api_key
+
+router = APIRouter(tags=["ai_outputs"])
+
+
+def _enrich_output(output: dict) -> dict:
+    """Parse JSON string fields into structured objects for API consumers."""
+    enriched = dict(output)
+    for field in ("source_records_json", "safety_flags_json"):
+        raw = enriched.get(field)
+        key = field.replace("_json", "")
+        if raw:
+            try:
+                enriched[key] = json.loads(raw)
+            except (ValueError, TypeError):
+                enriched[key] = None
+        else:
+            enriched[key] = None
+        enriched.pop(field, None)
+    return enriched
+
+
+@router.get("/api/ai/outputs/{output_id}")
+def get_ai_output(
+    output_id: str,
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return a single AI output record by ID.
+
+    Returns 404 when the output_id is unknown. Never triggers AI generation.
+    """
+    with get_session() as session:
+        repo = EventRepository(session)
+        output = repo.get_ai_output(output_id)
+
+    if output is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"AI output {output_id!r} not found",
+        )
+    return _enrich_output(output)
+
+
+@router.get("/api/campaigns/{campaign_id}/ai-outputs")
+def list_campaign_ai_outputs(
+    campaign_id: str,
+    output_type: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """List AI output records for a campaign, newest first.
+
+    Optionally filtered by output_type (e.g. 'campaign_summary').
+    Returns an empty list when the campaign has no outputs — never 404.
+    """
+    with get_session() as session:
+        repo = EventRepository(session)
+        outputs = repo.list_ai_outputs_for_resource(
+            "campaign",
+            campaign_id,
+            output_type=output_type,
+            limit=limit,
+        )
+
+    return {
+        "campaign_id": campaign_id,
+        "outputs": [_enrich_output(o) for o in outputs],
+        "count": len(outputs),
+    }

--- a/app/routers/jobs.py
+++ b/app/routers/jobs.py
@@ -55,6 +55,9 @@ def _enrich_job(job: dict) -> dict:
     else:
         enriched["backend_metadata"] = None
 
+    # ai_output_id is already a plain string (or None); no parsing needed.
+    # It links to GET /api/ai/outputs/{ai_output_id} when status=completed.
+
     return enriched
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,7 @@ def reset_db_rows():
     yield
     engine = get_engine()
     with engine.connect() as conn:
+        conn.execute(text("DELETE FROM ai_outputs"))
         conn.execute(text("DELETE FROM processing_jobs"))
         conn.execute(text("DELETE FROM behavioral_fingerprints"))
         conn.execute(text("DELETE FROM campaign_tags"))

--- a/tests/integration/test_ai_outputs_endpoints.py
+++ b/tests/integration/test_ai_outputs_endpoints.py
@@ -1,0 +1,381 @@
+"""Integration tests for AI output persistence (Phase 6 PR A2).
+
+Tests verify:
+  - summary job creates an ai_output record
+  - brief job creates an ai_output record
+  - ai_output_id present in completed job response
+  - GET /api/ai/outputs/{id} returns 200 with full record
+  - GET /api/ai/outputs/{id} returns 404 for unknown id
+  - GET /api/ai/outputs/{id} requires auth
+  - GET /api/campaigns/{id}/ai-outputs returns list of outputs
+  - GET /api/campaigns/{id}/ai-outputs returns empty list for new campaign
+  - GET /api/campaigns/{id}/ai-outputs requires auth
+  - Rejected output persists with content=None in DB
+  - Rejected output retrievable via GET
+  - Multiple summary jobs create separate output records (no overwrite)
+  - data_quality_score present and non-negative on completed output
+  - prompt_hash present; content of prompt never stored
+  - source_records parseable as JSON
+  - AI output is never used as prompt input (invariant check)
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.ai import MockAIBackend
+from app.db.connection import get_engine
+from app.main import app
+
+client = TestClient(app)
+HEADERS = {"x-api-key": "dev-123"}
+
+_CID = "cccccccc-dddd-eeee-ffff-000000000001"
+_MEMBER_IP = "10.1.2.3"
+_TS = "2026-01-15T00:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_campaign(campaign_id: str = _CID, *, status: str = "active") -> None:
+    engine = get_engine()
+    with engine.connect() as conn:
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO campaigns (
+                    id, name, status, confidence,
+                    first_seen, last_seen, dormant_since,
+                    reactivation_count, member_ip_count,
+                    attack_tactic_dist, top_target_ports, notes,
+                    created_at, updated_at
+                ) VALUES (
+                    :id, :name, :status, 0.75,
+                    :ts, :ts, NULL, 0, 1,
+                    '{}', '[]', NULL, :ts, :ts
+                )
+            """),
+            {"id": campaign_id, "name": "OUT-TEST", "status": status, "ts": _TS},
+        )
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO source_ips (ip, first_seen, last_seen, event_count)
+                VALUES (:ip, :ts, :ts, 5)
+            """),
+            {"ip": _MEMBER_IP, "ts": _TS},
+        )
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO campaign_members
+                    (campaign_id, source_ip, confidence, added_at, last_active)
+                VALUES (:cid, :ip, 0.75, :ts, :ts)
+            """),
+            {"cid": campaign_id, "ip": _MEMBER_IP, "ts": _TS},
+        )
+        conn.commit()
+
+
+def _trigger_summary(monkeypatch, campaign_id: str = _CID) -> dict:
+    """POST /summary and return the 202 JSON body."""
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Campaign is active. Credential scanning observed."),
+    )
+    resp = client.post(f"/api/campaigns/{campaign_id}/summary", headers=HEADERS)
+    assert resp.status_code == 202
+    return resp.json()
+
+
+def _poll_job(job_id: str) -> dict:
+    resp = client.get(f"/api/jobs/{job_id}", headers=HEADERS)
+    assert resp.status_code == 200
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Summary job creates ai_output
+# ---------------------------------------------------------------------------
+
+
+def test_summary_job_sets_ai_output_id(monkeypatch):
+    _insert_campaign()
+    accepted = _trigger_summary(monkeypatch)
+    job = _poll_job(accepted["job_id"])
+    assert job["status"] == "completed"
+    assert job["ai_output_id"] is not None
+
+
+def test_summary_job_ai_output_retrievable(monkeypatch):
+    _insert_campaign()
+    accepted = _trigger_summary(monkeypatch)
+    job = _poll_job(accepted["job_id"])
+    output_id = job["ai_output_id"]
+
+    resp = client.get(f"/api/ai/outputs/{output_id}", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == output_id
+    assert body["job_id"] == accepted["job_id"]
+    assert body["output_type"] == "campaign_summary"
+    assert body["resource_type"] == "campaign"
+    assert body["resource_id"] == _CID
+
+
+def test_summary_output_has_content(monkeypatch):
+    _insert_campaign()
+    accepted = _trigger_summary(monkeypatch)
+    job = _poll_job(accepted["job_id"])
+    resp = client.get(f"/api/ai/outputs/{job['ai_output_id']}", headers=HEADERS)
+    body = resp.json()
+    assert body["content"] is not None
+    assert len(body["content"]) > 0
+
+
+def test_summary_output_has_prompt_hash(monkeypatch):
+    _insert_campaign()
+    accepted = _trigger_summary(monkeypatch)
+    job = _poll_job(accepted["job_id"])
+    resp = client.get(f"/api/ai/outputs/{job['ai_output_id']}", headers=HEADERS)
+    body = resp.json()
+    assert body["prompt_hash"] is not None
+    assert len(body["prompt_hash"]) == 64  # SHA-256 hex
+
+
+def test_summary_output_has_no_raw_prompt(monkeypatch):
+    """Prompt content must never appear in the ai_output record."""
+    _insert_campaign()
+    accepted = _trigger_summary(monkeypatch)
+    job = _poll_job(accepted["job_id"])
+    resp = client.get(f"/api/ai/outputs/{job['ai_output_id']}", headers=HEADERS)
+    body = resp.json()
+    assert "user_prompt" not in body
+    assert "prompt" not in body
+
+
+def test_summary_output_data_quality_score_present(monkeypatch):
+    _insert_campaign()
+    accepted = _trigger_summary(monkeypatch)
+    job = _poll_job(accepted["job_id"])
+    resp = client.get(f"/api/ai/outputs/{job['ai_output_id']}", headers=HEADERS)
+    body = resp.json()
+    assert body["data_quality_score"] is not None
+    assert body["data_quality_score"] >= 0.0
+
+
+def test_summary_output_source_records_parseable(monkeypatch):
+    _insert_campaign()
+    accepted = _trigger_summary(monkeypatch)
+    job = _poll_job(accepted["job_id"])
+    resp = client.get(f"/api/ai/outputs/{job['ai_output_id']}", headers=HEADERS)
+    body = resp.json()
+    assert isinstance(body["source_records"], dict)
+
+
+def test_summary_output_backend_and_model_name(monkeypatch):
+    _insert_campaign()
+    accepted = _trigger_summary(monkeypatch)
+    job = _poll_job(accepted["job_id"])
+    resp = client.get(f"/api/ai/outputs/{job['ai_output_id']}", headers=HEADERS)
+    body = resp.json()
+    assert body["backend"] == "none"  # default AI_BACKEND in test env
+    assert body["model_name"] == "mock"  # MockAIBackend.model_name
+
+
+def test_summary_output_triggered_by(monkeypatch):
+    _insert_campaign()
+    accepted = _trigger_summary(monkeypatch)
+    job = _poll_job(accepted["job_id"])
+    resp = client.get(f"/api/ai/outputs/{job['ai_output_id']}", headers=HEADERS)
+    body = resp.json()
+    assert body["triggered_by"] == "api_key"
+
+
+# ---------------------------------------------------------------------------
+# Brief job creates ai_output
+# ---------------------------------------------------------------------------
+
+
+def test_brief_job_sets_ai_output_id(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Threat brief: campaign is active."),
+    )
+    resp = client.post("/api/campaigns/brief", headers=HEADERS)
+    assert resp.status_code == 202
+    job = _poll_job(resp.json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["ai_output_id"] is not None
+
+
+def test_brief_output_has_correct_type(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Threat brief: active campaign observed."),
+    )
+    resp = client.post("/api/campaigns/brief", headers=HEADERS)
+    job = _poll_job(resp.json()["job_id"])
+    output_resp = client.get(f"/api/ai/outputs/{job['ai_output_id']}", headers=HEADERS)
+    body = output_resp.json()
+    assert body["output_type"] == "campaign_brief"
+    assert body["resource_type"] is None  # briefs have no single resource
+
+
+# ---------------------------------------------------------------------------
+# Rejected output
+# ---------------------------------------------------------------------------
+
+
+def test_rejected_output_persists_with_null_content(monkeypatch):
+    """IP in output → rejected=True, content=None, but ai_output row is written."""
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Campaign run by 192.168.1.1."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 202
+    job = _poll_job(resp.json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["ai_output_id"] is not None
+
+    output_resp = client.get(f"/api/ai/outputs/{job['ai_output_id']}", headers=HEADERS)
+    body = output_resp.json()
+    assert body["rejected"] is True
+    assert body["content"] is None
+    assert body["rejection_reason"] == "ip_detected"
+
+
+# ---------------------------------------------------------------------------
+# Multiple outputs for same campaign accumulate
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_summaries_create_separate_outputs(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Active campaign."),
+    )
+    resp1 = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job1 = _poll_job(resp1.json()["job_id"])
+
+    # Need a second job — mark first completed so dedup allows it.
+    resp2 = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job2 = _poll_job(resp2.json()["job_id"])
+
+    assert job1["ai_output_id"] != job2["ai_output_id"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/campaigns/{id}/ai-outputs
+# ---------------------------------------------------------------------------
+
+
+def test_campaign_ai_outputs_returns_list(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Active."),
+    )
+    client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    resp = client.get(f"/api/campaigns/{_CID}/ai-outputs", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "outputs" in body
+    assert "count" in body
+    assert isinstance(body["outputs"], list)
+    assert body["count"] == len(body["outputs"])
+
+
+def test_campaign_ai_outputs_contains_created_output(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Active campaign."),
+    )
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    job = _poll_job(resp.json()["job_id"])
+    output_id = job["ai_output_id"]
+
+    list_resp = client.get(f"/api/campaigns/{_CID}/ai-outputs", headers=HEADERS)
+    ids = [o["id"] for o in list_resp.json()["outputs"]]
+    assert output_id in ids
+
+
+def test_campaign_ai_outputs_empty_for_no_outputs():
+    cid = str(uuid.uuid4())
+    _insert_campaign(campaign_id=cid)
+    resp = client.get(f"/api/campaigns/{cid}/ai-outputs", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["outputs"] == []
+    assert body["count"] == 0
+
+
+def test_campaign_ai_outputs_requires_auth():
+    resp = client.get(f"/api/campaigns/{_CID}/ai-outputs")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/ai/outputs/{output_id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_output_requires_auth(monkeypatch):
+    _insert_campaign()
+    accepted = _trigger_summary(monkeypatch)
+    job = _poll_job(accepted["job_id"])
+    resp = client.get(f"/api/ai/outputs/{job['ai_output_id']}")
+    assert resp.status_code == 401
+
+
+def test_get_output_returns_404_for_unknown():
+    resp = client.get("/api/ai/outputs/does-not-exist", headers=HEADERS)
+    assert resp.status_code == 404
+
+
+def test_get_output_wrong_key_returns_401(monkeypatch):
+    _insert_campaign()
+    accepted = _trigger_summary(monkeypatch)
+    job = _poll_job(accepted["job_id"])
+    resp = client.get(
+        f"/api/ai/outputs/{job['ai_output_id']}",
+        headers={"x-api-key": "wrong"},
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# AI output never used as prompt input (§3 invariant)
+# ---------------------------------------------------------------------------
+
+
+def test_ai_output_content_not_in_prompt_builder(monkeypatch):
+    """Verify prompt_builder functions do not accept or use stored ai_output records.
+
+    This is a code-level invariant test: the build_campaign_summary_prompt
+    signature takes campaign, fingerprint, observations — not an ai_output dict.
+    Passing an ai_output dict where campaign is expected must not silently succeed.
+    """
+    from app.ai.prompt_builder import build_campaign_summary_prompt
+
+    fake_ai_output = {
+        "id": "o1",
+        "content": "Previous AI summary text",
+        "output_type": "campaign_summary",
+    }
+    # build_campaign_summary_prompt should not return content from fake_ai_output
+    try:
+        result = build_campaign_summary_prompt(fake_ai_output, None, [])
+        # If it didn't raise, verify the prompt does not echo the AI output content
+        assert "Previous AI summary text" not in result.get("user_prompt", "")
+    except (KeyError, TypeError, AttributeError):
+        pass  # Expected: prompt builder rejects the fake dict shape

--- a/tests/unit/test_ai_outputs_repository.py
+++ b/tests/unit/test_ai_outputs_repository.py
@@ -1,0 +1,292 @@
+"""Unit tests for AiOutputRepository.
+
+Uses an in-memory SQLite engine with create_all_tables().
+All tests are isolated: the engine is module-scoped and the tables are
+truncated between tests via the _clean fixture.
+
+Coverage:
+  - create_ai_output inserts row and returns full dict
+  - id is auto-generated when not provided
+  - get_ai_output returns row by id
+  - get_ai_output returns None for unknown id
+  - rejected output persists with content=None
+  - truncated flag stored correctly
+  - source_records_json stored as JSON string
+  - safety_flags_json stored as JSON string
+  - list_ai_outputs_for_resource returns rows in DESC generated_at order
+  - list_ai_outputs_for_resource filters by output_type
+  - list_ai_outputs_for_resource returns empty list when no matches
+  - list_ai_outputs_for_job returns rows for job_id
+  - list_ai_outputs_for_job returns empty list for unknown job
+  - get_latest_ai_output_for_resource returns most recent
+  - get_latest_ai_output_for_resource returns None when no rows
+  - write-once: no update method exists on AiOutputRepository
+  - data_quality_score stored and retrieved correctly
+  - multiple outputs for same resource accumulate (no overwrite)
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from app.db.connection import create_all_tables
+from app.db.repositories.ai_outputs import AiOutputRepository
+
+
+@pytest.fixture(scope="module")
+def engine():
+    e = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    create_all_tables(e)
+    return e
+
+
+@pytest.fixture(scope="module")
+def Session(engine):
+    return sessionmaker(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def _clean(engine):
+    yield
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM ai_outputs"))
+        conn.commit()
+
+
+def _repo(Session):
+    session = Session()
+    return AiOutputRepository(session), session
+
+
+def _make_output(Session, **overrides):
+    repo, session = _repo(Session)
+    defaults = dict(
+        job_id=str(uuid.uuid4()),
+        output_type="campaign_summary",
+        resource_type="campaign",
+        resource_id=str(uuid.uuid4()),
+        content="Campaign X is active.",
+        backend="mock",
+        model_name="mock",
+        prompt_hash="abc123",
+        payload_bytes=512,
+        source_records_json={"campaign_id": "c1", "observation_count": 5},
+        safety_flags_json=["low_confidence"],
+        rejected=False,
+        rejection_reason=None,
+        truncated=False,
+        data_quality_score=0.75,
+        generated_at="2026-01-15T12:00:00+00:00",
+        triggered_by="api_key",
+    )
+    defaults.update(overrides)
+    result = repo.create_ai_output(**defaults)
+    session.commit()
+    session.close()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# create and get
+# ---------------------------------------------------------------------------
+
+
+def test_create_returns_dict(Session):
+    output = _make_output(Session)
+    assert isinstance(output, dict)
+    assert output["output_type"] == "campaign_summary"
+
+
+def test_create_auto_generates_id(Session):
+    output = _make_output(Session)
+    assert output["id"] is not None
+    assert len(output["id"]) > 0
+
+
+def test_create_with_explicit_id(Session):
+    oid = str(uuid.uuid4())
+    output = _make_output(Session, output_id=oid)
+    assert output["id"] == oid
+
+
+def test_get_ai_output_returns_row(Session):
+    output = _make_output(Session)
+    repo, session = _repo(Session)
+    fetched = repo.get_ai_output(output["id"])
+    session.close()
+    assert fetched is not None
+    assert fetched["id"] == output["id"]
+    assert fetched["content"] == "Campaign X is active."
+
+
+def test_get_ai_output_returns_none_for_unknown(Session):
+    repo, session = _repo(Session)
+    result = repo.get_ai_output("does-not-exist")
+    session.close()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# rejected and truncated
+# ---------------------------------------------------------------------------
+
+
+def test_rejected_output_persists_with_null_content(Session):
+    output = _make_output(
+        Session,
+        content=None,
+        rejected=True,
+        rejection_reason="ip_detected",
+    )
+    repo, session = _repo(Session)
+    fetched = repo.get_ai_output(output["id"])
+    session.close()
+    assert fetched["rejected"] is True
+    assert fetched["content"] is None
+    assert fetched["rejection_reason"] == "ip_detected"
+
+
+def test_truncated_flag_stored(Session):
+    output = _make_output(Session, truncated=True, rejection_reason="truncated")
+    repo, session = _repo(Session)
+    fetched = repo.get_ai_output(output["id"])
+    session.close()
+    assert fetched["truncated"] is True
+
+
+# ---------------------------------------------------------------------------
+# data_quality_score
+# ---------------------------------------------------------------------------
+
+
+def test_data_quality_score_stored(Session):
+    output = _make_output(Session, data_quality_score=0.843)
+    repo, session = _repo(Session)
+    fetched = repo.get_ai_output(output["id"])
+    session.close()
+    assert abs(fetched["data_quality_score"] - 0.843) < 0.001
+
+
+def test_data_quality_score_null_allowed(Session):
+    output = _make_output(Session, data_quality_score=None)
+    repo, session = _repo(Session)
+    fetched = repo.get_ai_output(output["id"])
+    session.close()
+    assert fetched["data_quality_score"] is None
+
+
+# ---------------------------------------------------------------------------
+# list_ai_outputs_for_resource
+# ---------------------------------------------------------------------------
+
+
+def test_list_for_resource_returns_rows(Session):
+    rid = str(uuid.uuid4())
+    _make_output(Session, resource_id=rid)
+    _make_output(Session, resource_id=rid)
+    repo, session = _repo(Session)
+    results = repo.list_ai_outputs_for_resource("campaign", rid)
+    session.close()
+    assert len(results) == 2
+
+
+def test_list_for_resource_newest_first(Session):
+    rid = str(uuid.uuid4())
+    _make_output(Session, resource_id=rid, generated_at="2026-01-01T00:00:00+00:00")
+    _make_output(Session, resource_id=rid, generated_at="2026-06-01T00:00:00+00:00")
+    repo, session = _repo(Session)
+    results = repo.list_ai_outputs_for_resource("campaign", rid)
+    session.close()
+    assert results[0]["generated_at"] > results[1]["generated_at"]
+
+
+def test_list_for_resource_filter_by_output_type(Session):
+    rid = str(uuid.uuid4())
+    _make_output(Session, resource_id=rid, output_type="campaign_summary")
+    _make_output(Session, resource_id=rid, output_type="campaign_brief")
+    repo, session = _repo(Session)
+    results = repo.list_ai_outputs_for_resource("campaign", rid, output_type="campaign_summary")
+    session.close()
+    assert len(results) == 1
+    assert results[0]["output_type"] == "campaign_summary"
+
+
+def test_list_for_resource_empty_when_no_match(Session):
+    repo, session = _repo(Session)
+    results = repo.list_ai_outputs_for_resource("campaign", "non-existent-id")
+    session.close()
+    assert results == []
+
+
+def test_list_for_resource_multiple_outputs_accumulate(Session):
+    """Regression: multiple outputs for the same resource should not overwrite."""
+    rid = str(uuid.uuid4())
+    for _ in range(3):
+        _make_output(Session, resource_id=rid)
+    repo, session = _repo(Session)
+    results = repo.list_ai_outputs_for_resource("campaign", rid)
+    session.close()
+    assert len(results) == 3
+
+
+# ---------------------------------------------------------------------------
+# list_ai_outputs_for_job
+# ---------------------------------------------------------------------------
+
+
+def test_list_for_job_returns_rows(Session):
+    jid = str(uuid.uuid4())
+    _make_output(Session, job_id=jid)
+    repo, session = _repo(Session)
+    results = repo.list_ai_outputs_for_job(jid)
+    session.close()
+    assert len(results) == 1
+    assert results[0]["job_id"] == jid
+
+
+def test_list_for_job_empty_for_unknown_job(Session):
+    repo, session = _repo(Session)
+    results = repo.list_ai_outputs_for_job("no-such-job")
+    session.close()
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# get_latest_ai_output_for_resource
+# ---------------------------------------------------------------------------
+
+
+def test_get_latest_returns_most_recent(Session):
+    rid = str(uuid.uuid4())
+    _make_output(Session, resource_id=rid, generated_at="2026-01-01T00:00:00+00:00")
+    _make_output(Session, resource_id=rid, generated_at="2026-06-01T00:00:00+00:00")
+    repo, session = _repo(Session)
+    latest = repo.get_latest_ai_output_for_resource("campaign", rid)
+    session.close()
+    assert latest is not None
+    assert latest["generated_at"] == "2026-06-01T00:00:00+00:00"
+
+
+def test_get_latest_returns_none_when_no_rows(Session):
+    repo, session = _repo(Session)
+    result = repo.get_latest_ai_output_for_resource("campaign", "unknown-id")
+    session.close()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# write-once invariant
+# ---------------------------------------------------------------------------
+
+
+def test_no_update_method_on_repository(Session):
+    """AiOutputRepository must not expose any mutation method for existing rows."""
+    repo, session = _repo(Session)
+    session.close()
+    assert not hasattr(repo, "update_ai_output")
+    assert not hasattr(repo, "delete_ai_output")
+    assert not hasattr(repo, "patch_ai_output")


### PR DESCRIPTION
## Summary

- Introduces `ai_outputs` table as an immutable provenance record for every AI-generated artifact; write-once semantics enforced at the application layer (no UPDATE path)
- Adds Alembic migration `0005_phase6_ai_outputs` and adds `ai_output_id` column to `processing_jobs`
- Runner writes `ai_outputs` row before calling `complete_job()`, setting `ai_output_id` on the job; `result_summary_json` is retained for polling continuity
- Adds `GET /api/ai/outputs/{output_id}` and `GET /api/campaigns/{campaign_id}/ai-outputs` read-only retrieval endpoints
- Adds `model_name` property to all AI backend classes (`none`, `mock`, `<model>`) for provenance tracking
- Data quality score computed at execution time: confidence 40%, observation count 30%, fingerprint dimension completeness 20%, recency 10%
- Prompt hash (SHA-256) stored; prompt content never persisted

## Architecture notes

- **Write-once**: `AiOutputRepository` exposes `create_ai_output()` only — no `update`, no `delete`. Corrections and regenerations create new rows; history is append-only
- **Provenance chain**: `ai_outputs` → `source_records_json` snapshot → `job_id` → `processing_jobs` → `triggered_by`; prompt reconstructable from `source_records` + prompt builder at `generated_at` if needed
- **Coexistence**: `result_summary_json` on `processing_jobs` retained for polling continuity; `ai_output_id` in the job response is the bridge to the history path
- **Invariant preserved**: AI outputs are never fed back into prompt builder (§3, §10 Rule 1); `build_campaign_summary_prompt` accepts only campaign/fingerprint/observations

## Test plan

- [ ] `python -m pytest --tb=short -q` → 1063 passed, 3 skipped, 0 failures
- [ ] `tests/unit/test_ai_outputs_repository.py` — full `AiOutputRepository` CRUD, write-once invariant, rejected/truncated semantics, data_quality_score
- [ ] `tests/integration/test_ai_outputs_endpoints.py` — endpoint auth, 404, ai_output_id in job response, rejected output persists, multiple outputs accumulate, campaign list, invariant test
- [ ] pre-commit clean (black + ruff)

## Intentionally deferred

- Provenance traversal endpoint (`GET /api/ai/outputs/{id}/provenance`) — PR C3 or later
- `campaign_ids_json` dedicated column for briefs — `source_records_json` carries the information
- Dashboard history panel — PR C3
- Removing `result_summary_json` — deferred until dashboard migrates to history panel