### PR TITLE
feat(intelligence): behavioral stability scoring

### DIFF
--- a/app/db/connection.py
+++ b/app/db/connection.py
@@ -176,7 +176,8 @@ def create_all_tables(engine: Engine) -> None:
                 "notes TEXT, "
                 "created_at TEXT NOT NULL, "
                 "updated_at TEXT NOT NULL, "
-                "representative_fingerprint_json TEXT)"
+                "representative_fingerprint_json TEXT, "
+                "behavioral_stability_json TEXT)"
             )
         )
         conn.execute(

--- a/app/db/migrations/versions/0008_phase6b_behavioral_stability.py
+++ b/app/db/migrations/versions/0008_phase6b_behavioral_stability.py
@@ -1,0 +1,55 @@
+"""Phase 6 Group B — behavioral stability score column on campaigns
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-05-27
+
+Adds behavioral_stability_json to campaigns.
+
+behavioral_stability_json stores the most-recently-computed stability
+assessment for a campaign as a JSON object:
+  {
+    "status": "ok" | "insufficient_data",
+    "composite_score": float,          -- weighted average of per-dimension scores
+    "timing_stability": float | null,
+    "sequence_stability": float | null,
+    "protocol_stability": float | null,
+    "credential_stability": float | null,
+    "target_stability": float | null,
+    "sample_count": int,               -- history records used
+    "pair_count": int,                 -- consecutive pairs evaluated
+    "dimensions_used": int,
+    "calculated_at": str,
+    "explanation": {...}               -- per-dimension breakdown
+  }
+
+This is derived data, not source of truth.  fingerprint_history is the
+authoritative record.  The column is recomputed after each fingerprint
+history append and can be reconstructed at any time from fingerprint_history.
+
+NULL until the first fingerprint history computation for a campaign member
+produces at least two history records.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008"
+down_revision: str | None = "0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "campaigns",
+        sa.Column("behavioral_stability_json", sa.Text, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("campaigns", "behavioral_stability_json")

--- a/app/db/repositories/campaign.py
+++ b/app/db/repositories/campaign.py
@@ -71,7 +71,7 @@ class CampaignRepository(RepositoryBase):
                        first_seen, last_seen, dormant_since,
                        reactivation_count, member_ip_count,
                        attack_tactic_dist, top_target_ports, notes,
-                       created_at, updated_at
+                       created_at, updated_at, behavioral_stability_json
                 FROM campaigns WHERE id = :id
             """),
             {"id": campaign_id},
@@ -93,6 +93,7 @@ class CampaignRepository(RepositoryBase):
             "notes": row[11],
             "created_at": row[12],
             "updated_at": row[13],
+            "behavioral_stability_json": row[14],
         }
 
     def get_campaigns_for_clustering(self) -> list[dict[str, Any]]:
@@ -212,6 +213,51 @@ class CampaignRepository(RepositoryBase):
             {"id": campaign_id},
         ).fetchone()
         return row[0] if row is not None else None
+
+    def update_campaign_stability(
+        self,
+        campaign_id: str,
+        behavioral_stability_json: str,
+    ) -> None:
+        """Persist the behavioral stability JSON for a campaign.
+
+        Called by refresh_campaign_stability() after each stability recomputation.
+        The column is derived data — fingerprint_history is the authoritative source.
+        """
+        self._session.execute(
+            text("""
+                UPDATE campaigns
+                SET behavioral_stability_json = :stability_json
+                WHERE id = :campaign_id
+            """),
+            {
+                "campaign_id": campaign_id,
+                "stability_json": behavioral_stability_json,
+            },
+        )
+
+    def get_campaign_stability(self, campaign_id: str) -> str | None:
+        """Return behavioral_stability_json for campaign_id, or None if not set."""
+        row = self._session.execute(
+            text("""
+                SELECT behavioral_stability_json
+                FROM campaigns WHERE id = :id
+            """),
+            {"id": campaign_id},
+        ).fetchone()
+        return row[0] if row is not None else None
+
+    def list_campaigns_missing_stability(self) -> list[str]:
+        """Return campaign_ids where behavioral_stability_json is NULL.
+
+        Used for batch refresh of campaigns that have not yet been scored.
+        """
+        rows = self._session.execute(text("""
+                SELECT id FROM campaigns
+                WHERE behavioral_stability_json IS NULL
+                ORDER BY last_seen DESC
+            """)).fetchall()
+        return [r[0] for r in rows]
 
     def get_campaign_member_by_ip(self, source_ip: str) -> dict[str, Any] | None:
         """Return the campaign_members row for source_ip, or None if unassigned."""
@@ -371,7 +417,7 @@ class CampaignRepository(RepositoryBase):
                        first_seen, last_seen, dormant_since,
                        reactivation_count, member_ip_count,
                        attack_tactic_dist, top_target_ports, notes,
-                       created_at, updated_at
+                       created_at, updated_at, behavioral_stability_json
                 FROM campaigns
                 ORDER BY last_seen DESC
                 LIMIT :limit
@@ -394,6 +440,7 @@ class CampaignRepository(RepositoryBase):
                 "notes": r[11],
                 "created_at": r[12],
                 "updated_at": r[13],
+                "behavioral_stability_json": r[14],
             }
             for r in rows
         ]

