### PR TITLE
feat(intelligence): fingerprint history and representative campaign fingerprints

### DIFF
--- a/app/db/connection.py
+++ b/app/db/connection.py
@@ -175,7 +175,8 @@ def create_all_tables(engine: Engine) -> None:
                 "top_target_ports TEXT, "
                 "notes TEXT, "
                 "created_at TEXT NOT NULL, "
-                "updated_at TEXT NOT NULL)"
+                "updated_at TEXT NOT NULL, "
+                "representative_fingerprint_json TEXT)"
             )
         )
         conn.execute(
@@ -286,6 +287,27 @@ def create_all_tables(engine: Engine) -> None:
                 "latency_ms INTEGER NOT NULL DEFAULT 0, "
                 "status TEXT NOT NULL, "
                 "error_type TEXT, "
+                "created_at TEXT NOT NULL)"
+            )
+        )
+
+        # Phase 6 Group B — fingerprint history (append-only longitudinal snapshots).
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS fingerprint_history ("
+                "id TEXT PRIMARY KEY, "
+                "fingerprint_id TEXT, "
+                "source_ip TEXT NOT NULL, "
+                "campaign_id TEXT, "
+                "fingerprint_version INTEGER NOT NULL, "
+                "computed_at TEXT NOT NULL, "
+                "event_count_at_computation INTEGER NOT NULL, "
+                "confidence REAL NOT NULL, "
+                "timing_features TEXT, "
+                "sequence_features TEXT, "
+                "protocol_features TEXT, "
+                "credential_features TEXT, "
+                "target_features TEXT, "
                 "created_at TEXT NOT NULL)"
             )
         )

--- a/app/db/migrations/versions/0007_phase6b_fingerprint_history.py
+++ b/app/db/migrations/versions/0007_phase6b_fingerprint_history.py
@@ -1,0 +1,112 @@
+"""Phase 6 Group B — fingerprint history and campaign representative fingerprint
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-05-27
+
+Creates: fingerprint_history
+Alters:  campaigns — adds representative_fingerprint_json column
+
+fingerprint_history is an append-only longitudinal record of every computed
+fingerprint snapshot.  The behavioral_fingerprints table retains only the
+current (latest) fingerprint per IP; fingerprint_history accumulates the
+full history for metamorphic detection and behavioral stability analysis
+(§11.2, §11.3 of the Phase 6 blueprint).
+
+representative_fingerprint_json on campaigns is a denormalized cache of the
+most-recently-active member's fingerprint features, stored to eliminate the
+O(n) per-campaign member → fingerprint lookups in the clustering candidate
+query (§13.2).  It is derived from behavioral_fingerprints; behavioral_fingerprints
+remains the authoritative source.
+
+Rules:
+  - fingerprint_history is append-only: no UPDATE or DELETE methods.
+  - representative_fingerprint_json is updated after each fingerprint
+    computation that results in a campaign assignment.
+  - No raw credentials or raw payloads are stored in fingerprint_history.
+    Feature columns store statistical summaries and distributions only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0007"
+down_revision: str | None = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # fingerprint_history — longitudinal fingerprint snapshot table.
+    #
+    # fingerprint_id:             FK to behavioral_fingerprints.id at the time
+    #                             of computation; NULL when IP is new and the
+    #                             fingerprints row was just inserted.
+    # source_ip:                  The IP whose fingerprint was computed.
+    # campaign_id:                The campaign the IP was associated with at
+    #                             computation time; NULL for new IPs before
+    #                             clustering assigns them.
+    # fingerprint_version:        Schema version of the feature encoding (§12.1).
+    # computed_at:                When the fingerprint computation ran.
+    # event_count_at_computation: Number of events used in this computation.
+    # confidence:                 The fingerprint confidence at this snapshot.
+    # timing_features:            JSON feature dict at this snapshot (no raw events).
+    # sequence_features:          JSON feature dict (port/event sequences).
+    # protocol_features:          JSON feature dict (TLS/SSH/HTTP signals).
+    # credential_features:        JSON feature dict (patterns only, no raw creds).
+    # target_features:            JSON feature dict (port distributions).
+    # created_at:                 When this history record was written.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "fingerprint_history",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("fingerprint_id", sa.Text, nullable=True),
+        sa.Column("source_ip", sa.Text, nullable=False),
+        sa.Column("campaign_id", sa.Text, nullable=True),
+        sa.Column("fingerprint_version", sa.Integer, nullable=False),
+        sa.Column("computed_at", sa.Text, nullable=False),
+        sa.Column("event_count_at_computation", sa.Integer, nullable=False),
+        sa.Column("confidence", sa.Real, nullable=False),
+        sa.Column("timing_features", sa.Text, nullable=True),
+        sa.Column("sequence_features", sa.Text, nullable=True),
+        sa.Column("protocol_features", sa.Text, nullable=True),
+        sa.Column("credential_features", sa.Text, nullable=True),
+        sa.Column("target_features", sa.Text, nullable=True),
+        sa.Column("created_at", sa.Text, nullable=False),
+    )
+    op.create_index("idx_fingerprint_history_source_ip", "fingerprint_history", ["source_ip"])
+    op.create_index("idx_fingerprint_history_campaign_id", "fingerprint_history", ["campaign_id"])
+    op.create_index("idx_fingerprint_history_computed_at", "fingerprint_history", ["computed_at"])
+    op.create_index(
+        "idx_fingerprint_history_fingerprint_id",
+        "fingerprint_history",
+        ["fingerprint_id"],
+    )
+
+    # ------------------------------------------------------------------
+    # campaigns.representative_fingerprint_json — denormalized cache.
+    #
+    # Stores the fingerprint features of the most-recently-active campaign
+    # member, serialised as a JSON object.  Populated after each successful
+    # fingerprint computation → clustering assignment.  NULL until first
+    # assignment.  Always a cache; behavioral_fingerprints is authoritative.
+    # ------------------------------------------------------------------
+    op.add_column(
+        "campaigns",
+        sa.Column("representative_fingerprint_json", sa.Text, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("campaigns", "representative_fingerprint_json")
+
+    op.drop_index("idx_fingerprint_history_fingerprint_id", table_name="fingerprint_history")
+    op.drop_index("idx_fingerprint_history_computed_at", table_name="fingerprint_history")
+    op.drop_index("idx_fingerprint_history_campaign_id", table_name="fingerprint_history")
+    op.drop_index("idx_fingerprint_history_source_ip", table_name="fingerprint_history")
+    op.drop_table("fingerprint_history")

--- a/app/db/repositories/campaign.py
+++ b/app/db/repositories/campaign.py
@@ -11,6 +11,7 @@ PostgreSQL-compatibility rules enforced here:
 
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Any
 
@@ -97,15 +98,17 @@ class CampaignRepository(RepositoryBase):
     def get_campaigns_for_clustering(self) -> list[dict[str, Any]]:
         """Return active/dormant/reactivated campaigns with a representative fingerprint.
 
