### PR TITLE
feat(campaigns): add uncertain association review queue

### DIFF
--- a/app/db/connection.py
+++ b/app/db/connection.py
@@ -204,6 +204,7 @@ def create_all_tables(engine: Engine) -> None:
                 "is_reactivation INTEGER NOT NULL DEFAULT 0, "
                 "dormancy_gap_days REAL, "
                 "notes TEXT, "
+                "analyst_review_json TEXT, "
                 "FOREIGN KEY (campaign_id) REFERENCES campaigns(id))"
             )
         )

--- a/app/db/migrations/versions/0009_phase6b_observation_review.py
+++ b/app/db/migrations/versions/0009_phase6b_observation_review.py
@@ -1,0 +1,43 @@
+"""Phase 6 Group B — analyst review state for uncertain campaign observations
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-05-27
+
+Adds analyst_review_json to campaign_observations.
+
+analyst_review_json stores the analyst's interpretation of an uncertain
+association observation as a JSON object:
+  {
+    "decision": "analyst_confirmed" | "analyst_denied",
+    "notes": str | null,
+    "reviewed_at": str (ISO timestamp)
+  }
+
+This is analyst-supplied metadata, not a mutation of the original clustering
+decision.  The observation record and campaign membership are never modified
+by a review.  NULL until an analyst submits a review for the observation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009"
+down_revision: str | None = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "campaign_observations",
+        sa.Column("analyst_review_json", sa.Text, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("campaign_observations", "analyst_review_json")

--- a/app/db/repositories/campaign.py
+++ b/app/db/repositories/campaign.py
@@ -643,7 +643,7 @@ class CampaignRepository(RepositoryBase):
         rows = self._session.execute(
             text("""
                 SELECT id, campaign_id, source_ip, observed_at, event_count,
-                       is_reactivation, dormancy_gap_days, notes
+                       is_reactivation, dormancy_gap_days, notes, analyst_review_json
                 FROM campaign_observations
                 WHERE campaign_id = :campaign_id
                 ORDER BY observed_at ASC
@@ -660,6 +660,125 @@ class CampaignRepository(RepositoryBase):
                 "is_reactivation": bool(r[5]),
                 "dormancy_gap_days": r[6],
                 "notes": r[7],
+                "analyst_review_json": r[8],
             }
             for r in rows
         ]
