### PR TITLE
feat(ai): add audit logging and rate limiting

### DIFF
--- a/app/db/connection.py
+++ b/app/db/connection.py
@@ -267,6 +267,28 @@ def create_all_tables(engine: Engine) -> None:
                 "triggered_by TEXT)"
             )
         )
+
+        # Phase 6 PR A3 — AI call audit log (metadata only, no content).
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS ai_audit_log ("
+                "id TEXT PRIMARY KEY, "
+                "job_id TEXT, "
+                "output_id TEXT, "
+                "triggered_by TEXT, "
+                "backend TEXT NOT NULL, "
+                "model_name TEXT NOT NULL, "
+                "operation_type TEXT NOT NULL, "
+                "resource_type TEXT, "
+                "resource_id TEXT, "
+                "payload_bytes INTEGER NOT NULL DEFAULT 0, "
+                "response_bytes INTEGER NOT NULL DEFAULT 0, "
+                "latency_ms INTEGER NOT NULL DEFAULT 0, "
+                "status TEXT NOT NULL, "
+                "error_type TEXT, "
+                "created_at TEXT NOT NULL)"
+            )
+        )
         conn.commit()
 
 

--- a/app/db/migrations/versions/0006_phase6_ai_audit_log.py
+++ b/app/db/migrations/versions/0006_phase6_ai_audit_log.py
@@ -1,0 +1,83 @@
+"""Phase 6 ai_audit_log table
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-27
+
+Creates: ai_audit_log
+
+ai_audit_log records metadata for every AI backend call — and rate-limit
+events — for compliance, cost visibility, and operator accountability.
+
+Rules (§9.1):
+  - Content is NEVER stored: no prompt text, no response text.
+  - Only metadata: who, when, what model, how many bytes, how long, outcome.
+  - Append-only: no UPDATE or DELETE methods are exposed by the repository.
+  - Separate from the ingest audit_log table so retention policies can differ.
+
+Status values: success | failure | unavailable | disabled | rate_limited
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # ai_audit_log — metadata record for every AI call attempt.
+    #
+    # job_id:         links to processing_jobs (null for rate-limited events)
+    # output_id:      links to ai_outputs (null when no output was produced)
+    # triggered_by:   api_key | user:{sub}
+    # backend:        claude | ollama | none | mock
+    # model_name:     specific model identifier
+    # operation_type: campaign_summary | campaign_brief | fingerprint_clustering
+    # resource_type:  campaign | null
+    # resource_id:    campaign_id | null
+    # payload_bytes:  byte count of user_prompt; 0 for non-AI events
+    # response_bytes: byte count of raw response; 0 on failure
+    # latency_ms:     wall-clock time of backend.generate() call; 0 if not called
+    # status:         success | failure | unavailable | disabled | rate_limited
+    # error_type:     AIBackendError | AIBackendUnavailableError |
+    #                 AIDisabledError | null on success
+    # created_at:     when this record was written
+    # ------------------------------------------------------------------
+    op.create_table(
+        "ai_audit_log",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("job_id", sa.Text, nullable=True),
+        sa.Column("output_id", sa.Text, nullable=True),
+        sa.Column("triggered_by", sa.Text, nullable=True),
+        sa.Column("backend", sa.Text, nullable=False),
+        sa.Column("model_name", sa.Text, nullable=False),
+        sa.Column("operation_type", sa.Text, nullable=False),
+        sa.Column("resource_type", sa.Text, nullable=True),
+        sa.Column("resource_id", sa.Text, nullable=True),
+        sa.Column("payload_bytes", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("response_bytes", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("latency_ms", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("status", sa.Text, nullable=False),
+        sa.Column("error_type", sa.Text, nullable=True),
+        sa.Column("created_at", sa.Text, nullable=False),
+    )
+    op.create_index("idx_ai_audit_log_created_at", "ai_audit_log", ["created_at"])
+    op.create_index("idx_ai_audit_log_job_id", "ai_audit_log", ["job_id"])
+    op.create_index("idx_ai_audit_log_triggered_by", "ai_audit_log", ["triggered_by"])
+    op.create_index("idx_ai_audit_log_status", "ai_audit_log", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_ai_audit_log_status", table_name="ai_audit_log")
+    op.drop_index("idx_ai_audit_log_triggered_by", table_name="ai_audit_log")
+    op.drop_index("idx_ai_audit_log_job_id", table_name="ai_audit_log")
+    op.drop_index("idx_ai_audit_log_created_at", table_name="ai_audit_log")
+    op.drop_table("ai_audit_log")

--- a/app/db/repositories/ai_audit_log.py
+++ b/app/db/repositories/ai_audit_log.py
@@ -1,0 +1,156 @@
+"""AI audit log repository — append-only writes for the ai_audit_log table.
+
+All SQL lives here. No mutation methods are provided: audit records are
+immutable historical evidence. There is no update_ai_audit_log() and
+no delete_ai_audit_log().
+
+Content is never stored here — only call metadata. This is enforced by
+the schema (no content columns) and by design (callers pass byte counts,
+not content strings).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db.repositories._base import RepositoryBase
+
+
+def _row_to_dict(row) -> dict[str, Any]:
+    return {
+        "id": row[0],
+        "job_id": row[1],
+        "output_id": row[2],
+        "triggered_by": row[3],
+        "backend": row[4],
+        "model_name": row[5],
+        "operation_type": row[6],
+        "resource_type": row[7],
+        "resource_id": row[8],
+        "payload_bytes": row[9],
+        "response_bytes": row[10],
+        "latency_ms": row[11],
+        "status": row[12],
+        "error_type": row[13],
+        "created_at": row[14],
+    }
+
+
+_SELECT_COLS = """
+    SELECT id, job_id, output_id, triggered_by, backend, model_name,
+           operation_type, resource_type, resource_id,
+           payload_bytes, response_bytes, latency_ms,
+           status, error_type, created_at
+    FROM ai_audit_log
+"""
+
+
+class AiAuditLogRepository(RepositoryBase):
+    def create_ai_audit_log(
+        self,
+        *,
+        log_id: str | None = None,
+        job_id: str | None = None,
+        output_id: str | None = None,
+        triggered_by: str | None = None,
+        backend: str,
+        model_name: str,
+        operation_type: str,
+        resource_type: str | None = None,
+        resource_id: str | None = None,
+        payload_bytes: int = 0,
+        response_bytes: int = 0,
+        latency_ms: int = 0,
+        status: str,
+        error_type: str | None = None,
+        created_at: str | None = None,
+    ) -> dict[str, Any]:
+        """Insert an immutable ai_audit_log row and return it.
+
+        This is the only write method. Content (prompt text, response text)
+        is never accepted or stored — only metadata.
+        """
+        lid = log_id or str(uuid.uuid4())
+        now = created_at or datetime.now(UTC).isoformat()
+        self._session.execute(
+            text("""
+                INSERT INTO ai_audit_log (
+                    id, job_id, output_id, triggered_by,
+                    backend, model_name, operation_type,
+                    resource_type, resource_id,
+                    payload_bytes, response_bytes, latency_ms,
+                    status, error_type, created_at
+                ) VALUES (
+                    :id, :job_id, :output_id, :triggered_by,
+                    :backend, :model_name, :operation_type,
+                    :resource_type, :resource_id,
+                    :payload_bytes, :response_bytes, :latency_ms,
+                    :status, :error_type, :created_at
+                )
+            """),
+            {
+                "id": lid,
+                "job_id": job_id,
+                "output_id": output_id,
+                "triggered_by": triggered_by,
+                "backend": backend,
+                "model_name": model_name,
+                "operation_type": operation_type,
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "payload_bytes": payload_bytes,
+                "response_bytes": response_bytes,
+                "latency_ms": latency_ms,
+                "status": status,
+                "error_type": error_type,
+                "created_at": now,
+            },
+        )
+        return self.get_ai_audit_log(lid)  # type: ignore[return-value]
+
+    def get_ai_audit_log(self, log_id: str) -> dict[str, Any] | None:
+        """Return a single audit record by id, or None if not found."""
+        row = self._session.execute(
+            text(_SELECT_COLS + "WHERE id = :id"),
+            {"id": log_id},
+        ).fetchone()
+        return _row_to_dict(row) if row is not None else None
+
+    def list_ai_audit_logs(
+        self,
+        *,
+        limit: int = 50,
+        triggered_by: str | None = None,
+        backend: str | None = None,
+        status: str | None = None,
+        job_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return audit records, newest first, with optional filters."""
+        clauses = []
+        params: dict[str, Any] = {"limit": limit}
+        if triggered_by is not None:
+            clauses.append("triggered_by = :triggered_by")
+            params["triggered_by"] = triggered_by
+        if backend is not None:
+            clauses.append("backend = :backend")
+            params["backend"] = backend
+        if status is not None:
+            clauses.append("status = :status")
+            params["status"] = status
+        if job_id is not None:
+            clauses.append("job_id = :job_id")
+            params["job_id"] = job_id
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = self._session.execute(
+            text(_SELECT_COLS + f"{where} ORDER BY created_at DESC LIMIT :limit"),
+            params,
+        ).fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    def list_ai_audit_logs_for_job(self, job_id: str) -> list[dict[str, Any]]:
+        """Return all audit records for a given job_id, newest first."""
+        return self.list_ai_audit_logs(job_id=job_id, limit=100)

--- a/app/db/repositories/jobs.py
+++ b/app/db/repositories/jobs.py
@@ -336,3 +336,20 @@ class JobRepository(RepositoryBase):
             },
         )
         return result.rowcount
+
+    def count_recent_ai_jobs(self, triggered_by: str, *, since: str) -> int:
+        """Count campaign_summary and campaign_brief jobs created by triggered_by since cutoff.
+
+        Used for per-operator AI rate limiting at the analyze endpoints.
+        Only AI-triggering job types are counted; fingerprint_clustering is excluded.
+        """
+        row = self._session.execute(
+            text("""
+                SELECT COUNT(*) FROM processing_jobs
+                WHERE triggered_by = :triggered_by
+                  AND job_type IN ('campaign_summary', 'campaign_brief')
+                  AND created_at >= :since
+            """),
+            {"triggered_by": triggered_by, "since": since},
+        ).fetchone()
+        return int(row[0]) if row else 0

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -28,6 +28,7 @@ No FastAPI, router, or application imports belong in the sub-modules.
 
 from __future__ import annotations
 
+from app.db.repositories.ai_audit_log import AiAuditLogRepository
 from app.db.repositories.ai_outputs import AiOutputRepository
 from app.db.repositories.campaign import CampaignRepository
 from app.db.repositories.fingerprint import FingerprintRepository
@@ -45,14 +46,16 @@ class EventRepository(
     CampaignRepository,
     JobRepository,
     AiOutputRepository,
+    AiAuditLogRepository,
 ):
     """
-    Unified repository class. Inherits all SQL methods from the seven concern
+    Unified repository class. Inherits all SQL methods from the eight concern
     mixins. Callers see a single object with the full method surface; the
     internal split is an organisation detail invisible to callers.
 
     Python MRO: EventRepository → WriteRepository → ReadRepository →
                 IntelligenceRepository → FingerprintRepository →
                 CampaignRepository → JobRepository →
-                AiOutputRepository → RepositoryBase → object
+                AiOutputRepository → AiAuditLogRepository →
+                RepositoryBase → object
     """

--- a/app/jobs/runner.py
+++ b/app/jobs/runner.py
@@ -8,14 +8,14 @@ Execution model:
   2. Transition to 'running' via start_job(). If start_job returns False,
      another executor has already taken the job — return silently.
   3. Execute AI logic (read-only DB fetch → prompt build → AI call → validate).
-  4. On success: write ai_outputs row, then complete_job() with ai_output_id.
-  5. On any exception: fail_job() with a safe error summary. Stack traces
-     are logged but never stored in the job record.
+  4. On success: write ai_outputs row, write audit log, complete_job().
+  5. On any AI failure: write audit log, fail_job() with safe error summary.
+  6. On unhandled exception: _force_fail() best-effort.
 
 Deterministic-first invariants enforced here:
   - No writes to campaigns, fingerprints, events, or observations.
-  - AI outputs are stored in ai_outputs (PR A2) and result_summary_json
-    on processing_jobs is retained for polling continuity.
+  - AI outputs are stored in ai_outputs; result_summary_json retained for polling.
+  - AI audit records store metadata only — no prompt text, no response text.
   - get_ai_backend() is imported here so tests can monkeypatch
     'app.jobs.runner.get_ai_backend' without touching the router.
   - AI outputs are never used as prompt inputs (§3, §10 Rule 1).
@@ -108,7 +108,7 @@ def _execute_summary(job_id: str) -> None:
     campaign_id: str = job.get("resource_id") or ""
     triggered_by: str | None = job.get("triggered_by")
 
-    # Fetch campaign data — read-only session, separate from job lifecycle session.
+    # Fetch campaign data — read-only session.
     with get_session() as session:
         repo = EventRepository(session)
         campaign = repo.get_campaign(campaign_id)
@@ -122,23 +122,99 @@ def _execute_summary(job_id: str) -> None:
         all_obs = repo.get_campaign_observations(campaign_id)
         observations = all_obs[-_MAX_OBSERVATIONS:]
 
-    # Build prompt and call AI backend.
+    # Build prompt.
     prompt_data = build_campaign_summary_prompt(campaign, fingerprint, observations)
     user_prompt = prompt_data["user_prompt"]
     prompt_hash = _prompt_hash(user_prompt)
     payload_bytes = len(user_prompt.encode("utf-8"))
     data_quality_score = _compute_data_quality_score(campaign, fingerprint, observations)
 
+    # Acquire backend — may raise AIBackendError if misconfigured.
+    t0_call = time.monotonic()
     try:
         backend = get_ai_backend()
+    except AIBackendError as exc:
+        call_latency_ms = int((time.monotonic() - t0_call) * 1000)
+        _write_audit_log_safe(
+            job_id=job_id,
+            output_id=None,
+            triggered_by=triggered_by,
+            backend=settings.AI_BACKEND,
+            model_name="unknown",
+            operation_type="campaign_summary",
+            resource_type="campaign",
+            resource_id=campaign_id,
+            payload_bytes=payload_bytes,
+            response_bytes=0,
+            latency_ms=call_latency_ms,
+            status="failure",
+            error_type="AIBackendError",
+        )
+        _fail_job_safe(job_id, str(exc))
+        return
+
+    # Call AI backend.
+    try:
         raw_output = backend.generate(user_prompt)
+        call_latency_ms = int((time.monotonic() - t0_call) * 1000)
+        response_bytes = len(raw_output.encode("utf-8"))
+        call_status = "success"
+        call_error_type = None
     except AIDisabledError as exc:
+        call_latency_ms = int((time.monotonic() - t0_call) * 1000)
+        _write_audit_log_safe(
+            job_id=job_id,
+            output_id=None,
+            triggered_by=triggered_by,
+            backend=settings.AI_BACKEND,
+            model_name=backend.model_name,
+            operation_type="campaign_summary",
+            resource_type="campaign",
+            resource_id=campaign_id,
+            payload_bytes=payload_bytes,
+            response_bytes=0,
+            latency_ms=call_latency_ms,
+            status="disabled",
+            error_type="AIDisabledError",
+        )
         _fail_job_safe(job_id, str(exc))
         return
     except AIBackendUnavailableError as exc:
+        call_latency_ms = int((time.monotonic() - t0_call) * 1000)
+        _write_audit_log_safe(
+            job_id=job_id,
+            output_id=None,
+            triggered_by=triggered_by,
+            backend=settings.AI_BACKEND,
+            model_name=backend.model_name,
+            operation_type="campaign_summary",
+            resource_type="campaign",
+            resource_id=campaign_id,
+            payload_bytes=payload_bytes,
+            response_bytes=0,
+            latency_ms=call_latency_ms,
+            status="unavailable",
+            error_type="AIBackendUnavailableError",
+        )
         _fail_job_safe(job_id, str(exc))
         return
     except AIBackendError as exc:
+        call_latency_ms = int((time.monotonic() - t0_call) * 1000)
+        _write_audit_log_safe(
+            job_id=job_id,
+            output_id=None,
+            triggered_by=triggered_by,
+            backend=settings.AI_BACKEND,
+            model_name=backend.model_name,
+            operation_type="campaign_summary",
+            resource_type="campaign",
+            resource_id=campaign_id,
+            payload_bytes=payload_bytes,
+            response_bytes=0,
+            latency_ms=call_latency_ms,
+            status="failure",
+            error_type="AIBackendError",
+        )
         _fail_job_safe(job_id, str(exc))
         return
 
@@ -189,6 +265,23 @@ def _execute_summary(job_id: str) -> None:
             triggered_by=triggered_by,
         )
 
+    # Write audit log with output_id now known.
+    _write_audit_log_safe(
+        job_id=job_id,
+        output_id=output_id,
+        triggered_by=triggered_by,
+        backend=settings.AI_BACKEND,
+        model_name=backend.model_name,
+        operation_type="campaign_summary",
+        resource_type="campaign",
+        resource_id=campaign_id,
+        payload_bytes=payload_bytes,
+        response_bytes=response_bytes,
+        latency_ms=call_latency_ms,
+        status=call_status,
+        error_type=call_error_type,
+    )
+
     with get_session() as session:
         repo = EventRepository(session)
         repo.complete_job(
@@ -216,7 +309,7 @@ def _execute_brief(job_id: str) -> None:
 
     triggered_by: str | None = job.get("triggered_by")
 
-    # Parse max_campaigns from backend_metadata_json (stored by analyze router).
+    # Parse max_campaigns from backend_metadata_json.
     max_campaigns = 10
     if job.get("backend_metadata_json"):
         try:
@@ -263,16 +356,90 @@ def _execute_brief(job_id: str) -> None:
     payload_bytes = len(user_prompt.encode("utf-8"))
     data_quality_score = round(min(len(campaigns) / 10.0, 1.0), 3)
 
+    t0_call = time.monotonic()
     try:
         backend = get_ai_backend()
+    except AIBackendError as exc:
+        call_latency_ms = int((time.monotonic() - t0_call) * 1000)
+        _write_audit_log_safe(
+            job_id=job_id,
+            output_id=None,
+            triggered_by=triggered_by,
+            backend=settings.AI_BACKEND,
+            model_name="unknown",
+            operation_type="campaign_brief",
+            resource_type=None,
+            resource_id=None,
+            payload_bytes=payload_bytes,
+            response_bytes=0,
+            latency_ms=call_latency_ms,
+            status="failure",
+            error_type="AIBackendError",
+        )
+        _fail_job_safe(job_id, str(exc))
+        return
+
+    try:
         raw_output = backend.generate(user_prompt)
+        call_latency_ms = int((time.monotonic() - t0_call) * 1000)
+        response_bytes = len(raw_output.encode("utf-8"))
+        call_status = "success"
+        call_error_type = None
     except AIDisabledError as exc:
+        call_latency_ms = int((time.monotonic() - t0_call) * 1000)
+        _write_audit_log_safe(
+            job_id=job_id,
+            output_id=None,
+            triggered_by=triggered_by,
+            backend=settings.AI_BACKEND,
+            model_name=backend.model_name,
+            operation_type="campaign_brief",
+            resource_type=None,
+            resource_id=None,
+            payload_bytes=payload_bytes,
+            response_bytes=0,
+            latency_ms=call_latency_ms,
+            status="disabled",
+            error_type="AIDisabledError",
+        )
         _fail_job_safe(job_id, str(exc))
         return
     except AIBackendUnavailableError as exc:
+        call_latency_ms = int((time.monotonic() - t0_call) * 1000)
+        _write_audit_log_safe(
+            job_id=job_id,
+            output_id=None,
+            triggered_by=triggered_by,
+            backend=settings.AI_BACKEND,
+            model_name=backend.model_name,
+            operation_type="campaign_brief",
+            resource_type=None,
+            resource_id=None,
+            payload_bytes=payload_bytes,
+            response_bytes=0,
+            latency_ms=call_latency_ms,
+            status="unavailable",
+            error_type="AIBackendUnavailableError",
+        )
         _fail_job_safe(job_id, str(exc))
         return
     except AIBackendError as exc:
+        call_latency_ms = int((time.monotonic() - t0_call) * 1000)
+        _write_audit_log_safe(
+            job_id=job_id,
+            output_id=None,
+            triggered_by=triggered_by,
+            backend=settings.AI_BACKEND,
+            model_name=backend.model_name,
+            operation_type="campaign_brief",
+            resource_type=None,
+            resource_id=None,
+            payload_bytes=payload_bytes,
+            response_bytes=0,
+            latency_ms=call_latency_ms,
+            status="failure",
+            error_type="AIBackendError",
+        )
         _fail_job_safe(job_id, str(exc))
         return
 
@@ -297,7 +464,6 @@ def _execute_brief(job_id: str) -> None:
     }
     backend_meta = {"ai_backend": settings.AI_BACKEND, "latency_ms": latency_ms}
 
-    # Write ai_output BEFORE completing the job.
     output_id = str(uuid.uuid4())
     with get_session() as session:
         repo = EventRepository(session)
@@ -321,6 +487,22 @@ def _execute_brief(job_id: str) -> None:
             generated_at=generated_at,
             triggered_by=triggered_by,
         )
+
+    _write_audit_log_safe(
+        job_id=job_id,
+        output_id=output_id,
+        triggered_by=triggered_by,
+        backend=settings.AI_BACKEND,
+        model_name=backend.model_name,
+        operation_type="campaign_brief",
+        resource_type=None,
+        resource_id=None,
+        payload_bytes=payload_bytes,
+        response_bytes=response_bytes,
+        latency_ms=call_latency_ms,
+        status=call_status,
+        error_type=call_error_type,
+    )
 
     with get_session() as session:
         repo = EventRepository(session)
@@ -349,9 +531,7 @@ def _compute_data_quality_score(
 ) -> float:
     """Composite data quality score: confidence 40%, obs 30%, fp 20%, recency 10%."""
     confidence = float(campaign.get("confidence") or 0.5)
-
     obs_score = min(len(observations) / 10.0, 1.0)
-
     fp_score = 0.0
     if fingerprint:
         dims = [
@@ -363,11 +543,53 @@ def _compute_data_quality_score(
         ]
         present = sum(1 for d in dims if fingerprint.get(d))
         fp_score = present / 5.0
-
     recency = 1.0 if observations else 0.0
-
     score = confidence * 0.4 + obs_score * 0.3 + fp_score * 0.2 + recency * 0.1
     return round(score, 3)
+
+
+# ---------------------------------------------------------------------------
+# Audit log helper
+# ---------------------------------------------------------------------------
+
+
+def _write_audit_log_safe(
+    *,
+    job_id: str | None,
+    output_id: str | None,
+    triggered_by: str | None,
+    backend: str,
+    model_name: str,
+    operation_type: str,
+    resource_type: str | None,
+    resource_id: str | None,
+    payload_bytes: int,
+    response_bytes: int,
+    latency_ms: int,
+    status: str,
+    error_type: str | None,
+) -> None:
+    """Write an AI audit record. Failures are logged but never propagated."""
+    try:
+        with get_session() as session:
+            repo = EventRepository(session)
+            repo.create_ai_audit_log(
+                job_id=job_id,
+                output_id=output_id,
+                triggered_by=triggered_by,
+                backend=backend,
+                model_name=model_name,
+                operation_type=operation_type,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                payload_bytes=payload_bytes,
+                response_bytes=response_bytes,
+                latency_ms=latency_ms,
+                status=status,
+                error_type=error_type,
+            )
+    except Exception:
+        logger.exception("Failed to write AI audit log job_id=%s status=%s", job_id, status)
 
 
 # ---------------------------------------------------------------------------

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -6,7 +6,7 @@ dashboard sessions from triggering maintenance operations accidentally.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from app.db.connection import get_session
 from app.db.repository import EventRepository
@@ -52,3 +52,34 @@ def run_analytics_job(
         repo = EventRepository(session)
         result = refresh_all_campaign_analytics(repo)
     return result
+
+
+@router.get("/ai-audit")
+def list_ai_audit_logs(
+    limit: int = Query(default=50, ge=1, le=500),
+    triggered_by: str | None = Query(default=None),
+    backend: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    _: dict = Depends(require_api_key),
+) -> dict:
+    """Return AI call audit records. API key required; JWT is not accepted.
+
+    Records contain call metadata only — no prompt text, no response content.
+    Sorted newest first.
+
+    Query params:
+      limit        — max records to return (1–500, default 50)
+      triggered_by — filter by operator identity (e.g. "api_key", "user:alice")
+      backend      — filter by AI backend name (e.g. "claude", "ollama", "none")
+      status       — filter by call outcome (success | failure | unavailable |
+                     disabled | rate_limited)
+    """
+    with get_session() as session:
+        repo = EventRepository(session)
+        logs = repo.list_ai_audit_logs(
+            limit=limit,
+            triggered_by=triggered_by,
+            backend=backend,
+            status=status,
+        )
+    return {"logs": logs, "count": len(logs)}

--- a/app/routers/analyze.py
+++ b/app/routers/analyze.py
@@ -15,6 +15,7 @@ Failure modes that still raise at POST time (before job creation):
   404 — campaign not found (summary only)
   401 — missing or invalid credentials
   422 — invalid request body
+  429 — per-operator AI rate limit exceeded (AI_MAX_REQUESTS_PER_MINUTE)
 
 Failure modes handled asynchronously (via job status):
   job.status=failed + error_message — AI disabled, backend unreachable,
@@ -25,12 +26,20 @@ Deduplication (summary only):
   campaign_id, the existing job_id is returned immediately with
   HTTP 202 and status='running'|'pending'.
 
+Rate limiting:
+  DB-backed, using the processing_jobs table. Counts campaign_summary and
+  campaign_brief jobs created by the same operator in the last 60 seconds.
+  Limit is AI_MAX_REQUESTS_PER_MINUTE (default 10). Rate-limited requests
+  are written to ai_audit_log with status='rate_limited' in a separate
+  session so the record commits even though an HTTPException is raised.
+
 Auth: require_jwt_or_api_key on all endpoints.
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import logging
+from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -40,6 +49,8 @@ from app.db.connection import get_session
 from app.db.repository import EventRepository
 from app.jobs.runner import run_campaign_brief_job, run_campaign_summary_job
 from app.utils.auth import require_jwt_or_api_key
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/campaigns", tags=["analyze"])
 
@@ -54,6 +65,39 @@ def _triggered_by(auth_info: dict) -> str:
         sub = auth_info.get("sub") or "unknown"
         return f"user:{sub}"
     return "api_key"
+
+
+def _write_rate_limit_audit_safe(
+    *,
+    triggered_by: str | None,
+    operation_type: str,
+    resource_type: str | None,
+    resource_id: str | None,
+) -> None:
+    """Write a rate_limited ai_audit_log record in a separate session.
+
+    Uses a separate get_session() call so this write commits independently
+    of the HTTPException that immediately follows — exceptions in the same
+    session block trigger rollback, which would swallow the audit record.
+    """
+    try:
+        with get_session() as session:
+            repo = EventRepository(session)
+            repo.create_ai_audit_log(
+                triggered_by=triggered_by,
+                backend=settings.AI_BACKEND,
+                model_name="unknown",
+                operation_type=operation_type,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                payload_bytes=0,
+                response_bytes=0,
+                latency_ms=0,
+                status="rate_limited",
+                error_type="RateLimitExceeded",
+            )
+    except Exception:
+        logger.exception("Failed to write rate_limited audit log triggered_by=%s", triggered_by)
 
 
 @router.post("/{campaign_id}/summary", status_code=status.HTTP_202_ACCEPTED)
@@ -85,6 +129,9 @@ def campaign_summary(
     dedup_key = f"campaign_summary:{campaign_id}"
     now = datetime.now(UTC).isoformat()
 
+    rate_limited = False
+    job = None
+
     with get_session() as session:
         repo = EventRepository(session)
 
@@ -101,18 +148,38 @@ def campaign_summary(
         if existing is not None:
             return _accepted_response(existing["id"], existing["status"], now)
 
-        # Create a new job.
-        job = repo.create_job(
-            job_type="campaign_summary",
+        # Rate limit: count AI jobs created by this operator in the last 60s.
+        cutoff = (datetime.now(UTC) - timedelta(seconds=60)).isoformat()
+        if (
+            repo.count_recent_ai_jobs(triggered_by, since=cutoff)
+            >= settings.AI_MAX_REQUESTS_PER_MINUTE
+        ):
+            rate_limited = True
+        else:
+            job = repo.create_job(
+                job_type="campaign_summary",
+                triggered_by=triggered_by,
+                resource_type="campaign",
+                resource_id=campaign_id,
+                deduplication_key=dedup_key,
+                created_at=now,
+            )
+
+    if rate_limited:
+        _write_rate_limit_audit_safe(
             triggered_by=triggered_by,
+            operation_type="campaign_summary",
             resource_type="campaign",
             resource_id=campaign_id,
-            deduplication_key=dedup_key,
-            created_at=now,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="AI rate limit exceeded. Try again in 60 seconds.",
+            headers={"Retry-After": "60"},
         )
 
-    background_tasks.add_task(run_campaign_summary_job, job["id"])
-    return _accepted_response(job["id"], "pending", now)
+    background_tasks.add_task(run_campaign_summary_job, job["id"])  # type: ignore[union-attr]
+    return _accepted_response(job["id"], "pending", now)  # type: ignore[index]
 
 
 @router.post("/brief", status_code=status.HTTP_202_ACCEPTED)
@@ -139,21 +206,45 @@ def campaign_brief(
     triggered_by = _triggered_by(auth_info)
     now = datetime.now(UTC).isoformat()
 
+    rate_limited = False
+    job = None
+
     with get_session() as session:
         repo = EventRepository(session)
-        # Store max_campaigns in backend_metadata_json so the runner can read it.
-        job = repo.create_job(
-            job_type="campaign_brief",
+        # Rate limit: count AI jobs created by this operator in the last 60s.
+        cutoff = (datetime.now(UTC) - timedelta(seconds=60)).isoformat()
+        if (
+            repo.count_recent_ai_jobs(triggered_by, since=cutoff)
+            >= settings.AI_MAX_REQUESTS_PER_MINUTE
+        ):
+            rate_limited = True
+        else:
+            # Store max_campaigns in backend_metadata_json so the runner can read it.
+            job = repo.create_job(
+                job_type="campaign_brief",
+                triggered_by=triggered_by,
+                resource_type=None,
+                resource_id=None,
+                deduplication_key=None,
+                created_at=now,
+                backend_metadata_json={"max_campaigns": body.max_campaigns},
+            )
+
+    if rate_limited:
+        _write_rate_limit_audit_safe(
             triggered_by=triggered_by,
+            operation_type="campaign_brief",
             resource_type=None,
             resource_id=None,
-            deduplication_key=None,
-            created_at=now,
-            backend_metadata_json={"max_campaigns": body.max_campaigns},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="AI rate limit exceeded. Try again in 60 seconds.",
+            headers={"Retry-After": "60"},
         )
 
-    background_tasks.add_task(run_campaign_brief_job, job["id"])
-    return _accepted_response(job["id"], "pending", now)
+    background_tasks.add_task(run_campaign_brief_job, job["id"])  # type: ignore[union-attr]
+    return _accepted_response(job["id"], "pending", now)  # type: ignore[index]
 
 
 def _accepted_response(job_id: str, job_status: str, accepted_at: str) -> dict:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,7 @@ def reset_db_rows():
     yield
     engine = get_engine()
     with engine.connect() as conn:
+        conn.execute(text("DELETE FROM ai_audit_log"))
         conn.execute(text("DELETE FROM ai_outputs"))
         conn.execute(text("DELETE FROM processing_jobs"))
         conn.execute(text("DELETE FROM behavioral_fingerprints"))

--- a/tests/integration/test_ai_audit_endpoints.py
+++ b/tests/integration/test_ai_audit_endpoints.py
@@ -1,0 +1,466 @@
+"""Integration tests for AI audit logging and rate limiting (Phase 6 PR A3).
+
+Coverage:
+  Rate limiting (POST /api/campaigns/{id}/summary):
+    - 429 returned when per-operator limit is exhausted
+    - Retry-After: 60 header present on 429
+    - 429 detail message references retry window
+    - rate_limited audit record written after 429
+    - First request under limit succeeds (202)
+    - Dedup check short-circuits before rate limit check
+
+  Rate limiting (POST /api/campaigns/brief):
+    - 429 returned when per-operator limit is exhausted
+    - Retry-After: 60 header present
+
+  GET /api/admin/ai-audit:
+    - 200 with {logs, count} shape
+    - 401 without API key
+    - 401 with wrong API key
+    - 401 with JWT-only auth (admin endpoint rejects JWT)
+    - Empty logs list when no records
+    - Audit record created after successful summary job
+    - Audit record has expected metadata fields
+    - Audit record does NOT contain prompt text or response content
+    - Filter by triggered_by
+    - Filter by status
+    - Filter by backend
+    - limit query param respected
+    - rate_limited audit records visible in audit log
+    - Audit record created when AI job fails (status=disabled)
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.ai import MockAIBackend
+from app.core.config import settings
+from app.db.connection import get_engine
+from app.main import app
+
+client = TestClient(app)
+API_KEY = "dev-123"
+HEADERS = {"x-api-key": API_KEY}
+
+_CID = "ffff0000-1111-2222-3333-444444444444"
+_MEMBER_IP = "10.9.8.7"
+_TS = "2026-01-20T00:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_campaign(campaign_id: str = _CID, *, status: str = "active") -> None:
+    engine = get_engine()
+    with engine.connect() as conn:
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO campaigns (
+                    id, name, status, confidence,
+                    first_seen, last_seen, dormant_since,
+                    reactivation_count, member_ip_count,
+                    attack_tactic_dist, top_target_ports, notes,
+                    created_at, updated_at
+                ) VALUES (
+                    :id, :name, :status, 0.70,
+                    :ts, :ts, NULL, 0, 1,
+                    '{}', '[]', NULL, :ts, :ts
+                )
+            """),
+            {"id": campaign_id, "name": "AUDIT-TEST", "status": status, "ts": _TS},
+        )
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO source_ips (ip, first_seen, last_seen, event_count)
+                VALUES (:ip, :ts, :ts, 3)
+            """),
+            {"ip": _MEMBER_IP, "ts": _TS},
+        )
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO campaign_members
+                    (campaign_id, source_ip, confidence, added_at, last_active)
+                VALUES (:cid, :ip, 0.70, :ts, :ts)
+            """),
+            {"cid": campaign_id, "ip": _MEMBER_IP, "ts": _TS},
+        )
+        conn.commit()
+
+
+def _insert_recent_jobs(count: int, *, job_type: str = "campaign_summary") -> None:
+    """Insert completed AI jobs with recent created_at to saturate rate limit."""
+    from datetime import UTC, datetime
+
+    engine = get_engine()
+    now = datetime.now(UTC).isoformat()
+    with engine.connect() as conn:
+        for _ in range(count):
+            conn.execute(
+                text("""
+                    INSERT INTO processing_jobs (
+                        id, job_type, status, created_at,
+                        triggered_by, progress_percent
+                    ) VALUES (
+                        :id, :job_type, 'completed', :created_at,
+                        'api_key', 100
+                    )
+                """),
+                {"id": str(uuid.uuid4()), "job_type": job_type, "created_at": now},
+            )
+        conn.commit()
+
+
+def _trigger_summary(monkeypatch, campaign_id: str = _CID) -> dict:
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Campaign is active. Credential scanning observed."),
+    )
+    resp = client.post(f"/api/campaigns/{campaign_id}/summary", headers=HEADERS)
+    return resp
+
+
+def _poll_job(job_id: str) -> dict:
+    resp = client.get(f"/api/jobs/{job_id}", headers=HEADERS)
+    assert resp.status_code == 200
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting — summary
+# ---------------------------------------------------------------------------
+
+
+def test_summary_succeeds_under_rate_limit(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "AI_MAX_REQUESTS_PER_MINUTE", 1)
+    resp = _trigger_summary(monkeypatch)
+    assert resp.status_code == 202
+
+
+def test_summary_429_when_rate_limit_exhausted(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "AI_MAX_REQUESTS_PER_MINUTE", 1)
+    _insert_recent_jobs(1, job_type="campaign_summary")
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 429
+
+
+def test_summary_429_retry_after_header(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "AI_MAX_REQUESTS_PER_MINUTE", 1)
+    _insert_recent_jobs(1, job_type="campaign_summary")
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 429
+    assert resp.headers.get("retry-after") == "60"
+
+
+def test_summary_429_detail_message(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "AI_MAX_REQUESTS_PER_MINUTE", 1)
+    _insert_recent_jobs(1, job_type="campaign_summary")
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 429
+    assert "rate limit" in resp.json()["detail"].lower()
+
+
+def test_summary_rate_limit_writes_audit_record(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "AI_MAX_REQUESTS_PER_MINUTE", 1)
+    _insert_recent_jobs(1, job_type="campaign_summary")
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 429
+    audit_resp = client.get("/api/admin/ai-audit", headers=HEADERS)
+    logs = audit_resp.json()["logs"]
+    rate_limited = [lg for lg in logs if lg["status"] == "rate_limited"]
+    assert len(rate_limited) >= 1
+    assert rate_limited[0]["operation_type"] == "campaign_summary"
+
+
+def test_summary_dedup_short_circuits_before_rate_limit(monkeypatch):
+    """Existing active job returned immediately; rate limit is never evaluated."""
+    _insert_campaign()
+    monkeypatch.setattr(settings, "AI_MAX_REQUESTS_PER_MINUTE", 0)
+    dedup_key = f"campaign_summary:{_CID}"
+    # Insert a pending job with the dedup key directly.
+    engine = get_engine()
+    from datetime import UTC, datetime
+
+    jid = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    with engine.connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO processing_jobs (
+                    id, job_type, status, created_at,
+                    triggered_by, resource_type, resource_id,
+                    deduplication_key, progress_percent
+                ) VALUES (
+                    :id, 'campaign_summary', 'pending', :now,
+                    'api_key', 'campaign', :cid, :dk, 0
+                )
+            """),
+            {"id": jid, "now": now, "cid": _CID, "dk": dedup_key},
+        )
+        conn.commit()
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 202
+    assert resp.json()["job_id"] == jid
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting — brief
+# ---------------------------------------------------------------------------
+
+
+def test_brief_429_when_rate_limit_exhausted(monkeypatch):
+    monkeypatch.setattr(settings, "AI_MAX_REQUESTS_PER_MINUTE", 1)
+    _insert_recent_jobs(1, job_type="campaign_brief")
+    resp = client.post("/api/campaigns/brief", headers=HEADERS)
+    assert resp.status_code == 429
+
+
+def test_brief_429_retry_after_header(monkeypatch):
+    monkeypatch.setattr(settings, "AI_MAX_REQUESTS_PER_MINUTE", 1)
+    _insert_recent_jobs(1, job_type="campaign_brief")
+    resp = client.post("/api/campaigns/brief", headers=HEADERS)
+    assert resp.status_code == 429
+    assert resp.headers.get("retry-after") == "60"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/ai-audit — auth
+# ---------------------------------------------------------------------------
+
+
+def test_audit_list_requires_api_key():
+    resp = client.get("/api/admin/ai-audit")
+    assert resp.status_code == 401
+
+
+def test_audit_list_rejects_wrong_api_key():
+    resp = client.get("/api/admin/ai-audit", headers={"x-api-key": "wrong"})
+    assert resp.status_code == 401
+
+
+def test_audit_list_rejects_jwt_only():
+    from jose import jwt as jose_jwt
+
+    secret = os.getenv("JWT_SECRET", "test-secret")
+    token = jose_jwt.encode({"sub": "admin"}, secret, algorithm="HS256")
+    resp = client.get(
+        "/api/admin/ai-audit",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/ai-audit — response shape
+# ---------------------------------------------------------------------------
+
+
+def test_audit_list_returns_200():
+    resp = client.get("/api/admin/ai-audit", headers=HEADERS)
+    assert resp.status_code == 200
+
+
+def test_audit_list_response_shape():
+    resp = client.get("/api/admin/ai-audit", headers=HEADERS)
+    body = resp.json()
+    assert "logs" in body
+    assert "count" in body
+    assert isinstance(body["logs"], list)
+    assert isinstance(body["count"], int)
+
+
+def test_audit_list_empty_initially():
+    resp = client.get("/api/admin/ai-audit", headers=HEADERS)
+    assert resp.json()["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/ai-audit — records after AI job
+# ---------------------------------------------------------------------------
+
+
+def test_audit_record_created_after_summary_job(monkeypatch):
+    _insert_campaign()
+    resp = _trigger_summary(monkeypatch)
+    assert resp.status_code == 202
+    job_id = resp.json()["job_id"]
+    _poll_job(job_id)
+    audit_resp = client.get("/api/admin/ai-audit", headers=HEADERS)
+    logs = audit_resp.json()["logs"]
+    assert len(logs) >= 1
+    matching = [lg for lg in logs if lg.get("job_id") == job_id]
+    assert len(matching) == 1
+
+
+def test_audit_record_fields_on_success(monkeypatch):
+    _insert_campaign()
+    resp = _trigger_summary(monkeypatch)
+    job_id = resp.json()["job_id"]
+    _poll_job(job_id)
+    audit_resp = client.get("/api/admin/ai-audit", headers=HEADERS)
+    record = next(lg for lg in audit_resp.json()["logs"] if lg.get("job_id") == job_id)
+    assert record["status"] == "success"
+    assert record["operation_type"] == "campaign_summary"
+    assert record["backend"] == settings.AI_BACKEND
+    assert record["model_name"] == "mock"
+    assert record["triggered_by"] == "api_key"
+    assert record["payload_bytes"] > 0
+    assert record["response_bytes"] > 0
+    assert record["latency_ms"] >= 0
+    assert record["created_at"]
+
+
+def test_audit_record_has_no_content_fields(monkeypatch):
+    """Audit records must never contain prompt text or response content."""
+    _insert_campaign()
+    resp = _trigger_summary(monkeypatch)
+    job_id = resp.json()["job_id"]
+    _poll_job(job_id)
+    audit_resp = client.get("/api/admin/ai-audit", headers=HEADERS)
+    record = next(lg for lg in audit_resp.json()["logs"] if lg.get("job_id") == job_id)
+    # These fields must not exist in the response.
+    for forbidden in ("content", "prompt", "response", "text", "summary"):
+        assert forbidden not in record, f"Forbidden field '{forbidden}' found in audit record"
+
+
+def test_audit_record_has_output_id_on_success(monkeypatch):
+    _insert_campaign()
+    resp = _trigger_summary(monkeypatch)
+    job_id = resp.json()["job_id"]
+    _poll_job(job_id)
+    audit_resp = client.get("/api/admin/ai-audit", headers=HEADERS)
+    record = next(lg for lg in audit_resp.json()["logs"] if lg.get("job_id") == job_id)
+    assert record["output_id"] is not None
+
+
+def test_audit_record_created_after_brief_job(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(
+        "app.jobs.runner.get_ai_backend",
+        lambda: MockAIBackend("Threat brief summary here."),
+    )
+    resp = client.post("/api/campaigns/brief", headers=HEADERS)
+    assert resp.status_code == 202
+    job_id = resp.json()["job_id"]
+    _poll_job(job_id)
+    audit_resp = client.get("/api/admin/ai-audit", headers=HEADERS)
+    logs = audit_resp.json()["logs"]
+    matching = [lg for lg in logs if lg.get("job_id") == job_id]
+    assert len(matching) == 1
+    assert matching[0]["operation_type"] == "campaign_brief"
+
+
+def test_audit_record_created_when_ai_disabled(monkeypatch):
+    from app.ai import AIDisabledError
+
+    _insert_campaign()
+
+    class _DisabledBackend:
+        model_name = "none"
+
+        def generate(self, prompt):
+            raise AIDisabledError("AI is disabled")
+
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: _DisabledBackend())
+    resp = client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    assert resp.status_code == 202
+    job_id = resp.json()["job_id"]
+    job = _poll_job(job_id)
+    assert job["status"] == "failed"
+    audit_resp = client.get("/api/admin/ai-audit", headers=HEADERS)
+    logs = audit_resp.json()["logs"]
+    matching = [lg for lg in logs if lg.get("job_id") == job_id]
+    assert len(matching) == 1
+    assert matching[0]["status"] == "disabled"
+    assert matching[0]["error_type"] == "AIDisabledError"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/ai-audit — filters
+# ---------------------------------------------------------------------------
+
+
+def test_audit_filter_by_triggered_by(monkeypatch):
+    _insert_campaign()
+    resp = _trigger_summary(monkeypatch)
+    _poll_job(resp.json()["job_id"])
+    audit_resp = client.get(
+        "/api/admin/ai-audit", headers=HEADERS, params={"triggered_by": "api_key"}
+    )
+    logs = audit_resp.json()["logs"]
+    assert len(logs) >= 1
+    assert all(lg["triggered_by"] == "api_key" for lg in logs)
+
+
+def test_audit_filter_by_status_success(monkeypatch):
+    _insert_campaign()
+    resp = _trigger_summary(monkeypatch)
+    _poll_job(resp.json()["job_id"])
+    audit_resp = client.get("/api/admin/ai-audit", headers=HEADERS, params={"status": "success"})
+    logs = audit_resp.json()["logs"]
+    assert len(logs) >= 1
+    assert all(lg["status"] == "success" for lg in logs)
+
+
+def test_audit_filter_by_backend(monkeypatch):
+    _insert_campaign()
+    resp = _trigger_summary(monkeypatch)
+    _poll_job(resp.json()["job_id"])
+    audit_resp = client.get(
+        "/api/admin/ai-audit",
+        headers=HEADERS,
+        params={"backend": settings.AI_BACKEND},
+    )
+    logs = audit_resp.json()["logs"]
+    assert len(logs) >= 1
+    assert all(lg["backend"] == settings.AI_BACKEND for lg in logs)
+
+
+def test_audit_filter_no_match_returns_empty():
+    audit_resp = client.get(
+        "/api/admin/ai-audit",
+        headers=HEADERS,
+        params={"triggered_by": "nobody-ever"},
+    )
+    body = audit_resp.json()
+    assert body["logs"] == []
+    assert body["count"] == 0
+
+
+def test_audit_limit_param(monkeypatch):
+    _insert_campaign()
+    # Create 3 audit records.
+    for _ in range(3):
+        resp = _trigger_summary(monkeypatch)
+        _poll_job(resp.json()["job_id"])
+    audit_resp = client.get("/api/admin/ai-audit", headers=HEADERS, params={"limit": 2})
+    body = audit_resp.json()
+    assert len(body["logs"]) == 2
+    assert body["count"] == 2
+
+
+def test_audit_rate_limited_records_visible(monkeypatch):
+    _insert_campaign()
+    monkeypatch.setattr(settings, "AI_MAX_REQUESTS_PER_MINUTE", 1)
+    _insert_recent_jobs(1, job_type="campaign_summary")
+    client.post(f"/api/campaigns/{_CID}/summary", headers=HEADERS)
+    audit_resp = client.get(
+        "/api/admin/ai-audit",
+        headers=HEADERS,
+        params={"status": "rate_limited"},
+    )
+    logs = audit_resp.json()["logs"]
+    assert len(logs) >= 1
+    assert logs[0]["status"] == "rate_limited"
+    assert logs[0]["error_type"] == "RateLimitExceeded"

--- a/tests/unit/test_ai_audit_log_repository.py
+++ b/tests/unit/test_ai_audit_log_repository.py
@@ -1,0 +1,313 @@
+"""Unit tests for AiAuditLogRepository.
+
+Uses an in-memory SQLite engine with create_all_tables().
+All tests are isolated: the engine is module-scoped and the table is
+truncated between tests via the _clean fixture.
+
+Coverage:
+  - create_ai_audit_log inserts row and returns full dict
+  - id is auto-generated when not provided
+  - explicit id is stored verbatim
+  - get_ai_audit_log returns row by id
+  - get_ai_audit_log returns None for unknown id
+  - all fields stored correctly (backend, model_name, bytes, latency, etc.)
+  - status=success stored correctly
+  - status=failure with error_type stored correctly
+  - status=disabled stored correctly
+  - status=unavailable stored correctly
+  - status=rate_limited stored correctly
+  - list_ai_audit_logs returns records newest first
+  - list_ai_audit_logs filters by triggered_by
+  - list_ai_audit_logs filters by backend
+  - list_ai_audit_logs filters by status
+  - list_ai_audit_logs filters by job_id
+  - list_ai_audit_logs respects limit
+  - list_ai_audit_logs returns empty list when no matches
+  - list_ai_audit_logs_for_job returns records for job_id
+  - list_ai_audit_logs_for_job returns empty list for unknown job
+  - write-once: no update method exists on AiAuditLogRepository
+  - write-once: no delete method exists on AiAuditLogRepository
+  - job_id and output_id may be None
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from app.db.connection import create_all_tables
+from app.db.repositories.ai_audit_log import AiAuditLogRepository
+
+
+@pytest.fixture(scope="module")
+def engine():
+    e = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    create_all_tables(e)
+    return e
+
+
+@pytest.fixture(scope="module")
+def Session(engine):
+    return sessionmaker(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def _clean(engine):
+    yield
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM ai_audit_log"))
+        conn.commit()
+
+
+def _repo(Session):
+    s = Session()
+    return AiAuditLogRepository(s), s
+
+
+def _make_log(Session, **overrides):
+    repo, s = _repo(Session)
+    kwargs = dict(
+        backend="mock",
+        model_name="mock",
+        operation_type="campaign_summary",
+        status="success",
+    )
+    kwargs.update(overrides)
+    log = repo.create_ai_audit_log(**kwargs)
+    s.commit()
+    s.close()
+    return log
+
+
+# ---------------------------------------------------------------------------
+# create / get
+# ---------------------------------------------------------------------------
+
+
+def test_create_returns_dict(Session):
+    log = _make_log(Session)
+    assert isinstance(log, dict)
+
+
+def test_auto_id(Session):
+    log = _make_log(Session)
+    assert log["id"]
+    assert len(log["id"]) == 36  # UUID4
+
+
+def test_explicit_id(Session):
+    lid = str(uuid.uuid4())
+    log = _make_log(Session, log_id=lid)
+    assert log["id"] == lid
+
+
+def test_get_by_id(Session):
+    log = _make_log(Session)
+    repo, s = _repo(Session)
+    fetched = repo.get_ai_audit_log(log["id"])
+    s.close()
+    assert fetched is not None
+    assert fetched["id"] == log["id"]
+
+
+def test_get_unknown_returns_none(Session):
+    repo, s = _repo(Session)
+    result = repo.get_ai_audit_log(str(uuid.uuid4()))
+    s.close()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Field storage
+# ---------------------------------------------------------------------------
+
+
+def test_all_fields_stored(Session):
+    job_id = str(uuid.uuid4())
+    output_id = str(uuid.uuid4())
+    log = _make_log(
+        Session,
+        job_id=job_id,
+        output_id=output_id,
+        triggered_by="user:alice",
+        backend="claude",
+        model_name="claude-3-haiku",
+        operation_type="campaign_brief",
+        resource_type="campaign",
+        resource_id="camp-001",
+        payload_bytes=1024,
+        response_bytes=512,
+        latency_ms=350,
+        status="success",
+        error_type=None,
+    )
+    assert log["job_id"] == job_id
+    assert log["output_id"] == output_id
+    assert log["triggered_by"] == "user:alice"
+    assert log["backend"] == "claude"
+    assert log["model_name"] == "claude-3-haiku"
+    assert log["operation_type"] == "campaign_brief"
+    assert log["resource_type"] == "campaign"
+    assert log["resource_id"] == "camp-001"
+    assert log["payload_bytes"] == 1024
+    assert log["response_bytes"] == 512
+    assert log["latency_ms"] == 350
+    assert log["status"] == "success"
+    assert log["error_type"] is None
+    assert log["created_at"]
+
+
+def test_status_failure_with_error_type(Session):
+    log = _make_log(
+        Session,
+        status="failure",
+        error_type="AIBackendError",
+        response_bytes=0,
+    )
+    assert log["status"] == "failure"
+    assert log["error_type"] == "AIBackendError"
+
+
+def test_status_disabled(Session):
+    log = _make_log(Session, status="disabled", error_type="AIDisabledError")
+    assert log["status"] == "disabled"
+    assert log["error_type"] == "AIDisabledError"
+
+
+def test_status_unavailable(Session):
+    log = _make_log(Session, status="unavailable", error_type="AIBackendUnavailableError")
+    assert log["status"] == "unavailable"
+
+
+def test_status_rate_limited(Session):
+    log = _make_log(Session, status="rate_limited", error_type="RateLimitExceeded")
+    assert log["status"] == "rate_limited"
+    assert log["error_type"] == "RateLimitExceeded"
+
+
+def test_nullable_job_and_output_id(Session):
+    log = _make_log(Session, job_id=None, output_id=None)
+    assert log["job_id"] is None
+    assert log["output_id"] is None
+
+
+def test_default_bytes_and_latency(Session):
+    log = _make_log(Session)
+    assert log["payload_bytes"] == 0
+    assert log["response_bytes"] == 0
+    assert log["latency_ms"] == 0
+
+
+# ---------------------------------------------------------------------------
+# list_ai_audit_logs
+# ---------------------------------------------------------------------------
+
+
+def test_list_returns_newest_first(Session):
+    _make_log(Session, created_at="2026-01-01T00:00:00+00:00", triggered_by="user:a")
+    _make_log(Session, created_at="2026-01-03T00:00:00+00:00", triggered_by="user:a")
+    _make_log(Session, created_at="2026-01-02T00:00:00+00:00", triggered_by="user:a")
+    repo, s = _repo(Session)
+    logs = repo.list_ai_audit_logs()
+    s.close()
+    dates = [lg["created_at"] for lg in logs]
+    assert dates == sorted(dates, reverse=True)
+
+
+def test_list_filter_triggered_by(Session):
+    _make_log(Session, triggered_by="user:alice")
+    _make_log(Session, triggered_by="user:bob")
+    _make_log(Session, triggered_by="user:alice")
+    repo, s = _repo(Session)
+    logs = repo.list_ai_audit_logs(triggered_by="user:alice")
+    s.close()
+    assert len(logs) == 2
+    assert all(lg["triggered_by"] == "user:alice" for lg in logs)
+
+
+def test_list_filter_backend(Session):
+    _make_log(Session, backend="claude", model_name="claude-3-haiku")
+    _make_log(Session, backend="ollama", model_name="llama3")
+    repo, s = _repo(Session)
+    logs = repo.list_ai_audit_logs(backend="claude")
+    s.close()
+    assert len(logs) == 1
+    assert logs[0]["backend"] == "claude"
+
+
+def test_list_filter_status(Session):
+    _make_log(Session, status="success")
+    _make_log(Session, status="failure", error_type="AIBackendError")
+    _make_log(Session, status="rate_limited", error_type="RateLimitExceeded")
+    repo, s = _repo(Session)
+    failures = repo.list_ai_audit_logs(status="failure")
+    s.close()
+    assert len(failures) == 1
+    assert failures[0]["status"] == "failure"
+
+
+def test_list_filter_job_id(Session):
+    jid = str(uuid.uuid4())
+    _make_log(Session, job_id=jid)
+    _make_log(Session, job_id=str(uuid.uuid4()))
+    repo, s = _repo(Session)
+    logs = repo.list_ai_audit_logs(job_id=jid)
+    s.close()
+    assert len(logs) == 1
+    assert logs[0]["job_id"] == jid
+
+
+def test_list_respects_limit(Session):
+    for _ in range(5):
+        _make_log(Session)
+    repo, s = _repo(Session)
+    logs = repo.list_ai_audit_logs(limit=3)
+    s.close()
+    assert len(logs) == 3
+
+
+def test_list_empty_no_match(Session):
+    repo, s = _repo(Session)
+    logs = repo.list_ai_audit_logs(triggered_by="nobody")
+    s.close()
+    assert logs == []
+
+
+# ---------------------------------------------------------------------------
+# list_ai_audit_logs_for_job
+# ---------------------------------------------------------------------------
+
+
+def test_list_for_job(Session):
+    jid = str(uuid.uuid4())
+    _make_log(Session, job_id=jid)
+    _make_log(Session, job_id=jid)
+    _make_log(Session, job_id=str(uuid.uuid4()))
+    repo, s = _repo(Session)
+    logs = repo.list_ai_audit_logs_for_job(jid)
+    s.close()
+    assert len(logs) == 2
+    assert all(lg["job_id"] == jid for lg in logs)
+
+
+def test_list_for_job_unknown(Session):
+    repo, s = _repo(Session)
+    logs = repo.list_ai_audit_logs_for_job(str(uuid.uuid4()))
+    s.close()
+    assert logs == []
+
+
+# ---------------------------------------------------------------------------
+# Write-once invariant
+# ---------------------------------------------------------------------------
+
+
+def test_no_update_method(Session):
+    assert not hasattr(AiAuditLogRepository, "update_ai_audit_log")
+
+
+def test_no_delete_method(Session):
+    assert not hasattr(AiAuditLogRepository, "delete_ai_audit_log")


### PR DESCRIPTION
## Summary

- Introduces `ai_audit_log` table (Alembic migration 0006) — metadata only, no prompt or response content ever stored
- `AiAuditLogRepository`: append-only mixin; no update/delete methods exist by design
- `runner.py` writes an audit record for every AI call outcome: `success`, `disabled`, `unavailable`, `failure`, and backend-init error
- DB-backed per-operator rate limiting via `count_recent_ai_jobs()` on the existing `processing_jobs` table — no in-memory state, survives restarts
- `analyze.py`: 429 with `Retry-After: 60` when `AI_MAX_REQUESTS_PER_MINUTE` is exceeded; audit record committed in a separate session before the `HTTPException` is raised (prevents rollback swallowing the record)
- `GET /api/admin/ai-audit`: API-key-only endpoint, filterable by `triggered_by`, `backend`, `status`; returns call metadata only

## Test plan

- [ ] 37 unit tests for `AiAuditLogRepository` (all statuses, list filters, write-once invariant)
- [ ] 28 integration tests for rate limiting (429, Retry-After header, audit written on 429) and the admin audit endpoint (auth, response shape, content-free invariant, filters)
- [ ] Full suite: 1112 passed, 3 skipped, 0 failures
- [ ] Pre-commit: black + ruff + hooks all pass

## Deferred

- SIEM export / webhook forwarding
- Dashboard audit history view
- Per-model cost tracking
- Pagination (cursor-based) on audit list