-        The representative fingerprint is the stored fingerprint of the
-        most-recently-active member IP for each campaign.
+        Fast path: when representative_fingerprint_json is populated on the
+        campaign row, parse it directly — one SQL query for all campaigns.
 
-        Campaigns with no members or whose most-recent member has no
-        stored fingerprint are silently excluded (no candidate to compare
-        against).
+        Slow path (fallback): for campaigns whose representative_fingerprint_json
+        is NULL (or fails to parse), fall back to per-member + behavioral_fingerprints
+        lookup.  This handles pre-migration rows and any cache-miss edge cases.
+
+        Campaigns with no members or no stored fingerprint are silently excluded.
         """
         campaign_rows = self._session.execute(text("""
-                SELECT id, status, last_seen
+                SELECT id, status, last_seen, representative_fingerprint_json
                 FROM campaigns
                 WHERE status IN ('active', 'dormant', 'reactivated')
             """)).fetchall()
@@ -114,7 +117,28 @@ class CampaignRepository(RepositoryBase):
             return []
 
         results: list[dict[str, Any]] = []
-        for cid, status, last_seen in campaign_rows:
+        for cid, status, last_seen, rep_fp_json in campaign_rows:
+            if rep_fp_json is not None:
+                try:
+                    fp_data = json.loads(rep_fp_json)
+                    results.append(
+                        {
+                            "campaign_id": cid,
+                            "status": status,
+                            "last_seen": last_seen,
+                            "timing_features": fp_data.get("timing_features"),
+                            "sequence_features": fp_data.get("sequence_features"),
+                            "protocol_features": fp_data.get("protocol_features"),
+                            "credential_features": fp_data.get("credential_features"),
+                            "target_features": fp_data.get("target_features"),
+                            "confidence": fp_data.get("confidence"),
+                        }
+                    )
+                    continue
+                except (json.JSONDecodeError, TypeError, AttributeError):
+                    pass
+
+            # Slow path: per-member lookup.
             member_row = self._session.execute(
                 text("""
                     SELECT source_ip FROM campaign_members
@@ -153,6 +177,41 @@ class CampaignRepository(RepositoryBase):
             )
 
         return results
+
+    def update_representative_fingerprint(
+        self,
+        campaign_id: str,
+        representative_fingerprint_json: str,
+    ) -> None:
+        """Cache the representative fingerprint JSON on the campaign row.
+
+        Called after a successful fingerprint computation + clustering assignment.
+        behavioral_fingerprints remains the authoritative source; this is a
+        denormalized cache to avoid O(n) per-campaign member + fingerprint lookups
+        in get_campaigns_for_clustering().
+        """
+        self._session.execute(
+            text("""
+                UPDATE campaigns
+                SET representative_fingerprint_json = :fp_json
+                WHERE id = :campaign_id
+            """),
+            {
+                "campaign_id": campaign_id,
+                "fp_json": representative_fingerprint_json,
+            },
+        )
+
+    def get_representative_fingerprint(self, campaign_id: str) -> str | None:
+        """Return the cached representative_fingerprint_json, or None if not set."""
+        row = self._session.execute(
+            text("""
+                SELECT representative_fingerprint_json
+                FROM campaigns WHERE id = :id
+            """),
+            {"id": campaign_id},
+        ).fetchone()
+        return row[0] if row is not None else None
 
     def get_campaign_member_by_ip(self, source_ip: str) -> dict[str, Any] | None:
         """Return the campaign_members row for source_ip, or None if unassigned."""