+
+    def get_campaign_observation(self, observation_id: str) -> dict[str, Any] | None:
+        """Return a single campaign_observations row as dict, or None if not found."""
+        row = self._session.execute(
+            text("""
+                SELECT id, campaign_id, source_ip, observed_at, event_count,
+                       is_reactivation, dormancy_gap_days, notes, analyst_review_json
+                FROM campaign_observations
+                WHERE id = :id
+            """),
+            {"id": observation_id},
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row[0],
+            "campaign_id": row[1],
+            "source_ip": row[2],
+            "observed_at": row[3],
+            "event_count": row[4],
+            "is_reactivation": bool(row[5]),
+            "dormancy_gap_days": row[6],
+            "notes": row[7],
+            "analyst_review_json": row[8],
+        }
+
+    def list_uncertain_observations(
+        self,
+        *,
+        campaign_id: str | None = None,
+        include_reviewed: bool = False,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Return uncertain-association observations from campaign_observations.
+
+        Uncertain observations are those whose notes JSON contains
+        "decision":"uncertain_association".  SQL pre-filters with LIKE, then
+        Python-side parsing confirms (no json_extract per PostgreSQL compat rules).
+
+        When include_reviewed=False (default), only rows where
+        analyst_review_json IS NULL are returned.
+        """
+        params: dict[str, Any] = {"limit": limit}
+        cid_clause = ""
+        if campaign_id is not None:
+            params["campaign_id"] = campaign_id
+            cid_clause = "AND campaign_id = :campaign_id"
+
+        review_clause = "" if include_reviewed else "AND analyst_review_json IS NULL"
+
+        rows = self._session.execute(
+            text(f"""
+                SELECT id, campaign_id, source_ip, observed_at, event_count,
+                       is_reactivation, dormancy_gap_days, notes, analyst_review_json
+                FROM campaign_observations
+                WHERE notes LIKE '%"decision":"uncertain_association"%'
+                {cid_clause}
+                {review_clause}
+                ORDER BY observed_at ASC
+                LIMIT :limit
+            """),
+            params,
+        ).fetchall()
+
+        result = []
+        for r in rows:
+            try:
+                parsed = json.loads(r[7]) if r[7] else {}
+                if not isinstance(parsed, dict):
+                    continue
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if parsed.get("decision") != "uncertain_association":
+                continue
+            result.append(
+                {
+                    "id": r[0],
+                    "campaign_id": r[1],
+                    "source_ip": r[2],
+                    "observed_at": r[3],
+                    "event_count": r[4],
+                    "is_reactivation": bool(r[5]),
+                    "dormancy_gap_days": r[6],
+                    "notes": r[7],
+                    "analyst_review_json": r[8],
+                }
+            )
+        return result
+
+    def annotate_campaign_observation(
+        self,
+        observation_id: str,
+        analyst_decision: str,
+        analyst_notes: str | None,
+        reviewed_at: str,
+    ) -> None:
+        """Write analyst review metadata to a campaign_observations row.
+
+        Does not modify the original clustering decision, campaign membership,
+        or any other observation fields.  Idempotent: subsequent calls overwrite
+        the previous review.
+        """
+        review = {
+            "decision": analyst_decision,
+            "notes": analyst_notes,
+            "reviewed_at": reviewed_at,
+        }
+        self._session.execute(
+            text("""
+                UPDATE campaign_observations
+                SET analyst_review_json = :review_json
+                WHERE id = :observation_id
+            """),
+            {
+                "observation_id": observation_id,
+                "review_json": json.dumps(review),
+            },
+        )

--- a/app/routers/campaigns.py
+++ b/app/routers/campaigns.py
@@ -1,8 +1,10 @@
 """Campaign intelligence endpoints.
 
-GET /api/campaigns                          — paginated campaign list
-GET /api/campaigns/{campaign_id}            — detail: campaign + members + observations
-GET /api/campaigns/{campaign_id}/observations — observation list for one campaign
+GET  /api/campaigns                                           — paginated list
+GET  /api/campaigns/uncertain-associations                    — pending review queue
+POST /api/campaigns/uncertain-associations/{id}/review        — submit analyst review
+GET  /api/campaigns/{campaign_id}                             — campaign detail
+GET  /api/campaigns/{campaign_id}/observations                — observation list
 
 All endpoints require API key or JWT authentication via require_jwt_or_api_key.
 No SQL belongs here — all queries go through EventRepository.
@@ -10,13 +12,27 @@ No SQL belongs here — all queries go through EventRepository.
 
 from __future__ import annotations
 
+import json
+import logging
+from datetime import UTC, datetime
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
 
 from app.db.connection import get_session
 from app.db.repository import EventRepository
 from app.utils.auth import require_jwt_or_api_key
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/campaigns", tags=["campaigns"])
+
+_VALID_REVIEW_DECISIONS = {"analyst_confirmed", "analyst_denied"}
+
+
+class ObservationReviewRequest(BaseModel):
+    decision: str
+    notes: str | None = None
 
 
 @router.get("")
@@ -28,6 +44,88 @@ def list_campaigns(
     with get_session() as session:
         items = EventRepository(session).list_campaigns(limit=limit)
     return {"items": items, "count": len(items)}
+
+
+@router.get("/uncertain-associations")
+def list_uncertain_associations(
+    campaign_id: str | None = Query(default=None),
+    include_reviewed: bool = Query(default=False),
+    limit: int = Query(default=200, ge=1, le=1000),
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return uncertain-association observations pending analyst review.
+
+    By default only unreviewed (pending) observations are returned.
+    Pass include_reviewed=true to include observations that have already
+    been reviewed.  Optionally filter to a single campaign via campaign_id.
+    """
+    with get_session() as session:
+        items = EventRepository(session).list_uncertain_observations(
+            campaign_id=campaign_id,
+            include_reviewed=include_reviewed,
+            limit=limit,
+        )
+    return {"items": items, "count": len(items)}
+
+
+@router.post("/uncertain-associations/{observation_id}/review", status_code=status.HTTP_200_OK)
+def review_uncertain_association(
+    observation_id: str,
+    body: ObservationReviewRequest,
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Submit an analyst review for an uncertain-association observation.
+
+    decision must be one of: analyst_confirmed, analyst_denied.
+    The review records the analyst's interpretation only — it does not
+    modify the original clustering decision, campaign membership, or
+    observation records.
+    """
+    if body.decision not in _VALID_REVIEW_DECISIONS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Invalid decision {body.decision!r}. "
+                f"Must be one of: {sorted(_VALID_REVIEW_DECISIONS)}"
+            ),
+        )
+
+    reviewed_at = datetime.now(UTC).isoformat()
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        obs = repo.get_campaign_observation(observation_id)
+        if obs is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Observation {observation_id!r} not found",
+            )
+        repo.annotate_campaign_observation(
+            observation_id=observation_id,
+            analyst_decision=body.decision,
+            analyst_notes=body.notes,
+            reviewed_at=reviewed_at,
+        )
+        updated = repo.get_campaign_observation(observation_id)
+
+    try:
+        with get_session() as audit_session:
+            EventRepository(audit_session).insert_audit_log(
+                event_type="observation_review",
+                detail=json.dumps(
+                    {
+                        "observation_id": observation_id,
+                        "campaign_id": obs["campaign_id"],
+                        "decision": body.decision,
+                    }
+                ),
+            )
+    except Exception:
+        logger.exception(
+            "Audit log failed for observation_review observation_id=%s", observation_id
+        )
+
+    return updated
 
 
 @router.get("/{campaign_id}")