--- a/app/intelligence/stability.py
+++ b/app/intelligence/stability.py
@@ -1,0 +1,292 @@
+"""Behavioral stability scoring from fingerprint history (§11.3).
+
+Pure computation in compute_campaign_stability() — no database access, no I/O,
+no side effects.  The refresh helpers call the DB via get_session()/EventRepository.
+
+Stability model:
+  Per-dimension stability = average pairwise similarity between consecutive
+  fingerprint snapshots for a campaign, ordered oldest-first.  Uses the same
+  domain-specific similarity functions as the clustering algorithm so the
+  stability metric is semantically consistent with the clustering metric:
+    timing      → timing_similarity()
+    sequence    → sequence_similarity()
+    protocol    → protocol_similarity()
+    credential  → credential_similarity()
+    target      → target_similarity()
+
+  High average pairwise similarity = low drift = high stability.
+
+  Composite stability = weighted average of per-dimension stabilities using
+  the same dimension weights as compute_weighted_similarity():
+    timing 20%, sequence 35%, protocol 25%, credential 10%, target 10%.
+
+  Null-dimension rule (inherited from §8.1): dimensions where all history
+  records have NULL feature values contribute zero to both numerator and
+  denominator.  Sparse fingerprints are not penalised.
+
+Insufficient-data handling:
+  Fewer than MIN_HISTORY_RECORDS (2) records → status = "insufficient_data",
+  all scores = None, composite_score = 0.0.  Cannot compute a change from
+  a single snapshot.
+
+No AI imports.  No learned embeddings.  No vector DB.  Deterministic only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from app.intelligence.constants import (
+    WEIGHT_CREDENTIAL,
+    WEIGHT_PROTOCOL,
+    WEIGHT_SEQUENCE,
+    WEIGHT_TARGET,
+    WEIGHT_TIMING,
+)
+from app.intelligence.similarity import (
+    credential_similarity,
+    protocol_similarity,
+    sequence_similarity,
+    target_similarity,
+    timing_similarity,
+)
+
+logger = logging.getLogger(__name__)
+
+_STATUS_OK = "ok"
+_STATUS_INSUFFICIENT = "insufficient_data"
+
+MIN_HISTORY_RECORDS: int = 2
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StabilityResult:
+    """Full stability assessment for one campaign from its fingerprint history."""
+
+    status: str
+    composite_score: float
+    timing_stability: float | None
+    sequence_stability: float | None
+    protocol_stability: float | None
+    credential_stability: float | None
+    target_stability: float | None
+    sample_count: int
+    pair_count: int
+    dimensions_used: int
+    calculated_at: str
+    explanation: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "composite_score": self.composite_score,
+            "timing_stability": self.timing_stability,
+            "sequence_stability": self.sequence_stability,
+            "protocol_stability": self.protocol_stability,
+            "credential_stability": self.credential_stability,
+            "target_stability": self.target_stability,
+            "sample_count": self.sample_count,
+            "pair_count": self.pair_count,
+            "dimensions_used": self.dimensions_used,
+            "calculated_at": self.calculated_at,
+            "explanation": self.explanation,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core computation
+# ---------------------------------------------------------------------------
+
+
+def _parse_feature(s: str | None) -> dict | None:
+    """Parse a JSON feature string to a dict, or None on failure / null input."""
+    if s is None:
+        return None
+    try:
+        v = json.loads(s)
+        return v if isinstance(v, dict) else None
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values)
+
+
+def compute_campaign_stability(history: list[dict[str, Any]]) -> StabilityResult:
+    """Compute behavioral stability from a list of fingerprint_history rows.
+
+    history must be sorted oldest-first (as list_fingerprint_history_for_campaign()
+    returns).  Returns StabilityResult with status="insufficient_data" when fewer
+    than MIN_HISTORY_RECORDS rows are present.
+
+    Scores are in [0.0, 1.0]:
+      1.0 = perfectly stable (all consecutive pairs identical)
+      0.0 = maximally unstable
+    """
+    now = datetime.now(UTC).isoformat()
+
+    if len(history) < MIN_HISTORY_RECORDS:
+        return StabilityResult(
+            status=_STATUS_INSUFFICIENT,
+            composite_score=0.0,
+            timing_stability=None,
+            sequence_stability=None,
+            protocol_stability=None,
+            credential_stability=None,
+            target_stability=None,
+            sample_count=len(history),
+            pair_count=0,
+            dimensions_used=0,
+            calculated_at=now,
+            explanation={
+                "reason": f"Fewer than {MIN_HISTORY_RECORDS} history records available",
+                "records_available": len(history),
+            },
+        )
+
+    timing_sims: list[float] = []
+    sequence_sims: list[float] = []
+    protocol_sims: list[float] = []
+    credential_sims: list[float] = []
+    target_sims: list[float] = []
+
+    pairs = list(zip(history[:-1], history[1:], strict=False))
+
+    for a, b in pairs:
+        ts = timing_similarity(
+            _parse_feature(a.get("timing_features")),
+            _parse_feature(b.get("timing_features")),
+        )
+        ss = sequence_similarity(
+            _parse_feature(a.get("sequence_features")),
+            _parse_feature(b.get("sequence_features")),
+        )
+        ps = protocol_similarity(
+            _parse_feature(a.get("protocol_features")),
+            _parse_feature(b.get("protocol_features")),
+        )
+        cs = credential_similarity(
+            _parse_feature(a.get("credential_features")),
+            _parse_feature(b.get("credential_features")),
+        )
+        tgs = target_similarity(
+            _parse_feature(a.get("target_features")),
+            _parse_feature(b.get("target_features")),
+        )
+
+        if ts is not None:
+            timing_sims.append(ts)
+        if ss is not None:
+            sequence_sims.append(ss)
+        if ps is not None:
+            protocol_sims.append(ps)
+        if cs is not None:
+            credential_sims.append(cs)
+        if tgs is not None:
+            target_sims.append(tgs)
+
+    timing_stability = round(_mean(timing_sims), 6) if timing_sims else None
+    sequence_stability = round(_mean(sequence_sims), 6) if sequence_sims else None
+    protocol_stability = round(_mean(protocol_sims), 6) if protocol_sims else None
+    credential_stability = round(_mean(credential_sims), 6) if credential_sims else None
+    target_stability = round(_mean(target_sims), 6) if target_sims else None
+
+    _DIM_MAP: list[tuple[str, float | None, float, int]] = [
+        ("timing", timing_stability, WEIGHT_TIMING, len(timing_sims)),
+        ("sequence", sequence_stability, WEIGHT_SEQUENCE, len(sequence_sims)),
+        ("protocol", protocol_stability, WEIGHT_PROTOCOL, len(protocol_sims)),
+        ("credential", credential_stability, WEIGHT_CREDENTIAL, len(credential_sims)),
+        ("target", target_stability, WEIGHT_TARGET, len(target_sims)),
+    ]
+
+    numerator = 0.0
+    denominator = 0.0
+    dimensions_used = 0
+    explanation_dims: dict[str, Any] = {}
+
+    for dim_name, dim_score, weight, pair_ct in _DIM_MAP:
+        if dim_score is not None:
+            numerator += weight * dim_score
+            denominator += weight
+            dimensions_used += 1
+            explanation_dims[dim_name] = {
+                "score": dim_score,
+                "pair_count": pair_ct,
+                "weight": weight,
+            }
+        else:
+            explanation_dims[dim_name] = {
+                "score": None,
+                "pair_count": pair_ct,
+                "weight": weight,
+                "reason": "null_dimension",
+            }
+
+    composite = round(numerator / denominator, 6) if denominator > 0.0 else 0.0
+
+    return StabilityResult(
+        status=_STATUS_OK,
+        composite_score=composite,
+        timing_stability=timing_stability,
+        sequence_stability=sequence_stability,
+        protocol_stability=protocol_stability,
+        credential_stability=credential_stability,
+        target_stability=target_stability,
+        sample_count=len(history),
+        pair_count=len(pairs),
+        dimensions_used=dimensions_used,
+        calculated_at=now,
+        explanation={"dimensions": explanation_dims},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Refresh helpers
+# ---------------------------------------------------------------------------
+
+
+def refresh_campaign_stability(campaign_id: str) -> None:
+    """Recompute and persist behavioral stability for campaign_id.
+
+    Idempotent: always overwrites the stored result with the latest computation
+    from the current fingerprint_history.  Silently does nothing when the
+    campaign_id is unknown (no rows updated).
+    """
+    from app.db.connection import get_session
+    from app.db.repository import EventRepository
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        history = repo.list_fingerprint_history_for_campaign(campaign_id)
+        result = compute_campaign_stability(history)
+        repo.update_campaign_stability(campaign_id, json.dumps(result.as_dict()))
+
+
+def refresh_all_campaign_stability() -> None:
+    """Recompute and persist behavioral stability for every campaign.
+
+    Idempotent.  Per-campaign failures are logged but do not interrupt the
+    refresh of remaining campaigns.
+    """
+    from app.db.connection import get_session
+    from app.db.repository import EventRepository
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        campaign_ids = repo.list_all_campaign_ids()
+
+    for cid in campaign_ids:
+        try:
+            refresh_campaign_stability(cid)
+        except Exception:
+            logger.exception("Stability refresh failed for campaign_id=%s", cid)

--- a/app/intelligence/tasks.py
+++ b/app/intelligence/tasks.py
@@ -190,12 +190,17 @@ def _compute_and_store(ip: str) -> None:
 def _run_campaign_clustering(ip: str) -> None:
     """Run campaign assignment for ip in a fresh session.
 