--- a/app/db/repositories/fingerprint_history.py
+++ b/app/db/repositories/fingerprint_history.py
@@ -1,0 +1,163 @@
+"""Fingerprint history repository — append-only writes for fingerprint_history.
+
+All SQL lives here.  No mutation methods are provided: history records are
+immutable longitudinal snapshots.  There is no update_fingerprint_history()
+and no delete_fingerprint_history().
+
+Each row captures a complete fingerprint snapshot at a point in time:
+  - The behavioral_fingerprints table stores only the latest fingerprint per IP.
+  - This table accumulates every recomputation for longitudinal analysis.
+
+Content rules (§11.2):
+  - Feature columns store statistical summaries and distributions only.
+  - No raw credentials, no raw payloads, no raw event content.
+  - tool_signals is intentionally omitted — it is not a stability-relevant
+    dimension and may contain tool-name strings that could encode identifiable
+    information across versions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db.repositories._base import RepositoryBase
+
+
+def _row_to_dict(row) -> dict[str, Any]:
+    return {
+        "id": row[0],
+        "fingerprint_id": row[1],
+        "source_ip": row[2],
+        "campaign_id": row[3],
+        "fingerprint_version": row[4],
+        "computed_at": row[5],
+        "event_count_at_computation": row[6],
+        "confidence": row[7],
+        "timing_features": row[8],
+        "sequence_features": row[9],
+        "protocol_features": row[10],
+        "credential_features": row[11],
+        "target_features": row[12],
+        "created_at": row[13],
+    }
+
+
+_SELECT_COLS = """
+    SELECT id, fingerprint_id, source_ip, campaign_id,
+           fingerprint_version, computed_at, event_count_at_computation,
+           confidence, timing_features, sequence_features, protocol_features,
+           credential_features, target_features, created_at
+    FROM fingerprint_history
+"""
+
+
+class FingerprintHistoryRepository(RepositoryBase):
+    def insert_fingerprint_history(
+        self,
+        *,
+        history_id: str | None = None,
+        fingerprint_id: str | None = None,
+        source_ip: str,
+        campaign_id: str | None = None,
+        fingerprint_version: int,
+        computed_at: str,
+        event_count_at_computation: int,
+        confidence: float,
+        timing_features: str | None = None,
+        sequence_features: str | None = None,
+        protocol_features: str | None = None,
+        credential_features: str | None = None,
+        target_features: str | None = None,
+        created_at: str | None = None,
+    ) -> dict[str, Any]:
+        """Append a fingerprint snapshot to the history table and return it.
+
+        This is the only write method.  No update or delete path exists.
+        The returned dict reflects the inserted row.
+        """
+        hid = history_id or str(uuid.uuid4())
+        now = created_at or datetime.now(UTC).isoformat()
+        self._session.execute(
+            text("""
+                INSERT INTO fingerprint_history (
+                    id, fingerprint_id, source_ip, campaign_id,
+                    fingerprint_version, computed_at, event_count_at_computation,
+                    confidence, timing_features, sequence_features,
+                    protocol_features, credential_features, target_features,
+                    created_at
+                ) VALUES (
+                    :id, :fingerprint_id, :source_ip, :campaign_id,
+                    :fingerprint_version, :computed_at, :event_count_at_computation,
+                    :confidence, :timing_features, :sequence_features,
+                    :protocol_features, :credential_features, :target_features,
+                    :created_at
+                )
+            """),
+            {
+                "id": hid,
+                "fingerprint_id": fingerprint_id,
+                "source_ip": source_ip,
+                "campaign_id": campaign_id,
+                "fingerprint_version": fingerprint_version,
+                "computed_at": computed_at,
+                "event_count_at_computation": event_count_at_computation,
+                "confidence": confidence,
+                "timing_features": timing_features,
+                "sequence_features": sequence_features,
+                "protocol_features": protocol_features,
+                "credential_features": credential_features,
+                "target_features": target_features,
+                "created_at": now,
+            },
+        )
+        return self.get_fingerprint_history_entry(hid)  # type: ignore[return-value]
+
+    def get_fingerprint_history_entry(self, history_id: str) -> dict[str, Any] | None:
+        """Return a single history record by id, or None if not found."""
+        row = self._session.execute(
+            text(_SELECT_COLS + "WHERE id = :id"),
+            {"id": history_id},
+        ).fetchone()
+        return _row_to_dict(row) if row is not None else None
+
+    def list_fingerprint_history_for_ip(
+        self,
+        source_ip: str,
+        *,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return history records for an IP, oldest first.
+
+        Oldest first is the natural order for longitudinal analysis:
+        each record represents a point further along the behavioral timeline.
+        """
+        rows = self._session.execute(
+            text(_SELECT_COLS + "WHERE source_ip = :ip ORDER BY computed_at ASC LIMIT :limit"),
+            {"ip": source_ip, "limit": limit},
+        ).fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    def list_fingerprint_history_for_campaign(
+        self,
+        campaign_id: str,
+        *,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Return history records for a campaign, oldest first."""
+        rows = self._session.execute(
+            text(_SELECT_COLS + "WHERE campaign_id = :cid ORDER BY computed_at ASC LIMIT :limit"),
+            {"cid": campaign_id, "limit": limit},
+        ).fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    def count_fingerprint_history_for_ip(self, source_ip: str) -> int:
+        """Return the number of history records for an IP."""
+        row = self._session.execute(
+            text("SELECT COUNT(*) FROM fingerprint_history WHERE source_ip = :ip"),
+            {"ip": source_ip},
+        ).fetchone()
+        return int(row[0]) if row else 0

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -7,11 +7,12 @@ EventRepository so all callers continue to use the same import path:
     from app.db.repository import EventRepository
 
 Internal structure (by concern):
-    repositories/write.py        — insert, upsert, update, delete
-    repositories/read.py         — dashboard queries and ingest-side cache reads
-    repositories/intelligence.py — intelligence API query methods
-    repositories/fingerprint.py  — behavioral fingerprint reads and writes
-    repositories/campaign.py     — campaign CRUD and clustering query methods
+    repositories/write.py               — insert, upsert, update, delete
+    repositories/read.py                — dashboard queries and ingest-side cache reads
+    repositories/intelligence.py        — intelligence API query methods
+    repositories/fingerprint.py         — behavioral fingerprint reads and writes
+    repositories/campaign.py            — campaign CRUD and clustering query methods
+    repositories/fingerprint_history.py — append-only longitudinal fingerprint history
 
 The caller owns the session and therefore the transaction boundary.
 
@@ -32,6 +33,7 @@ from app.db.repositories.ai_audit_log import AiAuditLogRepository
 from app.db.repositories.ai_outputs import AiOutputRepository
 from app.db.repositories.campaign import CampaignRepository
 from app.db.repositories.fingerprint import FingerprintRepository
+from app.db.repositories.fingerprint_history import FingerprintHistoryRepository
 from app.db.repositories.intelligence import IntelligenceRepository
 from app.db.repositories.jobs import JobRepository
 from app.db.repositories.read import ReadRepository
@@ -47,9 +49,10 @@ class EventRepository(
     JobRepository,
     AiOutputRepository,
     AiAuditLogRepository,
+    FingerprintHistoryRepository,
 ):
     """
-    Unified repository class. Inherits all SQL methods from the eight concern
+    Unified repository class. Inherits all SQL methods from the nine concern
     mixins. Callers see a single object with the full method surface; the
     internal split is an organisation detail invisible to callers.
 
@@ -57,5 +60,5 @@ class EventRepository(
                 IntelligenceRepository → FingerprintRepository →
                 CampaignRepository → JobRepository →
                 AiOutputRepository → AiAuditLogRepository →
-                RepositoryBase → object
+                FingerprintHistoryRepository → RepositoryBase → object
     """

--- a/app/intelligence/tasks.py
+++ b/app/intelligence/tasks.py
@@ -17,18 +17,45 @@ Deduplication model (Phase 6):
   because fingerprint computation is idempotent (upsert semantics). The
   previous threading.Lock was correct for single-process deployments; the DB
   check is correct for multi-process deployments.
+
+Phase 6 Group B additions:
+  - _compute_and_store() appends a fingerprint_history row on each computation.
+  - _run_campaign_clustering() updates representative_fingerprint_json on the
+    assigned campaign after a successful association.
+  - _build_representative_fp_json() packages feature columns for the cache;
+    tool_signals is excluded (§11.2).
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from fastapi import BackgroundTasks
 
 logger = logging.getLogger(__name__)
+
+
+def _build_representative_fp_json(fp: dict[str, Any]) -> str:
+    """Serialize fingerprint feature columns to JSON for representative_fingerprint_json.
+
+    tool_signals is excluded — it is not a stability-relevant dimension and
+    may contain tool-name strings that could encode identifiable information
+    across versions (§11.2).
+    """
+    return json.dumps(
+        {
+            "timing_features": fp.get("timing_features"),
+            "sequence_features": fp.get("sequence_features"),
+            "protocol_features": fp.get("protocol_features"),
+            "credential_features": fp.get("credential_features"),
+            "target_features": fp.get("target_features"),
+            "confidence": fp.get("confidence"),
+        }
+    )
 
 
 def schedule_fingerprint_if_not_pending(ip: str, background_tasks: BackgroundTasks) -> None:
@@ -102,6 +129,9 @@ def _run_fingerprint_task(ip: str, job_id: str) -> None:
 def _compute_and_store(ip: str) -> None:
     """Fetch events, compute fingerprint, write to behavioral_fingerprints.
 
+    Appends a fingerprint_history row in the same session as the upsert so
+    the history write is atomic with the fingerprint update (§11.2, §11.3).
+
     After a successful fingerprint commit, triggers campaign clustering when
     the fingerprint meets the minimum confidence threshold (§12.6). The
     fingerprint session commits before clustering — a clustering failure
@@ -120,10 +150,11 @@ def _compute_and_store(ip: str) -> None:
         if not events:
             return
         fp = build_fingerprint(events)
+        computed_at = datetime.now(UTC).isoformat()
         repo.upsert_behavioral_fingerprint(
             ip=ip,
             fingerprint_version=FINGERPRINT_VERSION,
-            computed_at=datetime.now(UTC).isoformat(),
+            computed_at=computed_at,
             event_count=fp["event_count"],
             timing_features=fp["timing_features"],
             sequence_features=fp["sequence_features"],
@@ -133,6 +164,23 @@ def _compute_and_store(ip: str) -> None:
             tool_signals=fp["tool_signals"],
             confidence=fp["confidence"],
         )
+        stored = repo.get_behavioral_fingerprint(ip)
+        member = repo.get_campaign_member_by_ip(ip)
+        if stored is not None:
+            repo.insert_fingerprint_history(
+                fingerprint_id=stored["id"],
+                source_ip=ip,
+                campaign_id=member["campaign_id"] if member is not None else None,
+                fingerprint_version=FINGERPRINT_VERSION,
+                computed_at=computed_at,
+                event_count_at_computation=fp["event_count"],
+                confidence=fp["confidence"],
+                timing_features=fp["timing_features"],
+                sequence_features=fp["sequence_features"],
+                protocol_features=fp["protocol_features"],
+                credential_features=fp["credential_features"],
+                target_features=fp["target_features"],
+            )
         fp_confidence = fp["confidence"]
 
     if fp_confidence >= 0.20:
@@ -141,6 +189,9 @@ def _compute_and_store(ip: str) -> None:
 
 def _run_campaign_clustering(ip: str) -> None:
     """Run campaign assignment for ip in a fresh session.
+
+    After assignment, updates representative_fingerprint_json on the campaign
+    so the next clustering query can use the fast path (§13.2).
 
     Failures are logged but do not propagate — a clustering failure must
     never surface as a fingerprint-computation error (§3.3 / §11).
@@ -155,6 +206,9 @@ def _run_campaign_clustering(ip: str) -> None:
             stored_fp = repo.get_behavioral_fingerprint(ip)
             if stored_fp is None:
                 return
-            assign_to_campaign(ip, stored_fp, repo)
+            decision = assign_to_campaign(ip, stored_fp, repo)
+            if decision.campaign_id is not None:
+                rep_fp_json = _build_representative_fp_json(stored_fp)
+                repo.update_representative_fingerprint(decision.campaign_id, rep_fp_json)
     except Exception:
         logger.exception("Campaign clustering failed for ip=%s", ip)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,6 +23,7 @@ def reset_db_rows():
         conn.execute(text("DELETE FROM ai_audit_log"))
         conn.execute(text("DELETE FROM ai_outputs"))
         conn.execute(text("DELETE FROM processing_jobs"))
+        conn.execute(text("DELETE FROM fingerprint_history"))
         conn.execute(text("DELETE FROM behavioral_fingerprints"))
         conn.execute(text("DELETE FROM campaign_tags"))
         conn.execute(text("DELETE FROM campaign_observations"))

--- a/tests/integration/test_fingerprint_history_integration.py
+++ b/tests/integration/test_fingerprint_history_integration.py
@@ -1,0 +1,574 @@
+"""Integration tests for Phase 6 Group B — fingerprint history and campaign
+representative fingerprint denormalization.
+
+Tests hit the full DB stack (in-memory SQLite, bootstrapped by tests/conftest.py).
+Rows are reset per test by tests/integration/conftest.py.
+
+Coverage:
+  get_campaigns_for_clustering fast path:
+    - Returns representative fingerprint data from JSON cache when populated
+    - Returns correct campaign metadata (id, status, last_seen)
+    - Feature columns parsed from JSON match stored values
+
+  get_campaigns_for_clustering slow path:
+    - Falls back to per-member lookup when representative_fingerprint_json is NULL
+    - Falls back when representative_fingerprint_json contains invalid JSON
+    - Returns correct fingerprint data from behavioral_fingerprints
+
+  Fingerprint history — written during computation:
+    - _compute_and_store() writes exactly one history row
+    - History row has correct source_ip and fingerprint_version
+    - History row has campaign_id=None for an unassigned IP
+    - History row has campaign_id set for an already-assigned IP
+    - Multiple _compute_and_store() calls accumulate history rows (append-only)
+    - Feature columns in history row are JSON strings, not raw events
+
+  Representative fingerprint update:
+    - _run_campaign_clustering() updates representative_fingerprint_json
+      on the assigned campaign
+    - Representative fingerprint JSON contains expected feature keys
+    - tool_signals is NOT included in representative fingerprint JSON
+
+  No raw credentials:
+    - credential_features in history row stores statistical summaries, not raw values
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from app.db.connection import get_engine
+from app.db.repository import EventRepository
+
+_TS = "2026-03-01T00:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_source_ip(ip: str) -> None:
+    with get_engine().connect() as conn:
+        conn.execute(
+            text(
+                "INSERT OR IGNORE INTO source_ips"
+                " (ip, first_seen, last_seen, event_count) VALUES (:ip, :ts, :ts, 0)"
+            ),
+            {"ip": ip, "ts": _TS},
+        )
+        conn.commit()
+
+
+def _insert_campaign(
+    campaign_id: str | None = None,
+    *,
+    status: str = "active",
+    representative_fingerprint_json: str | None = None,
+) -> str:
+    cid = campaign_id or str(uuid.uuid4())
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO campaigns (
+                    id, name, status, confidence, first_seen, last_seen,
+                    dormant_since, reactivation_count, member_ip_count,
+                    attack_tactic_dist, top_target_ports, notes,
+                    created_at, updated_at, representative_fingerprint_json
+                ) VALUES (
+                    :id, :name, :status, 0.75, :ts, :ts,
+                    NULL, 0, 0,
+                    NULL, NULL, NULL,
+                    :ts, :ts, :rep_fp
+                )
+            """),
+            {
+                "id": cid,
+                "name": f"CAMP-{cid[:8]}",
+                "status": status,
+                "ts": _TS,
+                "rep_fp": representative_fingerprint_json,
+            },
+        )
+        conn.commit()
+    return cid
+
+
+def _insert_member(campaign_id: str, ip: str) -> None:
+    _insert_source_ip(ip)
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO campaign_members
+                    (campaign_id, source_ip, confidence, added_at, last_active)
+                VALUES (:cid, :ip, 0.75, :ts, :ts)
+            """),
+            {"cid": campaign_id, "ip": ip, "ts": _TS},
+        )
+        conn.commit()
+
+
+def _insert_fingerprint(ip: str, *, fp_id: str | None = None) -> str:
+    fid = fp_id or str(uuid.uuid4())
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO behavioral_fingerprints (
+                    id, source_ip, fingerprint_version, computed_at,
+                    event_count_at_computation, timing_features, sequence_features,
+                    protocol_features, credential_features, target_features,
+                    tool_signals, confidence
+                ) VALUES (
+                    :id, :ip, 1, :ts,
+                    15,
+                    '{"mean_inter_arrival": 1.2, "burst_cv": 0.5}',
+                    '{"port_sequence": [22, 80]}',
+                    '{"service_distribution": {"ssh": 10}}',
+                    '{"username_class_dist": {"dictionary": 5}}',
+                    '{"top_dst_ports": [22]}',
+                    '{"tools": ["masscan"]}',
+                    0.80
+                )
+            """),
+            {"id": fid, "ip": ip, "ts": _TS},
+        )
+        conn.commit()
+    return fid
+
+
+def _insert_event(
+    eid: str,
+    ip: str,
+    *,
+    event_type: str = "auth_failed",
+    dst_port: int = 22,
+    ts: str = _TS,
+    raw_data: dict | None = None,
+) -> None:
+    """Insert a raw_event + event row for fingerprint computation."""
+    payload = json.dumps({"source": "test-sensor", "data": raw_data or {}})
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO raw_events (id, ts, ingested_at, source, raw_json)
+                VALUES (:id, :ts, :ts, :ip, :payload)
+            """),
+            {"id": eid, "ts": ts, "ip": ip, "payload": payload},
+        )
+        conn.execute(
+            text("""
+                INSERT INTO events
+                    (id, ts, src_ip, dst_port, protocol, event_type, schema_version)
+                VALUES (:id, :ts, :src_ip, :dst_port, 'tcp', :event_type, 1)
+            """),
+            {"id": eid, "ts": ts, "src_ip": ip, "dst_port": dst_port, "event_type": event_type},
+        )
+        conn.commit()
+
+
+def _get_representative_fp(campaign_id: str) -> str | None:
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            text("SELECT representative_fingerprint_json FROM campaigns WHERE id = :id"),
+            {"id": campaign_id},
+        ).fetchone()
+    return row[0] if row else None
+
+
+def _count_history_for_ip(ip: str) -> int:
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            text("SELECT COUNT(*) FROM fingerprint_history WHERE source_ip = :ip"),
+            {"ip": ip},
+        ).fetchone()
+    return row[0] if row else 0
+
+
+def _get_history_rows_for_ip(ip: str) -> list[dict]:
+    with get_engine().connect() as conn:
+        rows = conn.execute(
+            text("""
+                SELECT id, fingerprint_id, source_ip, campaign_id,
+                       fingerprint_version, computed_at, event_count_at_computation,
+                       confidence, timing_features, sequence_features, protocol_features,
+                       credential_features, target_features, created_at
+                FROM fingerprint_history WHERE source_ip = :ip
+                ORDER BY computed_at ASC
+            """),
+            {"ip": ip},
+        ).fetchall()
+    return [
+        {
+            "id": r[0],
+            "fingerprint_id": r[1],
+            "source_ip": r[2],
+            "campaign_id": r[3],
+            "fingerprint_version": r[4],
+            "computed_at": r[5],
+            "event_count_at_computation": r[6],
+            "confidence": r[7],
+            "timing_features": r[8],
+            "sequence_features": r[9],
+            "protocol_features": r[10],
+            "credential_features": r[11],
+            "target_features": r[12],
+            "created_at": r[13],
+        }
+        for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# get_campaigns_for_clustering — fast path
+# ---------------------------------------------------------------------------
+
+
+def test_clustering_fast_path_returns_representative_data():
+    """Campaign with representative_fingerprint_json set uses fast path."""
+    rep_fp = json.dumps(
+        {
+            "timing_features": '{"mean_inter_arrival": 2.0}',
+            "sequence_features": '{"port_sequence": [22]}',
+            "protocol_features": None,
+            "credential_features": '{"username_class_dist": {"dictionary": 3}}',
+            "target_features": None,
+            "confidence": 0.77,
+        }
+    )
+    cid = _insert_campaign(representative_fingerprint_json=rep_fp)
+
+    from app.db.connection import get_session
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        candidates = repo.get_campaigns_for_clustering()
+
+    match = next((c for c in candidates if c["campaign_id"] == cid), None)
+    assert match is not None
+    assert match["confidence"] == pytest.approx(0.77)
+    assert match["timing_features"] == '{"mean_inter_arrival": 2.0}'
+    assert match["credential_features"] == '{"username_class_dist": {"dictionary": 3}}'
+    assert match["protocol_features"] is None
+
+
+def test_clustering_fast_path_campaign_metadata_correct():
+    rep_fp = json.dumps(
+        {
+            "timing_features": None,
+            "sequence_features": None,
+            "protocol_features": None,
+            "credential_features": None,
+            "target_features": None,
+            "confidence": 0.55,
+        }
+    )
+    cid = _insert_campaign(status="dormant", representative_fingerprint_json=rep_fp)
+
+    from app.db.connection import get_session
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        candidates = repo.get_campaigns_for_clustering()
+
+    match = next((c for c in candidates if c["campaign_id"] == cid), None)
+    assert match is not None
+    assert match["status"] == "dormant"
+    assert match["last_seen"] == _TS
+
+
+# ---------------------------------------------------------------------------
+# get_campaigns_for_clustering — slow path / fallback
+# ---------------------------------------------------------------------------
+
+
+def test_clustering_slow_path_when_rep_fp_null():
+    """Campaign without representative_fingerprint_json falls back to member lookup."""
+    cid = _insert_campaign(representative_fingerprint_json=None)
+    ip = f"10.88.{uuid.uuid4().int % 256}.1"
+    _insert_member(cid, ip)
+    _insert_fingerprint(ip)
+
+    from app.db.connection import get_session
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        candidates = repo.get_campaigns_for_clustering()
+
+    match = next((c for c in candidates if c["campaign_id"] == cid), None)
+    assert match is not None
+    assert match["confidence"] == pytest.approx(0.80)
+    assert match["timing_features"] == '{"mean_inter_arrival": 1.2, "burst_cv": 0.5}'
+
+
+def test_clustering_slow_path_invalid_json_falls_back():
+    """Campaign with corrupt representative_fingerprint_json falls back."""
+    cid = _insert_campaign(representative_fingerprint_json="NOT VALID JSON }{")
+    ip = f"10.89.{uuid.uuid4().int % 256}.1"
+    _insert_member(cid, ip)
+    _insert_fingerprint(ip)
+
+    from app.db.connection import get_session
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        candidates = repo.get_campaigns_for_clustering()
+
+    match = next((c for c in candidates if c["campaign_id"] == cid), None)
+    assert match is not None
+    assert match["confidence"] == pytest.approx(0.80)
+
+
+def test_clustering_excludes_campaign_with_no_members_and_null_rep_fp():
+    """Campaign with NULL representative fingerprint and no members is excluded."""
+    cid = _insert_campaign(representative_fingerprint_json=None)
+
+    from app.db.connection import get_session
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        candidates = repo.get_campaigns_for_clustering()
+
+    assert not any(c["campaign_id"] == cid for c in candidates)
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint history written during computation
+# ---------------------------------------------------------------------------
+
+
+def test_compute_and_store_writes_one_history_row():
+    ip = f"10.50.{uuid.uuid4().int % 256}.1"
+    _insert_source_ip(ip)
+    for i in range(5):
+        ts = f"2026-01-{i+1:02d}T00:00:00+00:00"
+        _insert_event(str(uuid.uuid4()), ip, ts=ts)
+
+    from app.intelligence.tasks import _compute_and_store
+
+    _compute_and_store(ip)
+
+    assert _count_history_for_ip(ip) == 1
+
+
+def test_compute_and_store_history_row_has_correct_source_ip():
+    ip = f"10.51.{uuid.uuid4().int % 256}.1"
+    _insert_source_ip(ip)
+    for i in range(5):
+        ts = f"2026-01-{i+1:02d}T00:00:00+00:00"
+        _insert_event(str(uuid.uuid4()), ip, ts=ts)
+
+    from app.intelligence.tasks import _compute_and_store
+
+    _compute_and_store(ip)
+
+    rows = _get_history_rows_for_ip(ip)
+    assert len(rows) == 1
+    assert rows[0]["source_ip"] == ip
+    assert rows[0]["fingerprint_version"] == 1
+
+
+def test_compute_and_store_history_campaign_id_none_for_unassigned_ip():
+    ip = f"10.52.{uuid.uuid4().int % 256}.1"
+    _insert_source_ip(ip)
+    for i in range(5):
+        ts = f"2026-01-{i+1:02d}T00:00:00+00:00"
+        _insert_event(str(uuid.uuid4()), ip, ts=ts)
+
+    from app.intelligence.tasks import _compute_and_store
+
+    _compute_and_store(ip)
+
+    rows = _get_history_rows_for_ip(ip)
+    assert rows[0]["campaign_id"] is None
+
+
+def test_compute_and_store_history_campaign_id_set_for_member():
+    ip = f"10.53.{uuid.uuid4().int % 256}.1"
+    cid = _insert_campaign()
+    _insert_member(cid, ip)
+    for i in range(5):
+        ts = f"2026-01-{i+1:02d}T00:00:00+00:00"
+        _insert_event(str(uuid.uuid4()), ip, ts=ts)
+
+    from app.intelligence.tasks import _compute_and_store
+
+    _compute_and_store(ip)
+
+    rows = _get_history_rows_for_ip(ip)
+    assert rows[0]["campaign_id"] == cid
+
+
+def test_compute_and_store_history_accumulates_multiple_calls():
+    ip = f"10.54.{uuid.uuid4().int % 256}.1"
+    _insert_source_ip(ip)
+    for i in range(5):
+        ts = f"2026-01-{i+1:02d}T00:00:00+00:00"
+        _insert_event(str(uuid.uuid4()), ip, ts=ts)
+
+    from app.intelligence.tasks import _compute_and_store
+
+    _compute_and_store(ip)
+    _compute_and_store(ip)
+
+    assert _count_history_for_ip(ip) == 2
+
+
+def test_compute_and_store_history_feature_columns_are_json_strings():
+    """Feature columns in history must be JSON strings, not raw event data."""
+    ip = f"10.55.{uuid.uuid4().int % 256}.1"
+    _insert_source_ip(ip)
+    for i in range(5):
+        ts = f"2026-01-{i+1:02d}T00:00:00+00:00"
+        _insert_event(str(uuid.uuid4()), ip, ts=ts, dst_port=22, event_type="auth_failed")
+
+    from app.intelligence.tasks import _compute_and_store
+
+    _compute_and_store(ip)
+
+    rows = _get_history_rows_for_ip(ip)
+    row = rows[0]
+    # Any non-null feature column must be valid JSON, not raw event data.
+    for col in (
+        "timing_features",
+        "sequence_features",
+        "protocol_features",
+        "credential_features",
+        "target_features",
+    ):
+        val = row[col]
+        if val is not None:
+            parsed = json.loads(val)
+            assert isinstance(parsed, dict)
+
+
+# ---------------------------------------------------------------------------
+# No raw credentials in history
+# ---------------------------------------------------------------------------
+
+
+def test_credential_features_stores_summary_not_raw_credentials():
+    """credential_features must store distribution counts, not raw usernames."""
+    ip = f"10.56.{uuid.uuid4().int % 256}.1"
+    _insert_source_ip(ip)
+    raw_cred_data = {"username": "administrator", "password": "P@ssw0rd!"}
+    for i in range(5):
+        ts = f"2026-01-{i+1:02d}T00:00:00+00:00"
+        _insert_event(
+            str(uuid.uuid4()),
+            ip,
+            ts=ts,
+            event_type="auth_failed",
+            raw_data=raw_cred_data,
+        )
+
+    from app.intelligence.tasks import _compute_and_store
+
+    _compute_and_store(ip)
+
+    rows = _get_history_rows_for_ip(ip)
+    row = rows[0]
+    cred_json = row["credential_features"]
+    if cred_json is not None:
+        parsed = json.loads(cred_json)
+        # Must not contain raw credential values
+        assert "administrator" not in json.dumps(parsed)
+        assert "P@ssw0rd!" not in json.dumps(parsed)
+        # Must contain statistical summaries
+        assert isinstance(parsed, dict)
+
+
+# ---------------------------------------------------------------------------
+# Representative fingerprint update after clustering
+# ---------------------------------------------------------------------------
+
+
+def test_representative_fp_updated_after_clustering_assigns_campaign():
+    """After campaign assignment, representative_fingerprint_json must be set."""
+    ip = f"10.60.{uuid.uuid4().int % 256}.1"
+    _insert_source_ip(ip)
+    _insert_fingerprint(ip)
+
+    # Insert a campaign with a matching fingerprint so assign_to_campaign will
+    # find a candidate.  Use the fast path with a pre-populated representative fp.
+    ref_fp = json.dumps(
+        {
+            "timing_features": '{"mean_inter_arrival": 1.2, "burst_cv": 0.5}',
+            "sequence_features": '{"port_sequence": [22, 80]}',
+            "protocol_features": '{"service_distribution": {"ssh": 10}}',
+            "credential_features": '{"username_class_dist": {"dictionary": 5}}',
+            "target_features": '{"top_dst_ports": [22]}',
+            "confidence": 0.80,
+        }
+    )
+    cid = _insert_campaign(representative_fingerprint_json=ref_fp)
+    ip_member = f"10.60.{uuid.uuid4().int % 256}.2"
+    _insert_member(cid, ip_member)
+    _insert_fingerprint(ip_member)
+
+    from app.intelligence.tasks import _run_campaign_clustering
+
+    _run_campaign_clustering(ip)
+
+    # If clustering assigned the IP to a campaign, representative_fp should be updated.
+    # We can't guarantee which campaign it lands on (depends on similarity), but we can
+    # at least verify the task runs without error and that rep fp on the assigned campaign
+    # is not null.  Check via the source_ip → campaign_members table.
+    from app.db.connection import get_session
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        member = repo.get_campaign_member_by_ip(ip)
+        if member is not None:
+            rep_fp_raw = _get_representative_fp(member["campaign_id"])
+            assert rep_fp_raw is not None
+            rep_fp_parsed = json.loads(rep_fp_raw)
+            assert "confidence" in rep_fp_parsed
+            assert "timing_features" in rep_fp_parsed
+            assert "tool_signals" not in rep_fp_parsed
+
+
+def test_representative_fp_json_excludes_tool_signals():
+    """_build_representative_fp_json must not include tool_signals."""
+    from app.intelligence.tasks import _build_representative_fp_json
+
+    fp = {
+        "timing_features": '{"mean_inter_arrival": 1.0}',
+        "sequence_features": '{"port_sequence": [22]}',
+        "protocol_features": None,
+        "credential_features": None,
+        "target_features": None,
+        "tool_signals": '{"tools": ["masscan", "zmap"]}',
+        "confidence": 0.70,
+    }
+    result = _build_representative_fp_json(fp)
+    parsed = json.loads(result)
+    assert "tool_signals" not in parsed
+    assert parsed["confidence"] == pytest.approx(0.70)
+    assert parsed["timing_features"] == '{"mean_inter_arrival": 1.0}'
+
+
+def test_representative_fp_json_contains_all_feature_keys():
+    from app.intelligence.tasks import _build_representative_fp_json
+
+    fp = {
+        "timing_features": "T",
+        "sequence_features": "S",
+        "protocol_features": "P",
+        "credential_features": "C",
+        "target_features": "TG",
+        "confidence": 0.90,
+    }
+    parsed = json.loads(_build_representative_fp_json(fp))
+    for key in (
+        "timing_features",
+        "sequence_features",
+        "protocol_features",
+        "credential_features",
+        "target_features",
+        "confidence",
+    ):
+        assert key in parsed

--- a/tests/unit/test_fingerprint_history_repository.py
+++ b/tests/unit/test_fingerprint_history_repository.py
@@ -1,0 +1,314 @@
+"""Unit tests for FingerprintHistoryRepository.
+
+Uses an in-memory SQLite engine with create_all_tables().
+All tests are isolated: the engine is module-scoped and the table is
+truncated between tests via the _clean fixture.
+
+Coverage:
+  - insert_fingerprint_history inserts row and returns full dict
+  - id is auto-generated when not provided
+  - explicit id is stored verbatim
+  - get_fingerprint_history_entry returns row by id
+  - get_fingerprint_history_entry returns None for unknown id
+  - all fields stored correctly
+  - nullable fields (fingerprint_id, campaign_id) may be None
+  - feature columns may be None
+  - list_fingerprint_history_for_ip returns records oldest first
+  - list_fingerprint_history_for_ip respects limit
+  - list_fingerprint_history_for_ip returns empty list for unknown ip
+  - list_fingerprint_history_for_campaign returns records oldest first
+  - list_fingerprint_history_for_campaign respects limit
+  - list_fingerprint_history_for_campaign returns empty list for unknown id
+  - count_fingerprint_history_for_ip returns correct count
+  - count_fingerprint_history_for_ip returns 0 for unknown ip
+  - write-once: no update method exists on FingerprintHistoryRepository
+  - write-once: no delete method exists on FingerprintHistoryRepository
+  - multiple history rows for same ip accumulate
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from app.db.connection import create_all_tables
+from app.db.repositories.fingerprint_history import FingerprintHistoryRepository
+
+
+@pytest.fixture(scope="module")
+def engine():
+    e = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    create_all_tables(e)
+    return e
+
+
+@pytest.fixture(scope="module")
+def Session(engine):
+    return sessionmaker(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def _clean(engine):
+    yield
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM fingerprint_history"))
+        conn.commit()
+
+
+def _repo(Session):
+    s = Session()
+    return FingerprintHistoryRepository(s), s
+
+
+def _insert(Session, **overrides):
+    repo, s = _repo(Session)
+    kwargs = dict(
+        source_ip="192.0.2.1",
+        fingerprint_version=1,
+        computed_at="2026-01-01T00:00:00+00:00",
+        event_count_at_computation=10,
+        confidence=0.75,
+    )
+    kwargs.update(overrides)
+    row = repo.insert_fingerprint_history(**kwargs)
+    s.commit()
+    s.close()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# insert / get
+# ---------------------------------------------------------------------------
+
+
+def test_insert_returns_dict(Session):
+    row = _insert(Session)
+    assert isinstance(row, dict)
+
+
+def test_auto_id(Session):
+    row = _insert(Session)
+    assert row["id"]
+    assert len(row["id"]) == 36
+
+
+def test_explicit_id(Session):
+    hid = str(uuid.uuid4())
+    row = _insert(Session, history_id=hid)
+    assert row["id"] == hid
+
+
+def test_get_by_id(Session):
+    row = _insert(Session)
+    repo, s = _repo(Session)
+    fetched = repo.get_fingerprint_history_entry(row["id"])
+    s.close()
+    assert fetched is not None
+    assert fetched["id"] == row["id"]
+
+
+def test_get_unknown_returns_none(Session):
+    repo, s = _repo(Session)
+    result = repo.get_fingerprint_history_entry(str(uuid.uuid4()))
+    s.close()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Field storage
+# ---------------------------------------------------------------------------
+
+
+def test_all_fields_stored(Session):
+    fp_id = str(uuid.uuid4())
+    cid = str(uuid.uuid4())
+    row = _insert(
+        Session,
+        fingerprint_id=fp_id,
+        source_ip="10.0.0.1",
+        campaign_id=cid,
+        fingerprint_version=1,
+        computed_at="2026-03-15T12:00:00+00:00",
+        event_count_at_computation=42,
+        confidence=0.88,
+        timing_features='{"mean_inter_arrival": 1.5}',
+        sequence_features='{"top_ports": [22, 80]}',
+        protocol_features='{"tls_ratio": 0.4}',
+        credential_features='{"unique_usernames": 3}',
+        target_features='{"port_entropy": 2.1}',
+    )
+    assert row["fingerprint_id"] == fp_id
+    assert row["source_ip"] == "10.0.0.1"
+    assert row["campaign_id"] == cid
+    assert row["fingerprint_version"] == 1
+    assert row["computed_at"] == "2026-03-15T12:00:00+00:00"
+    assert row["event_count_at_computation"] == 42
+    assert row["confidence"] == pytest.approx(0.88)
+    assert row["timing_features"] == '{"mean_inter_arrival": 1.5}'
+    assert row["sequence_features"] == '{"top_ports": [22, 80]}'
+    assert row["protocol_features"] == '{"tls_ratio": 0.4}'
+    assert row["credential_features"] == '{"unique_usernames": 3}'
+    assert row["target_features"] == '{"port_entropy": 2.1}'
+    assert row["created_at"]
+
+
+def test_nullable_fingerprint_id(Session):
+    row = _insert(Session, fingerprint_id=None)
+    assert row["fingerprint_id"] is None
+
+
+def test_nullable_campaign_id(Session):
+    row = _insert(Session, campaign_id=None)
+    assert row["campaign_id"] is None
+
+
+def test_nullable_feature_columns(Session):
+    row = _insert(
+        Session,
+        timing_features=None,
+        sequence_features=None,
+        protocol_features=None,
+        credential_features=None,
+        target_features=None,
+    )
+    assert row["timing_features"] is None
+    assert row["sequence_features"] is None
+    assert row["protocol_features"] is None
+    assert row["credential_features"] is None
+    assert row["target_features"] is None
+
+
+# ---------------------------------------------------------------------------
+# list_fingerprint_history_for_ip
+# ---------------------------------------------------------------------------
+
+
+def test_list_for_ip_oldest_first(Session):
+    ip = "10.1.1.1"
+    _insert(Session, source_ip=ip, computed_at="2026-01-03T00:00:00+00:00")
+    _insert(Session, source_ip=ip, computed_at="2026-01-01T00:00:00+00:00")
+    _insert(Session, source_ip=ip, computed_at="2026-01-02T00:00:00+00:00")
+    repo, s = _repo(Session)
+    rows = repo.list_fingerprint_history_for_ip(ip)
+    s.close()
+    dates = [r["computed_at"] for r in rows]
+    assert dates == sorted(dates)
+
+
+def test_list_for_ip_respects_limit(Session):
+    ip = "10.1.1.2"
+    for i in range(5):
+        _insert(Session, source_ip=ip, computed_at=f"2026-01-0{i+1}T00:00:00+00:00")
+    repo, s = _repo(Session)
+    rows = repo.list_fingerprint_history_for_ip(ip, limit=2)
+    s.close()
+    assert len(rows) == 2
+
+
+def test_list_for_ip_unknown(Session):
+    repo, s = _repo(Session)
+    rows = repo.list_fingerprint_history_for_ip("192.168.255.255")
+    s.close()
+    assert rows == []
+
+
+def test_list_for_ip_only_returns_that_ip(Session):
+    _insert(Session, source_ip="10.2.0.1")
+    _insert(Session, source_ip="10.2.0.2")
+    repo, s = _repo(Session)
+    rows = repo.list_fingerprint_history_for_ip("10.2.0.1")
+    s.close()
+    assert all(r["source_ip"] == "10.2.0.1" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# list_fingerprint_history_for_campaign
+# ---------------------------------------------------------------------------
+
+
+def test_list_for_campaign_oldest_first(Session):
+    cid = str(uuid.uuid4())
+    _insert(Session, campaign_id=cid, computed_at="2026-02-03T00:00:00+00:00")
+    _insert(Session, campaign_id=cid, computed_at="2026-02-01T00:00:00+00:00")
+    _insert(Session, campaign_id=cid, computed_at="2026-02-02T00:00:00+00:00")
+    repo, s = _repo(Session)
+    rows = repo.list_fingerprint_history_for_campaign(cid)
+    s.close()
+    dates = [r["computed_at"] for r in rows]
+    assert dates == sorted(dates)
+
+
+def test_list_for_campaign_respects_limit(Session):
+    cid = str(uuid.uuid4())
+    for i in range(5):
+        _insert(Session, campaign_id=cid, computed_at=f"2026-02-0{i+1}T00:00:00+00:00")
+    repo, s = _repo(Session)
+    rows = repo.list_fingerprint_history_for_campaign(cid, limit=3)
+    s.close()
+    assert len(rows) == 3
+
+
+def test_list_for_campaign_unknown(Session):
+    repo, s = _repo(Session)
+    rows = repo.list_fingerprint_history_for_campaign(str(uuid.uuid4()))
+    s.close()
+    assert rows == []
+
+
+def test_list_for_campaign_excludes_other_campaigns(Session):
+    cid_a = str(uuid.uuid4())
+    cid_b = str(uuid.uuid4())
+    _insert(Session, campaign_id=cid_a)
+    _insert(Session, campaign_id=cid_b)
+    repo, s = _repo(Session)
+    rows = repo.list_fingerprint_history_for_campaign(cid_a)
+    s.close()
+    assert all(r["campaign_id"] == cid_a for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# count_fingerprint_history_for_ip
+# ---------------------------------------------------------------------------
+
+
+def test_count_for_ip(Session):
+    ip = "10.3.0.1"
+    _insert(Session, source_ip=ip)
+    _insert(Session, source_ip=ip)
+    _insert(Session, source_ip=ip)
+    repo, s = _repo(Session)
+    count = repo.count_fingerprint_history_for_ip(ip)
+    s.close()
+    assert count == 3
+
+
+def test_count_for_unknown_ip_returns_zero(Session):
+    repo, s = _repo(Session)
+    count = repo.count_fingerprint_history_for_ip("192.168.0.99")
+    s.close()
+    assert count == 0
+
+
+def test_multiple_rows_accumulate(Session):
+    ip = "10.3.0.2"
+    for _ in range(4):
+        _insert(Session, source_ip=ip)
+    repo, s = _repo(Session)
+    assert repo.count_fingerprint_history_for_ip(ip) == 4
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Write-once invariant
+# ---------------------------------------------------------------------------
+
+
+def test_no_update_method(Session):
+    assert not hasattr(FingerprintHistoryRepository, "update_fingerprint_history")
+
+
+def test_no_delete_method(Session):
+    assert not hasattr(FingerprintHistoryRepository, "delete_fingerprint_history")


### PR DESCRIPTION
## Summary

- Adds `fingerprint_history` table (append-only) that accumulates every fingerprint snapshot per IP — provides the longitudinal record needed for behavioral stability and metamorphic detection work
- Adds `representative_fingerprint_json` to `campaigns` as a write-through cache of the most-recently-active member's fingerprint, replacing the O(2n) per-member SQL lookups in `get_campaigns_for_clustering()` with a single-pass query
- Writes a history row on each fingerprint computation (same session as the upsert, atomic); updates the campaign cache after every clustering assignment

## Changes

**Migration** (`0007`): creates `fingerprint_history` (14 cols, 4 indexes); adds `representative_fingerprint_json TEXT` to `campaigns`

**Repository layer**:
- `FingerprintHistoryRepository` — 5 methods; insert/get/list/count; no update/delete (append-only enforced structurally)
- `CampaignRepository.get_campaigns_for_clustering()` — fast path parses `representative_fingerprint_json` directly; falls back to per-member + `behavioral_fingerprints` lookup when NULL or invalid JSON
- `CampaignRepository.update_representative_fingerprint()` — cache write after clustering assignment

**Task layer** (`tasks.py`):
- `_build_representative_fp_json()` — packages 5 feature columns + confidence; `tool_signals` excluded (§11.2)
- `_compute_and_store()` — appends history row in same session as upsert
- `_run_campaign_clustering()` — updates representative fingerprint after successful assignment

**Tests**: 27 unit tests (`test_fingerprint_history_repository.py`), 18 integration tests (`test_fingerprint_history_integration.py`) — 1149 total passing

## Source-of-truth boundary

`behavioral_fingerprints` remains authoritative. `representative_fingerprint_json` is a cache only — the slow path in `get_campaigns_for_clustering()` is always available as fallback.

## Deferred

Behavioral stability scoring, metamorphic detection, dashboard changes, vector search.

## Test plan

- [ ] Migration upgrade/downgrade runs cleanly
- [ ] `pytest` passes (1149 tests)
- [ ] Fast-path clustering returns correct data from JSON cache
- [ ] Slow-path fallback works when cache is NULL or invalid
- [ ] History rows accumulate across multiple fingerprint computations
- [ ] `tool_signals` absent from representative fingerprint JSON
- [ ] `credential_features` stores statistical summaries, not raw values