--- a/tests/integration/test_uncertain_associations_integration.py
+++ b/tests/integration/test_uncertain_associations_integration.py
@@ -1,0 +1,683 @@
+"""Integration tests for Phase 6 Group B PR B4 — uncertain association review queue.
+
+Tests hit the full DB stack (in-memory SQLite bootstrapped by tests/conftest.py).
+Rows reset per test by tests/integration/conftest.py.
+
+Coverage:
+  Repository — list_uncertain_observations:
+    - returns empty list when no observations exist
+    - returns uncertain observations (notes with decision=uncertain_association)
+    - excludes non-uncertain observations (automatic_association, null notes)
+    - filters by campaign_id when provided
+    - excludes reviewed observations by default
+    - includes reviewed observations when include_reviewed=True
+    - respects limit parameter
+
+  Repository — get_campaign_observation:
+    - returns dict for existing observation
+    - returns None for unknown observation_id
+
+  Repository — annotate_campaign_observation:
+    - writes analyst_review_json to the observation row
+    - does not modify campaign membership
+    - does not modify notes field
+    - second call overwrites first review (idempotent)
+
+  API — GET /api/campaigns/uncertain-associations:
+    - returns 200 with items list
+    - requires authentication (401 without key)
+    - returns only pending observations by default
+    - returns reviewed observations when include_reviewed=true
+    - filters by campaign_id query param
+    - items include expected keys
+
+  API — POST /api/campaigns/uncertain-associations/{id}/review:
+    - returns 200 with updated observation on success
+    - requires authentication (401 without key)
+    - returns 404 for unknown observation_id
+    - returns 422 for invalid decision value
+    - returns 422 for empty decision
+    - analyst_confirmed decision persists
+    - analyst_denied decision persists
+    - reviewed observation no longer in default pending list
+    - reviewed observation appears in include_reviewed=true list
+    - does not mutate campaign member count
+
+  No AI:
+    - campaigns.py router does not import from app.ai
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.db.connection import get_engine, get_session
+from app.db.repository import EventRepository
+from app.main import app
+
+client = TestClient(app)
+API_KEY = "dev-123"
+HEADERS = {"x-api-key": API_KEY}
+
+_TS = "2026-05-27T00:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_source_ip(ip: str) -> None:
+    with get_engine().connect() as conn:
+        conn.execute(
+            text(
+                "INSERT OR IGNORE INTO source_ips"
+                " (ip, first_seen, last_seen, event_count) VALUES (:ip, :ts, :ts, 0)"
+            ),
+            {"ip": ip, "ts": _TS},
+        )
+        conn.commit()
+
+
+def _insert_campaign(*, status: str = "active") -> str:
+    cid = str(uuid.uuid4())
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO campaigns (
+                    id, name, status, confidence, first_seen, last_seen,
+                    dormant_since, reactivation_count, member_ip_count,
+                    attack_tactic_dist, top_target_ports, notes,
+                    created_at, updated_at
+                ) VALUES (
+                    :id, :name, :status, 0.75, :ts, :ts,
+                    NULL, 0, 1, NULL, NULL, NULL, :ts, :ts
+                )
+            """),
+            {"id": cid, "name": f"CAMP-{cid[:8]}", "status": status, "ts": _TS},
+        )
+        conn.commit()
+    return cid
+
+
+def _insert_member(campaign_id: str, ip: str) -> None:
+    _insert_source_ip(ip)
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT OR IGNORE INTO campaign_members
+                    (campaign_id, source_ip, confidence, added_at, last_active)
+                VALUES (:cid, :ip, 0.75, :ts, :ts)
+            """),
+            {"cid": campaign_id, "ip": ip, "ts": _TS},
+        )
+        conn.commit()
+
+
+def _make_uncertain_notes(weighted_total: float = 0.65) -> str:
+    return json.dumps(
+        {
+            "timing_similarity": 0.7,
+            "sequence_similarity": 0.6,
+            "protocol_similarity": 0.65,
+            "credential_similarity": None,
+            "target_similarity": 0.7,
+            "weighted_total": weighted_total,
+            "dimensions_used": 4,
+            "threshold_applied": 0.6,
+            "decision": "uncertain_association",
+        },
+        separators=(",", ":"),
+    )
+
+
+def _make_auto_notes() -> str:
+    return json.dumps(
+        {
+            "weighted_total": 0.85,
+            "threshold_applied": 0.8,
+            "decision": "automatic_association",
+        },
+        separators=(",", ":"),
+    )
+
+
+def _insert_observation(
+    campaign_id: str,
+    source_ip: str,
+    *,
+    notes: str | None = None,
+    observed_at: str = _TS,
+) -> str:
+    oid = str(uuid.uuid4())
+    _insert_source_ip(source_ip)
+    with get_engine().connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO campaign_observations
+                    (id, campaign_id, source_ip, observed_at, event_count,
+                     is_reactivation, dormancy_gap_days, notes)
+                VALUES
+                    (:id, :cid, :ip, :observed_at, 10, 0, NULL, :notes)
+            """),
+            {
+                "id": oid,
+                "cid": campaign_id,
+                "ip": source_ip,
+                "observed_at": observed_at,
+                "notes": notes,
+            },
+        )
+        conn.commit()
+    return oid
+
+
+# ---------------------------------------------------------------------------
+# Repository — list_uncertain_observations
+# ---------------------------------------------------------------------------
+
+
+def test_list_uncertain_returns_empty_when_no_observations():
+    cid = _insert_campaign()
+    with get_session() as session:
+        items = EventRepository(session).list_uncertain_observations(campaign_id=cid)
+    assert items == []
+
+
+def test_list_uncertain_returns_uncertain_observation():
+    cid = _insert_campaign()
+    ip = f"10.10.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    with get_session() as session:
+        items = EventRepository(session).list_uncertain_observations(campaign_id=cid)
+    assert len(items) == 1
+    assert items[0]["id"] == oid
+
+
+def test_list_uncertain_excludes_automatic_association():
+    cid = _insert_campaign()
+    ip = f"10.11.{uuid.uuid4().int % 256}.1"
+    _insert_observation(cid, ip, notes=_make_auto_notes())
+    with get_session() as session:
+        items = EventRepository(session).list_uncertain_observations(campaign_id=cid)
+    assert items == []
+
+
+def test_list_uncertain_excludes_null_notes():
+    cid = _insert_campaign()
+    ip = f"10.12.{uuid.uuid4().int % 256}.1"
+    _insert_observation(cid, ip, notes=None)
+    with get_session() as session:
+        items = EventRepository(session).list_uncertain_observations(campaign_id=cid)
+    assert items == []
+
+
+def test_list_uncertain_filters_by_campaign_id():
+    cid1 = _insert_campaign()
+    cid2 = _insert_campaign()
+    ip1 = f"10.13.{uuid.uuid4().int % 256}.1"
+    ip2 = f"10.13.{uuid.uuid4().int % 256}.2"
+    _insert_observation(cid1, ip1, notes=_make_uncertain_notes())
+    _insert_observation(cid2, ip2, notes=_make_uncertain_notes())
+    with get_session() as session:
+        items = EventRepository(session).list_uncertain_observations(campaign_id=cid1)
+    assert len(items) == 1
+    assert items[0]["campaign_id"] == cid1
+
+
+def test_list_uncertain_returns_across_all_campaigns_when_no_filter():
+    cid1 = _insert_campaign()
+    cid2 = _insert_campaign()
+    ip1 = f"10.14.{uuid.uuid4().int % 256}.1"
+    ip2 = f"10.14.{uuid.uuid4().int % 256}.2"
+    _insert_observation(cid1, ip1, notes=_make_uncertain_notes())
+    _insert_observation(cid2, ip2, notes=_make_uncertain_notes())
+    with get_session() as session:
+        items = EventRepository(session).list_uncertain_observations()
+    cids = {i["campaign_id"] for i in items}
+    assert cid1 in cids
+    assert cid2 in cids
+
+
+def test_list_uncertain_excludes_reviewed_by_default():
+    cid = _insert_campaign()
+    ip = f"10.15.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    with get_session() as session:
+        EventRepository(session).annotate_campaign_observation(oid, "analyst_confirmed", None, _TS)
+    with get_session() as session:
+        items = EventRepository(session).list_uncertain_observations(campaign_id=cid)
+    assert items == []
+
+
+def test_list_uncertain_includes_reviewed_when_requested():
+    cid = _insert_campaign()
+    ip = f"10.16.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    with get_session() as session:
+        EventRepository(session).annotate_campaign_observation(oid, "analyst_confirmed", None, _TS)
+    with get_session() as session:
+        items = EventRepository(session).list_uncertain_observations(
+            campaign_id=cid, include_reviewed=True
+        )
+    assert len(items) == 1
+    assert items[0]["id"] == oid
+
+
+def test_list_uncertain_respects_limit():
+    cid = _insert_campaign()
+    for i in range(5):
+        ip = f"10.17.{i}.1"
+        _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    with get_session() as session:
+        items = EventRepository(session).list_uncertain_observations(campaign_id=cid, limit=3)
+    assert len(items) == 3
+
+
+def test_list_uncertain_returned_keys():
+    cid = _insert_campaign()
+    ip = f"10.18.{uuid.uuid4().int % 256}.1"
+    _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    with get_session() as session:
+        items = EventRepository(session).list_uncertain_observations(campaign_id=cid)
+    assert len(items) == 1
+    assert set(items[0].keys()) == {
+        "id",
+        "campaign_id",
+        "source_ip",
+        "observed_at",
+        "event_count",
+        "is_reactivation",
+        "dormancy_gap_days",
+        "notes",
+        "analyst_review_json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Repository — get_campaign_observation
+# ---------------------------------------------------------------------------
+
+
+def test_get_campaign_observation_returns_dict():
+    cid = _insert_campaign()
+    ip = f"10.20.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    with get_session() as session:
+        obs = EventRepository(session).get_campaign_observation(oid)
+    assert obs is not None
+    assert obs["id"] == oid
+    assert obs["campaign_id"] == cid
+
+
+def test_get_campaign_observation_returns_none_for_unknown():
+    with get_session() as session:
+        obs = EventRepository(session).get_campaign_observation(str(uuid.uuid4()))
+    assert obs is None
+
+
+def test_get_campaign_observation_analyst_review_json_initially_null():
+    cid = _insert_campaign()
+    ip = f"10.21.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    with get_session() as session:
+        obs = EventRepository(session).get_campaign_observation(oid)
+    assert obs["analyst_review_json"] is None
+
+
+# ---------------------------------------------------------------------------
+# Repository — annotate_campaign_observation
+# ---------------------------------------------------------------------------
+
+
+def test_annotate_writes_analyst_review_json():
+    cid = _insert_campaign()
+    ip = f"10.30.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    with get_session() as session:
+        EventRepository(session).annotate_campaign_observation(
+            oid, "analyst_confirmed", "Confirmed by SOC", _TS
+        )
+    with get_session() as session:
+        obs = EventRepository(session).get_campaign_observation(oid)
+    assert obs["analyst_review_json"] is not None
+    parsed = json.loads(obs["analyst_review_json"])
+    assert parsed["decision"] == "analyst_confirmed"
+    assert parsed["notes"] == "Confirmed by SOC"
+    assert parsed["reviewed_at"] == _TS
+
+
+def test_annotate_analyst_denied_persists():
+    cid = _insert_campaign()
+    ip = f"10.31.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    with get_session() as session:
+        EventRepository(session).annotate_campaign_observation(oid, "analyst_denied", None, _TS)
+    with get_session() as session:
+        obs = EventRepository(session).get_campaign_observation(oid)
+    parsed = json.loads(obs["analyst_review_json"])
+    assert parsed["decision"] == "analyst_denied"
+    assert parsed["notes"] is None
+
+
+def test_annotate_does_not_modify_notes_field():
+    cid = _insert_campaign()
+    ip = f"10.32.{uuid.uuid4().int % 256}.1"
+    original_notes = _make_uncertain_notes()
+    oid = _insert_observation(cid, ip, notes=original_notes)
+    with get_session() as session:
+        EventRepository(session).annotate_campaign_observation(
+            oid, "analyst_confirmed", "Some note", _TS
+        )
+    with get_session() as session:
+        obs = EventRepository(session).get_campaign_observation(oid)
+    assert obs["notes"] == original_notes
+
+
+def test_annotate_overwrites_previous_review():
+    cid = _insert_campaign()
+    ip = f"10.33.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    ts1 = "2026-05-27T10:00:00+00:00"
+    ts2 = "2026-05-27T11:00:00+00:00"
+    with get_session() as session:
+        EventRepository(session).annotate_campaign_observation(
+            oid, "analyst_confirmed", "First review", ts1
+        )
+    with get_session() as session:
+        EventRepository(session).annotate_campaign_observation(
+            oid, "analyst_denied", "Revised", ts2
+        )
+    with get_session() as session:
+        obs = EventRepository(session).get_campaign_observation(oid)
+    parsed = json.loads(obs["analyst_review_json"])
+    assert parsed["decision"] == "analyst_denied"
+    assert parsed["reviewed_at"] == ts2
+
+
+def test_annotate_does_not_change_campaign_member_count():
+    cid = _insert_campaign()
+    ip = f"10.34.{uuid.uuid4().int % 256}.1"
+    _insert_member(cid, ip)
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+
+    with get_session() as session:
+        before = EventRepository(session).get_campaign(cid)
+
+    with get_session() as session:
+        EventRepository(session).annotate_campaign_observation(oid, "analyst_confirmed", None, _TS)
+
+    with get_session() as session:
+        after = EventRepository(session).get_campaign(cid)
+
+    assert before["member_ip_count"] == after["member_ip_count"]
+
+
+# ---------------------------------------------------------------------------
+# API — GET /api/campaigns/uncertain-associations
+# ---------------------------------------------------------------------------
+
+
+def test_list_uncertain_api_returns_200():
+    resp = client.get("/api/campaigns/uncertain-associations", headers=HEADERS)
+    assert resp.status_code == 200
+
+
+def test_list_uncertain_api_returns_items_and_count():
+    resp = client.get("/api/campaigns/uncertain-associations", headers=HEADERS)
+    body = resp.json()
+    assert "items" in body
+    assert "count" in body
+    assert body["count"] == len(body["items"])
+
+
+def test_list_uncertain_api_requires_auth():
+    resp = client.get("/api/campaigns/uncertain-associations")
+    assert resp.status_code == 401
+
+
+def test_list_uncertain_api_returns_observation():
+    cid = _insert_campaign()
+    ip = f"10.40.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    resp = client.get("/api/campaigns/uncertain-associations", headers=HEADERS)
+    assert resp.status_code == 200
+    ids = [i["id"] for i in resp.json()["items"]]
+    assert oid in ids
+
+
+def test_list_uncertain_api_excludes_reviewed_by_default():
+    cid = _insert_campaign()
+    ip = f"10.41.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    with get_session() as session:
+        EventRepository(session).annotate_campaign_observation(oid, "analyst_confirmed", None, _TS)
+    resp = client.get("/api/campaigns/uncertain-associations", headers=HEADERS)
+    ids = [i["id"] for i in resp.json()["items"]]
+    assert oid not in ids
+
+
+def test_list_uncertain_api_includes_reviewed_when_flag_set():
+    cid = _insert_campaign()
+    ip = f"10.42.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    with get_session() as session:
+        EventRepository(session).annotate_campaign_observation(oid, "analyst_denied", None, _TS)
+    resp = client.get(
+        "/api/campaigns/uncertain-associations?include_reviewed=true", headers=HEADERS
+    )
+    ids = [i["id"] for i in resp.json()["items"]]
+    assert oid in ids
+
+
+def test_list_uncertain_api_filters_by_campaign_id():
+    cid1 = _insert_campaign()
+    cid2 = _insert_campaign()
+    ip1 = f"10.43.{uuid.uuid4().int % 256}.1"
+    ip2 = f"10.43.{uuid.uuid4().int % 256}.2"
+    oid1 = _insert_observation(cid1, ip1, notes=_make_uncertain_notes())
+    oid2 = _insert_observation(cid2, ip2, notes=_make_uncertain_notes())
+    resp = client.get(f"/api/campaigns/uncertain-associations?campaign_id={cid1}", headers=HEADERS)
+    ids = [i["id"] for i in resp.json()["items"]]
+    assert oid1 in ids
+    assert oid2 not in ids
+
+
+def test_list_uncertain_api_item_has_expected_keys():
+    cid = _insert_campaign()
+    ip = f"10.44.{uuid.uuid4().int % 256}.1"
+    _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    resp = client.get("/api/campaigns/uncertain-associations", headers=HEADERS)
+    item = resp.json()["items"][0]
+    for key in (
+        "id",
+        "campaign_id",
+        "source_ip",
+        "observed_at",
+        "event_count",
+        "notes",
+        "analyst_review_json",
+    ):
+        assert key in item, f"Missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# API — POST /api/campaigns/uncertain-associations/{id}/review
+# ---------------------------------------------------------------------------
+
+
+def test_review_returns_200_on_success():
+    cid = _insert_campaign()
+    ip = f"10.50.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    resp = client.post(
+        f"/api/campaigns/uncertain-associations/{oid}/review",
+        json={"decision": "analyst_confirmed"},
+        headers=HEADERS,
+    )
+    assert resp.status_code == 200
+
+
+def test_review_requires_auth():
+    oid = str(uuid.uuid4())
+    resp = client.post(
+        f"/api/campaigns/uncertain-associations/{oid}/review",
+        json={"decision": "analyst_confirmed"},
+    )
+    assert resp.status_code == 401
+
+
+def test_review_returns_404_for_unknown_observation():
+    oid = str(uuid.uuid4())
+    resp = client.post(
+        f"/api/campaigns/uncertain-associations/{oid}/review",
+        json={"decision": "analyst_confirmed"},
+        headers=HEADERS,
+    )
+    assert resp.status_code == 404
+
+
+def test_review_returns_422_for_invalid_decision():
+    cid = _insert_campaign()
+    ip = f"10.51.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    resp = client.post(
+        f"/api/campaigns/uncertain-associations/{oid}/review",
+        json={"decision": "accepted"},
+        headers=HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+def test_review_returns_422_for_empty_decision():
+    cid = _insert_campaign()
+    ip = f"10.52.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    resp = client.post(
+        f"/api/campaigns/uncertain-associations/{oid}/review",
+        json={"decision": ""},
+        headers=HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.parametrize("decision", ["analyst_confirmed", "analyst_denied"])
+def test_review_decision_persists(decision: str):
+    cid = _insert_campaign()
+    ip = f"10.53.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    resp = client.post(
+        f"/api/campaigns/uncertain-associations/{oid}/review",
+        json={"decision": decision, "notes": "test note"},
+        headers=HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["analyst_review_json"] is not None
+    parsed = json.loads(body["analyst_review_json"])
+    assert parsed["decision"] == decision
+    assert parsed["notes"] == "test note"
+
+
+def test_review_response_contains_observation_fields():
+    cid = _insert_campaign()
+    ip = f"10.54.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    resp = client.post(
+        f"/api/campaigns/uncertain-associations/{oid}/review",
+        json={"decision": "analyst_confirmed"},
+        headers=HEADERS,
+    )
+    body = resp.json()
+    assert body["id"] == oid
+    assert body["campaign_id"] == cid
+
+
+def test_reviewed_observation_removed_from_pending_list():
+    cid = _insert_campaign()
+    ip = f"10.55.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    client.post(
+        f"/api/campaigns/uncertain-associations/{oid}/review",
+        json={"decision": "analyst_confirmed"},
+        headers=HEADERS,
+    )
+    resp = client.get("/api/campaigns/uncertain-associations", headers=HEADERS)
+    ids = [i["id"] for i in resp.json()["items"]]
+    assert oid not in ids
+
+
+def test_reviewed_observation_appears_in_include_reviewed_list():
+    cid = _insert_campaign()
+    ip = f"10.56.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    client.post(
+        f"/api/campaigns/uncertain-associations/{oid}/review",
+        json={"decision": "analyst_denied"},
+        headers=HEADERS,
+    )
+    resp = client.get(
+        "/api/campaigns/uncertain-associations?include_reviewed=true", headers=HEADERS
+    )
+    ids = [i["id"] for i in resp.json()["items"]]
+    assert oid in ids
+
+
+def test_review_does_not_mutate_campaign_member_count():
+    cid = _insert_campaign()
+    ip = f"10.57.{uuid.uuid4().int % 256}.1"
+    _insert_member(cid, ip)
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+
+    before = client.get(f"/api/campaigns/{cid}", headers=HEADERS).json()["member_ip_count"]
+
+    client.post(
+        f"/api/campaigns/uncertain-associations/{oid}/review",
+        json={"decision": "analyst_confirmed"},
+        headers=HEADERS,
+    )
+
+    after = client.get(f"/api/campaigns/{cid}", headers=HEADERS).json()["member_ip_count"]
+    assert before == after
+
+
+def test_review_with_null_notes_body_field():
+    cid = _insert_campaign()
+    ip = f"10.58.{uuid.uuid4().int % 256}.1"
+    oid = _insert_observation(cid, ip, notes=_make_uncertain_notes())
+    resp = client.post(
+        f"/api/campaigns/uncertain-associations/{oid}/review",
+        json={"decision": "analyst_denied", "notes": None},
+        headers=HEADERS,
+    )
+    assert resp.status_code == 200
+    parsed = json.loads(resp.json()["analyst_review_json"])
+    assert parsed["notes"] is None
+
+
+# ---------------------------------------------------------------------------
+# No AI imports
+# ---------------------------------------------------------------------------
+
+
+def test_campaigns_router_has_no_ai_imports():
+    import importlib
+    import sys
+
+    if "app.routers.campaigns" in sys.modules:
+        mod = sys.modules["app.routers.campaigns"]
+    else:
+        mod = importlib.import_module("app.routers.campaigns")
+
+    source = mod.__file__
+    assert source is not None
+    with open(source) as f:
+        content = f.read()
+    assert "app.ai" not in content
+    assert "from app.ai" not in content
+    assert "import app.ai" not in content