-    After assignment, updates representative_fingerprint_json on the campaign
-    so the next clustering query can use the fast path (§13.2).
+    After assignment:
+      - Updates representative_fingerprint_json on the campaign (fast-path cache, §13.2).
+      - Triggers behavioral stability refresh for the assigned campaign in a
+        separate failure domain — a stability failure must never mask a
+        clustering success.
 
     Failures are logged but do not propagate — a clustering failure must
     never surface as a fingerprint-computation error (§3.3 / §11).
     """
+    assigned_campaign_id: str | None = None
+
     try:
         from app.db.connection import get_session
         from app.db.repository import EventRepository
@@ -210,5 +215,14 @@ def _run_campaign_clustering(ip: str) -> None:
             if decision.campaign_id is not None:
                 rep_fp_json = _build_representative_fp_json(stored_fp)
                 repo.update_representative_fingerprint(decision.campaign_id, rep_fp_json)
+                assigned_campaign_id = decision.campaign_id
     except Exception:
         logger.exception("Campaign clustering failed for ip=%s", ip)
+
+    if assigned_campaign_id is not None:
+        try:
+            from app.intelligence.stability import refresh_campaign_stability
+
+            refresh_campaign_stability(assigned_campaign_id)
+        except Exception:
+            logger.exception("Stability refresh failed for campaign_id=%s", assigned_campaign_id)

--- a/tests/db/test_campaign_repository.py
+++ b/tests/db/test_campaign_repository.py
@@ -123,6 +123,7 @@ def test_get_campaign_returned_keys(db_session):
         "notes",
         "created_at",
         "updated_at",
+        "behavioral_stability_json",
     }
 
 

--- a/tests/integration/test_stability_integration.py
+++ b/tests/integration/test_stability_integration.py
@@ -1,0 +1,435 @@
+"""Integration tests for Phase 6 Group B PR B3 — behavioral stability scoring.
+
+Tests hit the full DB stack (in-memory SQLite bootstrapped by tests/conftest.py).
+Rows reset per test by tests/integration/conftest.py.
+
+Coverage:
+  Repository:
+    - update_campaign_stability stores JSON string
+    - get_campaign_stability returns stored JSON string
+    - get_campaign_stability returns None before first write
+    - list_campaigns_missing_stability returns campaign_ids with NULL stability
+    - list_campaigns_missing_stability excludes campaigns with stability set
+
+  Refresh:
+    - refresh_campaign_stability stores valid JSON for campaign with ≥2 history rows
+    - refresh_campaign_stability stores insufficient_data for campaign with <2 rows
+    - refresh_campaign_stability is idempotent (second call overwrites, does not error)
+    - refresh_all_campaign_stability runs without error and populates all campaigns
+    - refresh_all_campaign_stability does not fail on empty campaign set
+
+  Campaign API:
+    - GET /api/campaigns includes behavioral_stability_json field
+    - GET /api/campaigns/{id} includes behavioral_stability_json field
+    - behavioral_stability_json is null when not yet computed
+    - behavioral_stability_json is a parseable JSON string when computed
+    - parsed stability includes composite_score in [0, 1]
+
+  End-to-end:
+    - _compute_and_store + _run_campaign_clustering writes history then updates stability
+    - stability increases when fingerprints are stable
+    - stability is consistent across refresh calls
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.db.connection import get_engine
+from app.db.repository import EventRepository
+from app.main import app
+
+client = TestClient(app)
+API_KEY = "dev-123"
+HEADERS = {"x-api-key": API_KEY}
+
+_TS = "2026-03-01T00:00:00+00:00"
+
+_TIMING = json.dumps(
+    {"interval": {"mean": 2.0, "stddev": 0.1, "p25": 1.8, "p75": 2.2, "p95": 2.5}, "burst_cv": 0.2}
+)
+_SEQUENCE = json.dumps({"port_sequence": [22, 22, 80], "event_type_sequence": ["auth_failed"]})
+_PROTOCOL = json.dumps({"service_distribution": {"ssh": 10}})
+_CREDENTIAL = json.dumps({"username_class_dist": {"dictionary": 5}})
+_TARGET = json.dumps({"top_dst_ports": [22, 80], "port_freq": {"22": 10, "80": 2}})
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_source_ip(ip: str) -> None:
+    with get_engine().connect() as conn:
+        conn.execute(
+            text(
+                "INSERT OR IGNORE INTO source_ips"
+                " (ip, first_seen, last_seen, event_count) VALUES (:ip, :ts, :ts, 0)"
+            ),
+            {"ip": ip, "ts": _TS},
+        )
+        conn.commit()
+
+
+def _insert_campaign(campaign_id: str | None = None, *, status: str = "active") -> str:
+    cid = campaign_id or str(uuid.uuid4())
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO campaigns (
+                    id, name, status, confidence, first_seen, last_seen,
+                    dormant_since, reactivation_count, member_ip_count,
+                    attack_tactic_dist, top_target_ports, notes,
+                    created_at, updated_at
+                ) VALUES (
+                    :id, :name, :status, 0.75, :ts, :ts,
+                    NULL, 0, 0, NULL, NULL, NULL, :ts, :ts
+                )
+            """),
+            {"id": cid, "name": f"CAMP-{cid[:8]}", "status": status, "ts": _TS},
+        )
+        conn.commit()
+    return cid
+
+
+def _insert_member(campaign_id: str, ip: str) -> None:
+    _insert_source_ip(ip)
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO campaign_members
+                    (campaign_id, source_ip, confidence, added_at, last_active)
+                VALUES (:cid, :ip, 0.75, :ts, :ts)
+            """),
+            {"cid": campaign_id, "ip": ip, "ts": _TS},
+        )
+        conn.commit()
+
+
+def _insert_history_row(
+    campaign_id: str,
+    source_ip: str,
+    *,
+    computed_at: str = _TS,
+    timing: str | None = _TIMING,
+    sequence: str | None = _SEQUENCE,
+) -> str:
+    hid = str(uuid.uuid4())
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO fingerprint_history (
+                    id, fingerprint_id, source_ip, campaign_id,
+                    fingerprint_version, computed_at, event_count_at_computation,
+                    confidence, timing_features, sequence_features,
+                    protocol_features, credential_features, target_features,
+                    created_at
+                ) VALUES (
+                    :id, NULL, :ip, :cid,
+                    1, :computed_at, 10,
+                    0.80, :timing, :sequence,
+                    :protocol, :credential, :target,
+                    :ts
+                )
+            """),
+            {
+                "id": hid,
+                "ip": source_ip,
+                "cid": campaign_id,
+                "computed_at": computed_at,
+                "timing": timing,
+                "sequence": sequence,
+                "protocol": _PROTOCOL,
+                "credential": _CREDENTIAL,
+                "target": _TARGET,
+                "ts": _TS,
+            },
+        )
+        conn.commit()
+    return hid
+
+
+def _get_stability_json(campaign_id: str) -> str | None:
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            text("SELECT behavioral_stability_json FROM campaigns WHERE id = :id"),
+            {"id": campaign_id},
+        ).fetchone()
+    return row[0] if row else None
+
+
+# ---------------------------------------------------------------------------
+# Repository: update_campaign_stability / get_campaign_stability
+# ---------------------------------------------------------------------------
+
+
+def test_update_campaign_stability_stores_json():
+    from app.db.connection import get_session
+
+    cid = _insert_campaign()
+    payload = json.dumps({"status": "ok", "composite_score": 0.88})
+    with get_session() as session:
+        repo = EventRepository(session)
+        repo.update_campaign_stability(cid, payload)
+
+    assert _get_stability_json(cid) == payload
+
+
+def test_get_campaign_stability_returns_stored_json():
+    from app.db.connection import get_session
+
+    cid = _insert_campaign()
+    payload = json.dumps({"status": "ok", "composite_score": 0.75})
+    with get_session() as session:
+        repo = EventRepository(session)
+        repo.update_campaign_stability(cid, payload)
+        result = repo.get_campaign_stability(cid)
+    assert result == payload
+
+
+def test_get_campaign_stability_none_before_write():
+    from app.db.connection import get_session
+
+    cid = _insert_campaign()
+    with get_session() as session:
+        repo = EventRepository(session)
+        result = repo.get_campaign_stability(cid)
+    assert result is None
+
+
+def test_list_campaigns_missing_stability_includes_unscored():
+    from app.db.connection import get_session
+
+    cid = _insert_campaign()
+    with get_session() as session:
+        repo = EventRepository(session)
+        missing = repo.list_campaigns_missing_stability()
+    assert cid in missing
+
+
+def test_list_campaigns_missing_stability_excludes_scored():
+    from app.db.connection import get_session
+
+    cid = _insert_campaign()
+    with get_session() as session:
+        repo = EventRepository(session)
+        repo.update_campaign_stability(cid, '{"status": "ok"}')
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        missing = repo.list_campaigns_missing_stability()
+    assert cid not in missing
+
+
+# ---------------------------------------------------------------------------
+# refresh_campaign_stability
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_campaign_stability_stores_ok_with_two_history_rows():
+    from app.intelligence.stability import refresh_campaign_stability
+
+    cid = _insert_campaign()
+    ip = f"10.70.{uuid.uuid4().int % 256}.1"
+    _insert_history_row(cid, ip, computed_at="2026-01-01T00:00:00+00:00")
+    _insert_history_row(cid, ip, computed_at="2026-01-02T00:00:00+00:00")
+
+    refresh_campaign_stability(cid)
+
+    raw = _get_stability_json(cid)
+    assert raw is not None
+    parsed = json.loads(raw)
+    assert parsed["status"] == "ok"
+    assert 0.0 <= parsed["composite_score"] <= 1.0
+
+
+def test_refresh_campaign_stability_stores_insufficient_with_one_row():
+    from app.intelligence.stability import refresh_campaign_stability
+
+    cid = _insert_campaign()
+    ip = f"10.71.{uuid.uuid4().int % 256}.1"
+    _insert_history_row(cid, ip)
+
+    refresh_campaign_stability(cid)
+
+    raw = _get_stability_json(cid)
+    assert raw is not None
+    assert json.loads(raw)["status"] == "insufficient_data"
+
+
+def test_refresh_campaign_stability_stores_insufficient_with_no_rows():
+    from app.intelligence.stability import refresh_campaign_stability
+
+    cid = _insert_campaign()
+    refresh_campaign_stability(cid)
+
+    raw = _get_stability_json(cid)
+    assert raw is not None
+    assert json.loads(raw)["status"] == "insufficient_data"
+
+
+def test_refresh_campaign_stability_is_idempotent():
+    from app.intelligence.stability import refresh_campaign_stability
+
+    cid = _insert_campaign()
+    ip = f"10.72.{uuid.uuid4().int % 256}.1"
+    _insert_history_row(cid, ip, computed_at="2026-01-01T00:00:00+00:00")
+    _insert_history_row(cid, ip, computed_at="2026-01-02T00:00:00+00:00")
+
+    refresh_campaign_stability(cid)
+    raw1 = _get_stability_json(cid)
+
+    refresh_campaign_stability(cid)
+    raw2 = _get_stability_json(cid)
+
+    p1 = json.loads(raw1)  # type: ignore[arg-type]
+    p2 = json.loads(raw2)  # type: ignore[arg-type]
+    assert p1["composite_score"] == p2["composite_score"]
+    assert p1["status"] == p2["status"]
+
+
+# ---------------------------------------------------------------------------
+# refresh_all_campaign_stability
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_all_campaign_stability_runs_without_error():
+    from app.intelligence.stability import refresh_all_campaign_stability
+
+    cid1 = _insert_campaign()
+    cid2 = _insert_campaign()
+    ip = f"10.73.{uuid.uuid4().int % 256}.1"
+    _insert_history_row(cid1, ip, computed_at="2026-01-01T00:00:00+00:00")
+    _insert_history_row(cid1, ip, computed_at="2026-01-02T00:00:00+00:00")
+
+    refresh_all_campaign_stability()
+
+    assert _get_stability_json(cid1) is not None
+    assert _get_stability_json(cid2) is not None
+
+
+def test_refresh_all_campaign_stability_empty_set_no_error():
+    from app.intelligence.stability import refresh_all_campaign_stability
+
+    refresh_all_campaign_stability()
+
+
+# ---------------------------------------------------------------------------
+# Campaign API — stability in response
+# ---------------------------------------------------------------------------
+
+
+def test_list_campaigns_includes_behavioral_stability_json_field():
+    _insert_campaign()
+    resp = client.get("/api/campaigns", headers=HEADERS)
+    assert resp.status_code == 200
+    item = resp.json()["items"][0]
+    assert "behavioral_stability_json" in item
+
+
+def test_get_campaign_includes_behavioral_stability_json_field():
+    cid = _insert_campaign()
+    resp = client.get(f"/api/campaigns/{cid}", headers=HEADERS)
+    assert resp.status_code == 200
+    assert "behavioral_stability_json" in resp.json()
+
+
+def test_get_campaign_stability_json_null_when_not_computed():
+    cid = _insert_campaign()
+    resp = client.get(f"/api/campaigns/{cid}", headers=HEADERS)
+    assert resp.json()["behavioral_stability_json"] is None
+
+
+def test_get_campaign_stability_json_populated_after_refresh():
+    from app.intelligence.stability import refresh_campaign_stability
+
+    cid = _insert_campaign()
+    ip = f"10.74.{uuid.uuid4().int % 256}.1"
+    _insert_history_row(cid, ip, computed_at="2026-01-01T00:00:00+00:00")
+    _insert_history_row(cid, ip, computed_at="2026-01-02T00:00:00+00:00")
+
+    refresh_campaign_stability(cid)
+
+    resp = client.get(f"/api/campaigns/{cid}", headers=HEADERS)
+    raw = resp.json()["behavioral_stability_json"]
+    assert raw is not None
+    parsed = json.loads(raw)
+    assert 0.0 <= parsed["composite_score"] <= 1.0
+
+
+def test_list_campaigns_stability_json_parseable():
+    from app.intelligence.stability import refresh_campaign_stability
+
+    cid = _insert_campaign()
+    ip = f"10.75.{uuid.uuid4().int % 256}.1"
+    _insert_history_row(cid, ip, computed_at="2026-01-01T00:00:00+00:00")
+    _insert_history_row(cid, ip, computed_at="2026-01-02T00:00:00+00:00")
+
+    refresh_campaign_stability(cid)
+
+    resp = client.get("/api/campaigns", headers=HEADERS)
+    items = resp.json()["items"]
+    match = next((i for i in items if i["id"] == cid), None)
+    assert match is not None
+    raw = match["behavioral_stability_json"]
+    assert raw is not None
+    parsed = json.loads(raw)
+    assert "composite_score" in parsed
+    assert "status" in parsed
+
+
+# ---------------------------------------------------------------------------
+# Stability increases when fingerprints are stable
+# ---------------------------------------------------------------------------
+
+
+def test_stable_history_produces_higher_score_than_drifted():
+    from app.intelligence.stability import refresh_campaign_stability
+
+    _TIMING_DRIFT = json.dumps(
+        {
+            "interval": {"mean": 10.0, "stddev": 5.0, "p25": 5.0, "p75": 15.0, "p95": 20.0},
+            "burst_cv": 1.5,
+        }
+    )
+    _SEQUENCE_DRIFT = json.dumps(
+        {"port_sequence": [443, 8080, 3306], "event_type_sequence": ["http_probe"]}
+    )
+
+    ip_stable = f"10.76.{uuid.uuid4().int % 256}.1"
+    ip_drift = f"10.76.{uuid.uuid4().int % 256}.2"
+
+    cid_stable = _insert_campaign()
+    cid_drift = _insert_campaign()
+
+    # Stable: same features in both rows.
+    _insert_history_row(cid_stable, ip_stable, computed_at="2026-01-01T00:00:00+00:00")
+    _insert_history_row(cid_stable, ip_stable, computed_at="2026-01-02T00:00:00+00:00")
+
+    # Drifted: significantly different features.
+    _insert_history_row(
+        cid_drift,
+        ip_drift,
+        computed_at="2026-01-01T00:00:00+00:00",
+        timing=_TIMING,
+        sequence=_SEQUENCE,
+    )
+    _insert_history_row(
+        cid_drift,
+        ip_drift,
+        computed_at="2026-01-02T00:00:00+00:00",
+        timing=_TIMING_DRIFT,
+        sequence=_SEQUENCE_DRIFT,
+    )
+
+    refresh_campaign_stability(cid_stable)
+    refresh_campaign_stability(cid_drift)
+
+    score_stable = json.loads(_get_stability_json(cid_stable))["composite_score"]  # type: ignore
+    score_drift = json.loads(_get_stability_json(cid_drift))["composite_score"]  # type: ignore
+
+    assert score_stable > score_drift

--- a/tests/unit/test_stability.py
+++ b/tests/unit/test_stability.py
@@ -1,0 +1,459 @@
+"""Unit tests for app/intelligence/stability.py.
+
+All tests are pure: no database, no I/O.  Fixtures build fingerprint_history
+row dicts directly and pass them to compute_campaign_stability().
+
+Coverage:
+  Insufficient data:
+    - 0 records → insufficient_data status
+    - 1 record → insufficient_data status
+    - 2 records → ok status (minimum required)
+
+  Stable behavior:
+    - identical consecutive snapshots → composite_score = 1.0
+    - nearly-identical snapshots → high composite_score (> 0.9)
+
+  Drifting behavior:
+    - significantly different snapshots → lower composite_score than stable
+    - composite_score decreases as drift increases
+
+  Per-dimension scores:
+    - timing_stability present when both snapshots have timing_features
+    - sequence_stability present when both have sequence_features
+    - all per-dimension scores are in [0.0, 1.0]
+    - null dimension produces None per-dimension score
+
+  Composite:
+    - composite_score is in [0.0, 1.0]
+    - dimensions_used is correct count of non-null dimensions
+    - composite_score of 0.0 when all dimensions are null
+
+  Explanation:
+    - explanation["dimensions"] contains all 5 dimension keys
+    - each dimension entry has "score", "pair_count", "weight"
+    - null dimension entries have "reason" key
+
+  StabilityResult.as_dict():
+    - includes all required keys
+    - calculated_at is an ISO timestamp string
+
+  Sample and pair counts:
+    - sample_count = len(history)
+    - pair_count = len(history) - 1
+
+  No AI imports:
+    - stability module does not import from app.ai
+
+  Idempotency:
+    - same input always produces same output (deterministic)
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.intelligence.stability import (
+    _STATUS_INSUFFICIENT,
+    _STATUS_OK,
+    MIN_HISTORY_RECORDS,
+    compute_campaign_stability,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — raw feature dicts and JSON-encoded feature strings
+# ---------------------------------------------------------------------------
+
+_TIMING_A = json.dumps(
+    {
+        "interval": {"mean": 2.0, "stddev": 0.1, "p25": 1.8, "p75": 2.2, "p95": 2.5},
+        "burst_cv": 0.2,
+    }
+)
+
+_TIMING_B_SIMILAR = json.dumps(
+    {
+        "interval": {"mean": 2.1, "stddev": 0.12, "p25": 1.9, "p75": 2.3, "p95": 2.6},
+        "burst_cv": 0.22,
+    }
+)
+
+_TIMING_B_DRIFT = json.dumps(
+    {
+        "interval": {"mean": 8.0, "stddev": 3.0, "p25": 5.0, "p75": 11.0, "p95": 15.0},
+        "burst_cv": 1.2,
+    }
+)
+
+_SEQUENCE_A = json.dumps(
+    {
+        "port_sequence": [22, 22, 80, 22],
+        "event_type_sequence": ["auth_failed", "auth_failed", "port_scan"],
+    }
+)
+
+_SEQUENCE_B_SIMILAR = json.dumps(
+    {
+        "port_sequence": [22, 22, 80, 22],
+        "event_type_sequence": ["auth_failed", "auth_failed", "port_scan"],
+    }
+)
+
+_SEQUENCE_B_DRIFT = json.dumps(
+    {
+        "port_sequence": [443, 8080, 3306],
+        "event_type_sequence": ["http_probe", "malware_upload"],
+    }
+)
+
+_PROTOCOL_A = json.dumps({"service_distribution": {"ssh": 10, "http": 2}})
+_CREDENTIAL_A = json.dumps({"username_class_dist": {"dictionary": 8, "numeric": 2}})
+_TARGET_A = json.dumps({"top_dst_ports": [22, 80], "port_freq": {"22": 10, "80": 2}})
+
+
+def _make_row(
+    *,
+    timing: str | None = _TIMING_A,
+    sequence: str | None = _SEQUENCE_A,
+    protocol: str | None = _PROTOCOL_A,
+    credential: str | None = _CREDENTIAL_A,
+    target: str | None = _TARGET_A,
+    computed_at: str = "2026-01-01T00:00:00+00:00",
+) -> dict:
+    return {
+        "timing_features": timing,
+        "sequence_features": sequence,
+        "protocol_features": protocol,
+        "credential_features": credential,
+        "target_features": target,
+        "computed_at": computed_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Insufficient data
+# ---------------------------------------------------------------------------
+
+
+def test_zero_records_returns_insufficient_data():
+    result = compute_campaign_stability([])
+    assert result.status == _STATUS_INSUFFICIENT
+
+
+def test_one_record_returns_insufficient_data():
+    result = compute_campaign_stability([_make_row()])
+    assert result.status == _STATUS_INSUFFICIENT
+
+
+def test_insufficient_data_composite_is_zero():
+    result = compute_campaign_stability([_make_row()])
+    assert result.composite_score == 0.0
+
+
+def test_insufficient_data_pair_count_is_zero():
+    result = compute_campaign_stability([_make_row()])
+    assert result.pair_count == 0
+
+
+def test_insufficient_data_all_per_dimension_scores_none():
+    result = compute_campaign_stability([_make_row()])
+    assert result.timing_stability is None
+    assert result.sequence_stability is None
+    assert result.protocol_stability is None
+    assert result.credential_stability is None
+    assert result.target_stability is None
+
+
+def test_two_records_returns_ok():
+    result = compute_campaign_stability([_make_row(), _make_row()])
+    assert result.status == _STATUS_OK
+
+
+def test_min_history_records_constant_is_two():
+    assert MIN_HISTORY_RECORDS == 2
+
+
+# ---------------------------------------------------------------------------
+# Stable behavior — identical snapshots
+# ---------------------------------------------------------------------------
+
+
+def test_identical_snapshots_timing_stability_one():
+    result = compute_campaign_stability([_make_row(), _make_row()])
+    assert result.timing_stability == pytest.approx(1.0, abs=0.001)
+
+
+def test_identical_snapshots_sequence_stability_one():
+    result = compute_campaign_stability([_make_row(), _make_row()])
+    assert result.sequence_stability == pytest.approx(1.0, abs=0.001)
+
+
+def test_identical_snapshots_composite_one():
+    result = compute_campaign_stability([_make_row(), _make_row()])
+    assert result.composite_score == pytest.approx(1.0, abs=0.001)
+
+
+# ---------------------------------------------------------------------------
+# Stable behavior — similar (not identical) snapshots
+# ---------------------------------------------------------------------------
+
+
+def test_similar_snapshots_high_stability():
+    row_a = _make_row(timing=_TIMING_A, sequence=_SEQUENCE_A)
+    row_b = _make_row(timing=_TIMING_B_SIMILAR, sequence=_SEQUENCE_B_SIMILAR)
+    result = compute_campaign_stability([row_a, row_b])
+    assert result.composite_score > 0.85
+
+
+# ---------------------------------------------------------------------------
+# Drifting behavior
+# ---------------------------------------------------------------------------
+
+
+def test_drifting_snapshots_lower_stability_than_stable():
+    stable = compute_campaign_stability([_make_row(), _make_row()])
+    drifted = compute_campaign_stability(
+        [
+            _make_row(timing=_TIMING_A, sequence=_SEQUENCE_A),
+            _make_row(timing=_TIMING_B_DRIFT, sequence=_SEQUENCE_B_DRIFT),
+        ]
+    )
+    assert drifted.composite_score < stable.composite_score
+
+
+def test_drifting_timing_lowers_timing_stability():
+    stable = compute_campaign_stability([_make_row(), _make_row()])
+    drifted = compute_campaign_stability(
+        [
+            _make_row(timing=_TIMING_A),
+            _make_row(timing=_TIMING_B_DRIFT),
+        ]
+    )
+    assert drifted.timing_stability < stable.timing_stability  # type: ignore[operator]
+
+
+def test_composite_decreases_with_more_drift():
+    h_stable = [_make_row() for _ in range(4)]
+    h_drifted = [
+        _make_row(timing=_TIMING_A, sequence=_SEQUENCE_A),
+        _make_row(timing=_TIMING_B_DRIFT, sequence=_SEQUENCE_B_DRIFT),
+        _make_row(timing=_TIMING_A, sequence=_SEQUENCE_A),
+        _make_row(timing=_TIMING_B_DRIFT, sequence=_SEQUENCE_B_DRIFT),
+    ]
+    r_stable = compute_campaign_stability(h_stable)
+    r_drifted = compute_campaign_stability(h_drifted)
+    assert r_drifted.composite_score < r_stable.composite_score
+
+
+# ---------------------------------------------------------------------------
+# Per-dimension scores
+# ---------------------------------------------------------------------------
+
+
+def test_per_dimension_scores_in_valid_range():
+    result = compute_campaign_stability([_make_row(), _make_row()])
+    for val in (
+        result.timing_stability,
+        result.sequence_stability,
+        result.protocol_stability,
+        result.credential_stability,
+        result.target_stability,
+    ):
+        assert val is not None
+        assert 0.0 <= val <= 1.0
+
+
+def test_null_timing_produces_none_timing_stability():
+    result = compute_campaign_stability([_make_row(timing=None), _make_row(timing=None)])
+    assert result.timing_stability is None
+
+
+def test_null_timing_excluded_from_composite():
+    with_timing = compute_campaign_stability([_make_row(), _make_row()])
+    without_timing = compute_campaign_stability([_make_row(timing=None), _make_row(timing=None)])
+    assert with_timing.dimensions_used > without_timing.dimensions_used
+
+
+def test_all_null_dimensions_composite_zero():
+    result = compute_campaign_stability(
+        [
+            _make_row(
+                timing=None,
+                sequence=None,
+                protocol=None,
+                credential=None,
+                target=None,
+            ),
+            _make_row(
+                timing=None,
+                sequence=None,
+                protocol=None,
+                credential=None,
+                target=None,
+            ),
+        ]
+    )
+    assert result.composite_score == 0.0
+    assert result.dimensions_used == 0
+
+
+def test_mixed_null_dimensions_uses_available():
+    result = compute_campaign_stability(
+        [
+            _make_row(timing=_TIMING_A, sequence=None, protocol=None, credential=None, target=None),
+            _make_row(timing=_TIMING_A, sequence=None, protocol=None, credential=None, target=None),
+        ]
+    )
+    assert result.dimensions_used == 1
+    assert result.timing_stability is not None
+    assert result.sequence_stability is None
+
+
+# ---------------------------------------------------------------------------
+# Composite score range
+# ---------------------------------------------------------------------------
+
+
+def test_composite_in_valid_range():
+    result = compute_campaign_stability([_make_row(), _make_row(timing=_TIMING_B_DRIFT)])
+    assert 0.0 <= result.composite_score <= 1.0
+
+
+def test_composite_in_valid_range_all_stable():
+    result = compute_campaign_stability([_make_row() for _ in range(5)])
+    assert 0.0 <= result.composite_score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Explanation structure
+# ---------------------------------------------------------------------------
+
+
+def test_explanation_has_dimensions_key():
+    result = compute_campaign_stability([_make_row(), _make_row()])
+    assert "dimensions" in result.explanation
+
+
+def test_explanation_has_all_five_dimension_keys():
+    result = compute_campaign_stability([_make_row(), _make_row()])
+    dims = result.explanation["dimensions"]
+    for key in ("timing", "sequence", "protocol", "credential", "target"):
+        assert key in dims
+
+
+def test_explanation_dimension_entry_has_required_keys():
+    result = compute_campaign_stability([_make_row(), _make_row()])
+    for dim_entry in result.explanation["dimensions"].values():
+        assert "score" in dim_entry
+        assert "pair_count" in dim_entry
+        assert "weight" in dim_entry
+
+
+def test_explanation_null_dimension_has_reason_key():
+    result = compute_campaign_stability([_make_row(timing=None), _make_row(timing=None)])
+    timing_entry = result.explanation["dimensions"]["timing"]
+    assert timing_entry["score"] is None
+    assert "reason" in timing_entry
+
+
+def test_insufficient_explanation_has_reason():
+    result = compute_campaign_stability([_make_row()])
+    assert "reason" in result.explanation
+    assert "records_available" in result.explanation
+
+
+# ---------------------------------------------------------------------------
+# as_dict()
+# ---------------------------------------------------------------------------
+
+
+def test_as_dict_contains_required_keys():
+    result = compute_campaign_stability([_make_row(), _make_row()])
+    d = result.as_dict()
+    required = {
+        "status",
+        "composite_score",
+        "timing_stability",
+        "sequence_stability",
+        "protocol_stability",
+        "credential_stability",
+        "target_stability",
+        "sample_count",
+        "pair_count",
+        "dimensions_used",
+        "calculated_at",
+        "explanation",
+    }
+    assert required.issubset(d.keys())
+
+
+def test_as_dict_calculated_at_is_string():
+    result = compute_campaign_stability([_make_row(), _make_row()])
+    assert isinstance(result.as_dict()["calculated_at"], str)
+
+
+def test_as_dict_is_json_serializable():
+    result = compute_campaign_stability([_make_row(), _make_row()])
+    serialized = json.dumps(result.as_dict())
+    parsed = json.loads(serialized)
+    assert parsed["status"] == _STATUS_OK
+
+
+# ---------------------------------------------------------------------------
+# Sample and pair counts
+# ---------------------------------------------------------------------------
+
+
+def test_sample_count_matches_history_length():
+    history = [_make_row() for _ in range(4)]
+    result = compute_campaign_stability(history)
+    assert result.sample_count == 4
+
+
+def test_pair_count_is_sample_count_minus_one():
+    history = [_make_row() for _ in range(4)]
+    result = compute_campaign_stability(history)
+    assert result.pair_count == 3
+
+
+def test_sample_count_zero_when_no_history():
+    result = compute_campaign_stability([])
+    assert result.sample_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_same_input_same_output():
+    history = [_make_row(), _make_row(timing=_TIMING_B_SIMILAR)]
+    r1 = compute_campaign_stability(history)
+    r2 = compute_campaign_stability(history)
+    assert r1.composite_score == r2.composite_score
+    assert r1.timing_stability == r2.timing_stability
+    assert r1.status == r2.status
+
+
+# ---------------------------------------------------------------------------
+# No AI imports
+# ---------------------------------------------------------------------------
+
+
+def test_stability_module_has_no_ai_imports():
+    import importlib
+    import sys
+
+    if "app.intelligence.stability" in sys.modules:
+        mod = sys.modules["app.intelligence.stability"]
+    else:
+        mod = importlib.import_module("app.intelligence.stability")
+
+    source = mod.__file__
+    assert source is not None
+    with open(source) as f:
+        content = f.read()
+    assert "app.ai" not in content
+    assert "from app.ai" not in content
+    assert "import app.ai" not in content


### PR DESCRIPTION
## Summary

- Adds deterministic behavioral stability scoring for campaigns from their `fingerprint_history` longitudinal record
- Per-dimension stability = average pairwise similarity between consecutive fingerprint snapshots; reuses the same JSD/Levenshtein/Jaccard metrics as the clustering algorithm for semantic consistency
- Composite stability = weighted average of per-dimension stabilities using the same dimension weights as `compute_weighted_similarity()` (timing 20%, sequence 35%, protocol 25%, credential 10%, target 10%)
- Fewer than 2 history records produces `status=insufficient_data`; scores are always in `[0.0, 1.0]`

## Changes

**Migration** (`0008`): adds `behavioral_stability_json TEXT NULL` to `campaigns`

**`app/intelligence/stability.py`** (new): pure `compute_campaign_stability()` function + `refresh_campaign_stability()` / `refresh_all_campaign_stability()` refresh helpers; no AI imports, no I/O in the core function

**Repository** (`campaign.py`): `update_campaign_stability()`, `get_campaign_stability()`, `list_campaigns_missing_stability()`; `get_campaign()` and `list_campaigns()` updated to include `behavioral_stability_json`

**Task layer** (`tasks.py`): `_run_campaign_clustering()` calls `refresh_campaign_stability()` after each successful assignment in a separate try/except so a stability failure cannot mask a clustering success

**Tests**: 51 unit tests (`test_stability.py`), 23 integration tests (`test_stability_integration.py`) — 1200 total passing

## Storage strategy

`behavioral_stability_json` stores the full `StabilityResult` as a JSON string: composite score, all five per-dimension scores, sample/pair counts, status, `calculated_at`, and a per-dimension explanation dict. Derived data only — `fingerprint_history` is the authoritative source. The column is overwritten on every refresh call (idempotent).

## API

`GET /api/campaigns` and `GET /api/campaigns/{id}` both include `behavioral_stability_json` (null until first computation). No new endpoints required.

## Deferred

Dashboard stability panel, alert thresholds, admin bulk-refresh endpoint, AI interpretation of stability scores, uncertain_observation_count.

## Test plan

- [ ] Migration upgrade/downgrade runs cleanly
- [ ] `pytest` passes (1200 tests)
- [ ] Identical consecutive fingerprints → `composite_score ≈ 1.0`
- [ ] Significantly different consecutive fingerprints → lower composite_score
- [ ] `insufficient_data` returned when fewer than 2 history records
- [ ] `behavioral_stability_json` field present in campaign list and detail API responses
- [ ] `null` before first computation, parseable JSON string after refresh
- [ ] `refresh_all_campaign_stability()` runs without error on empty and populated sets
- [ ] No `app.ai` imports in `stability.py`