--- a/tests/unit/test_uncertain_observations.py
+++ b/tests/unit/test_uncertain_observations.py
@@ -1,0 +1,169 @@
+"""Unit tests for uncertain-association filtering logic.
+
+Pure Python — no database, no I/O.  Tests cover the decision-identification
+logic used by list_uncertain_observations() and the valid/invalid analyst
+decision values enforced by the review endpoint.
+
+Coverage:
+  Notes JSON parsing:
+    - notes with decision="uncertain_association" is identified as uncertain
+    - notes with decision="automatic_association" is not uncertain
+    - notes with decision="existing_member" is not uncertain
+    - NULL notes is not uncertain
+    - malformed JSON notes is not uncertain
+    - notes missing "decision" key is not uncertain
+    - notes with decision as integer is not uncertain
+
+  Review decision validation:
+    - "analyst_confirmed" is a valid review decision
+    - "analyst_denied" is a valid review decision
+    - arbitrary strings are not valid review decisions
+    - empty string is not a valid review decision
+    - "uncertain_association" itself is not a valid review decision
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+_VALID_REVIEW_DECISIONS = {"analyst_confirmed", "analyst_denied"}
+
+_UNCERTAIN_ASSOCIATION = "uncertain_association"
+
+
+def _is_uncertain_observation(notes: str | None) -> bool:
+    """Mirror of the Python-side check in list_uncertain_observations()."""
+    if notes is None:
+        return False
+    try:
+        parsed = json.loads(notes)
+        if not isinstance(parsed, dict):
+            return False
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return parsed.get("decision") == _UNCERTAIN_ASSOCIATION
+
+
+def _make_notes(decision: str, weighted_total: float = 0.65) -> str:
+    return json.dumps(
+        {
+            "timing_similarity": 0.7,
+            "sequence_similarity": 0.6,
+            "weighted_total": weighted_total,
+            "dimensions_used": 2,
+            "threshold_applied": 0.6,
+            "decision": decision,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Notes JSON parsing
+# ---------------------------------------------------------------------------
+
+
+def test_uncertain_association_decision_is_identified():
+    assert _is_uncertain_observation(_make_notes("uncertain_association")) is True
+
+
+def test_automatic_association_decision_is_not_uncertain():
+    assert _is_uncertain_observation(_make_notes("automatic_association")) is False
+
+
+def test_existing_member_decision_is_not_uncertain():
+    assert _is_uncertain_observation(_make_notes("existing_member")) is False
+
+
+def test_null_notes_is_not_uncertain():
+    assert _is_uncertain_observation(None) is False
+
+
+def test_malformed_json_notes_is_not_uncertain():
+    assert _is_uncertain_observation("{not valid json") is False
+
+
+def test_empty_string_notes_is_not_uncertain():
+    assert _is_uncertain_observation("") is False
+
+
+def test_notes_without_decision_key_is_not_uncertain():
+    notes = json.dumps({"weighted_total": 0.65, "threshold_applied": 0.6})
+    assert _is_uncertain_observation(notes) is False
+
+
+def test_notes_with_integer_decision_is_not_uncertain():
+    notes = json.dumps({"decision": 1})
+    assert _is_uncertain_observation(notes) is False
+
+
+def test_notes_that_are_json_array_is_not_uncertain():
+    assert _is_uncertain_observation(json.dumps([1, 2, 3])) is False
+
+
+def test_notes_with_null_decision_is_not_uncertain():
+    notes = json.dumps({"decision": None})
+    assert _is_uncertain_observation(notes) is False
+
+
+# ---------------------------------------------------------------------------
+# Review decision validation
+# ---------------------------------------------------------------------------
+
+
+def test_analyst_confirmed_is_valid():
+    assert "analyst_confirmed" in _VALID_REVIEW_DECISIONS
+
+
+def test_analyst_denied_is_valid():
+    assert "analyst_denied" in _VALID_REVIEW_DECISIONS
+
+
+def test_exactly_two_valid_decisions():
+    assert len(_VALID_REVIEW_DECISIONS) == 2
+
+
+@pytest.mark.parametrize(
+    "bad_decision",
+    [
+        "uncertain_association",
+        "automatic_association",
+        "accepted",
+        "rejected",
+        "confirmed",
+        "denied",
+        "",
+        "ANALYST_CONFIRMED",
+    ],
+)
+def test_invalid_decision_not_in_valid_set(bad_decision: str):
+    assert bad_decision not in _VALID_REVIEW_DECISIONS
+
+
+# ---------------------------------------------------------------------------
+# Review JSON structure
+# ---------------------------------------------------------------------------
+
+
+def test_review_json_is_serializable():
+    review = {
+        "decision": "analyst_confirmed",
+        "notes": "Confirmed by SOC team",
+        "reviewed_at": "2026-05-27T12:00:00+00:00",
+    }
+    serialized = json.dumps(review)
+    parsed = json.loads(serialized)
+    assert parsed["decision"] == "analyst_confirmed"
+    assert parsed["notes"] == "Confirmed by SOC team"
+
+
+def test_review_json_with_null_notes_is_serializable():
+    review = {
+        "decision": "analyst_denied",
+        "notes": None,
+        "reviewed_at": "2026-05-27T12:00:00+00:00",
+    }
+    serialized = json.dumps(review)
+    parsed = json.loads(serialized)
+    assert parsed["notes"] is None


### PR DESCRIPTION
## Summary

- Adds `analyst_review_json TEXT NULL` column to `campaign_observations` (migration 0009)
- New repository methods: `list_uncertain_observations()`, `get_campaign_observation()`, `annotate_campaign_observation()`
- Two new API endpoints behind existing auth:
  - `GET /api/campaigns/uncertain-associations` — lists pending uncertain observations (default); supports `include_reviewed`, `campaign_id`, and `limit` query params
  - `POST /api/campaigns/uncertain-associations/{observation_id}/review` — accepts `analyst_confirmed` or `analyst_denied`; returns updated observation; writes best-effort audit log entry

## Design notes

- Uncertain observations identified via SQL `LIKE '%"decision":"uncertain_association"%'` pre-filter + Python-side JSON parse confirm (no `json_extract()` per PostgreSQL compat rule)
- Review records analyst interpretation only — no mutation of campaign membership, clustering decisions, or existing observation fields
- Review is idempotent: re-submitting overwrites the previous `analyst_review_json`
- Route `/uncertain-associations` declared before `/{campaign_id}` to prevent FastAPI routing conflict
- Audit write in isolated `try/except` session — never fails the primary request

## Test plan

- [ ] `tests/unit/test_uncertain_observations.py` — 20 pure-Python tests for decision identification and valid/invalid review values
- [ ] `tests/integration/test_uncertain_associations_integration.py` — 42 integration tests: repository filtering, annotation, API auth, 404/422 error cases, membership non-mutation, no-AI contract
- [ ] Full suite: 1262 passed, 0 failures
- [ ] Pre-commit: all hooks pass

## Out of scope (deferred)

- Dashboard review panel
- Bulk review endpoint
- Review history (only latest review per observation stored)