### PR TITLE
feat(ai): add time-window campaign briefs and dashboard brief panel

### DIFF
--- a/app/jobs/runner.py
+++ b/app/jobs/runner.py
@@ -309,24 +309,43 @@ def _execute_brief(job_id: str) -> None:
 
     triggered_by: str | None = job.get("triggered_by")
 
-    # Parse max_campaigns from backend_metadata_json.
+    # Parse params from backend_metadata_json.
     max_campaigns = 10
+    time_window_start: str | None = None
+    time_window_end: str | None = None
     if job.get("backend_metadata_json"):
         try:
             meta = json.loads(job["backend_metadata_json"])
             max_campaigns = int(meta.get("max_campaigns", 10))
+            time_window_start = meta.get("time_window_start") or None
+            time_window_end = meta.get("time_window_end") or None
         except (ValueError, TypeError, KeyError):
             pass
 
-    # Fetch campaigns — read-only session.
+    # Fetch campaigns sorted by last_seen DESC — read-only session.
     with get_session() as session:
         repo = EventRepository(session)
         all_campaigns = repo.list_campaigns(limit=max_campaigns * 4)
 
-    campaigns = [c for c in all_campaigns if c.get("status") in _BRIEF_STATUSES][:max_campaigns]
+    campaigns = [c for c in all_campaigns if c.get("status") in _BRIEF_STATUSES]
+
+    # Apply time window filter when provided.
+    if time_window_start is not None and time_window_end is not None:
+        campaigns = [
+            c
+            for c in campaigns
+            if time_window_start <= (c.get("last_seen") or "") <= time_window_end
+        ]
+
+    campaigns = campaigns[:max_campaigns]
 
     generated_at = datetime.now(UTC).isoformat()
     latency_ms = int((time.monotonic() - t0) * 1000)
+
+    empty_source_records: dict = {"campaign_ids": [], "campaign_count": 0}
+    if time_window_start is not None:
+        empty_source_records["time_window_start"] = time_window_start
+        empty_source_records["time_window_end"] = time_window_end
 
     if not campaigns:
         result = {
@@ -336,7 +355,7 @@ def _execute_brief(job_id: str) -> None:
             "warning": _SUMMARY_WARNING,
             "summary": None,
             "campaign_count": 0,
-            "source_records": {"campaign_ids": [], "campaign_count": 0},
+            "source_records": empty_source_records,
             "rejected": False,
             "rejection_reason": "no_campaigns",
             "truncated": False,
@@ -450,6 +469,11 @@ def _execute_brief(job_id: str) -> None:
     is_rejected = rejection_reason in ("ip_detected", "empty_response")
     is_truncated = rejection_reason == "truncated"
 
+    source_records = dict(prompt_data["source_records"])
+    if time_window_start is not None:
+        source_records["time_window_start"] = time_window_start
+        source_records["time_window_end"] = time_window_end
+
     result = {
         "ai_assisted": True,
         "ai_backend": settings.AI_BACKEND,
@@ -457,7 +481,7 @@ def _execute_brief(job_id: str) -> None:
         "warning": _SUMMARY_WARNING,
         "summary": None if is_rejected else validated_text,
         "campaign_count": len(campaigns),
-        "source_records": prompt_data["source_records"],
+        "source_records": source_records,
         "rejected": is_rejected,
         "rejection_reason": rejection_reason,
         "truncated": is_truncated,

--- a/app/routers/analyze.py
+++ b/app/routers/analyze.py
@@ -42,7 +42,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from app.core.config import settings
 from app.db.connection import get_session
@@ -57,6 +57,26 @@ router = APIRouter(prefix="/api/campaigns", tags=["analyze"])
 
 class BriefRequest(BaseModel):
     max_campaigns: int = Field(default=10, ge=1, le=25)
+    time_window_start: str | None = None
+    time_window_end: str | None = None
+
+    @model_validator(mode="after")
+    def _check_time_window(self) -> BriefRequest:
+        start = self.time_window_start
+        end = self.time_window_end
+        if (start is None) != (end is None):
+            raise ValueError("Both time_window_start and time_window_end must be provided together")
+        if start is not None and end is not None:
+            try:
+                dt_start = datetime.fromisoformat(start)
+                dt_end = datetime.fromisoformat(end)
+            except ValueError as exc:
+                raise ValueError(
+                    "time_window_start and time_window_end must be valid ISO 8601 strings"
+                ) from exc
+            if dt_start >= dt_end:
+                raise ValueError("time_window_start must be before time_window_end")
+        return self
 
 
 def _triggered_by(auth_info: dict) -> str:
@@ -219,7 +239,11 @@ def campaign_brief(
         ):
             rate_limited = True
         else:
-            # Store max_campaigns in backend_metadata_json so the runner can read it.
+            # Store params in backend_metadata_json so the runner can read them.
+            meta: dict = {"max_campaigns": body.max_campaigns}
+            if body.time_window_start is not None:
+                meta["time_window_start"] = body.time_window_start
+                meta["time_window_end"] = body.time_window_end
             job = repo.create_job(
                 job_type="campaign_brief",
                 triggered_by=triggered_by,
@@ -227,7 +251,7 @@ def campaign_brief(
                 resource_id=None,
                 deduplication_key=None,
                 created_at=now,
-                backend_metadata_json={"max_campaigns": body.max_campaigns},
+                backend_metadata_json=meta,
             )
 
     if rate_limited:

--- a/tests/integration/test_analyze_endpoints.py
+++ b/tests/integration/test_analyze_endpoints.py
@@ -1094,3 +1094,150 @@ def test_brief_reactivated_campaigns_included(monkeypatch):
     resp = client.post(_BRIEF_URL, headers=HEADERS)
     job = _get_job_result(resp.json()["job_id"])
     assert job["result"]["campaign_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Time-window support (PR C1)
+# ---------------------------------------------------------------------------
+
+_TW_INSIDE = "2026-03-01T00:00:00+00:00"  # inside window [2026-02-01, 2026-04-01]
+_TW_OUTSIDE = "2025-12-01T00:00:00+00:00"  # before window
+_TW_START = "2026-02-01T00:00:00+00:00"
+_TW_END = "2026-04-01T00:00:00+00:00"
+
+_TW_BODY = {
+    "time_window_start": _TW_START,
+    "time_window_end": _TW_END,
+}
+
+
+def test_brief_time_window_only_start_returns_422():
+    resp = client.post(
+        _BRIEF_URL,
+        headers=HEADERS,
+        json={"time_window_start": _TW_START},
+    )
+    assert resp.status_code == 422
+
+
+def test_brief_time_window_only_end_returns_422():
+    resp = client.post(
+        _BRIEF_URL,
+        headers=HEADERS,
+        json={"time_window_end": _TW_END},
+    )
+    assert resp.status_code == 422
+
+
+def test_brief_time_window_start_after_end_returns_422():
+    resp = client.post(
+        _BRIEF_URL,
+        headers=HEADERS,
+        json={"time_window_start": _TW_END, "time_window_end": _TW_START},
+    )
+    assert resp.status_code == 422
+
+
+def test_brief_time_window_start_equal_end_returns_422():
+    resp = client.post(
+        _BRIEF_URL,
+        headers=HEADERS,
+        json={"time_window_start": _TW_START, "time_window_end": _TW_START},
+    )
+    assert resp.status_code == 422
+
+
+def test_brief_time_window_invalid_iso_start_returns_422():
+    resp = client.post(
+        _BRIEF_URL,
+        headers=HEADERS,
+        json={"time_window_start": "not-a-date", "time_window_end": _TW_END},
+    )
+    assert resp.status_code == 422
+
+
+def test_brief_time_window_invalid_iso_end_returns_422():
+    resp = client.post(
+        _BRIEF_URL,
+        headers=HEADERS,
+        json={"time_window_start": _TW_START, "time_window_end": "not-a-date"},
+    )
+    assert resp.status_code == 422
+
+
+def test_brief_time_window_filters_in_campaign(monkeypatch):
+    """Campaign with last_seen inside the window is included."""
+    cid = str(uuid.uuid4())
+    _insert_campaign(cid, last_seen=_TW_INSIDE)
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS, json=_TW_BODY)
+    assert resp.status_code == 202
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["campaign_count"] >= 1
+    assert cid in job["result"]["source_records"]["campaign_ids"]
+
+
+def test_brief_time_window_excludes_campaign_outside_window(monkeypatch):
+    """Campaign with last_seen before window start is excluded."""
+    cid = str(uuid.uuid4())
+    _insert_campaign(cid, last_seen=_TW_OUTSIDE)
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS, json=_TW_BODY)
+    assert resp.status_code == 202
+    job = _get_job_result(resp.json()["job_id"])
+    assert cid not in job["result"]["source_records"]["campaign_ids"]
+
+
+def test_brief_time_window_source_records_has_window_fields(monkeypatch):
+    """source_records includes time_window_start/end when window is provided."""
+    _insert_campaign(last_seen=_TW_INSIDE)
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS, json=_TW_BODY)
+    job = _get_job_result(resp.json()["job_id"])
+    sr = job["result"]["source_records"]
+    assert sr["time_window_start"] == _TW_START
+    assert sr["time_window_end"] == _TW_END
+
+
+def test_brief_no_time_window_source_records_no_window_fields(monkeypatch):
+    """source_records has no time_window fields when no window is provided."""
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    job = _get_job_result(resp.json()["job_id"])
+    sr = job["result"]["source_records"]
+    assert "time_window_start" not in sr
+    assert "time_window_end" not in sr
+
+
+def test_brief_time_window_max_campaigns_still_enforced(monkeypatch):
+    """max_campaigns cap applies after time window filter."""
+    for _ in range(10):
+        cid = str(uuid.uuid4())
+        _insert_campaign(cid, last_seen=_TW_INSIDE)
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    body = {**_TW_BODY, "max_campaigns": 3}
+    resp = client.post(_BRIEF_URL, headers=HEADERS, json=body)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["campaign_count"] <= 3
+
+
+def test_brief_time_window_empty_window_result(monkeypatch):
+    """No campaigns in window produces no_campaigns rejection."""
+    _insert_campaign(last_seen=_TW_OUTSIDE)  # outside window
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS, json=_TW_BODY)
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["campaign_count"] == 0
+    assert job["result"]["rejection_reason"] == "no_campaigns"
+
+
+def test_brief_no_time_window_backward_compatible(monkeypatch):
+    """Requests without time_window work exactly as before."""
+    _insert_campaign()
+    monkeypatch.setattr("app.jobs.runner.get_ai_backend", lambda: MockAIBackend("Brief."))
+    resp = client.post(_BRIEF_URL, headers=HEADERS)
+    assert resp.status_code == 202
+    job = _get_job_result(resp.json()["job_id"])
+    assert job["result"]["status"] if "status" in job["result"] else job["status"] == "completed"
+    assert job["result"]["campaign_count"] >= 1

--- a/ui/dashboard/src/App.jsx
+++ b/ui/dashboard/src/App.jsx
@@ -6,6 +6,7 @@ import IntelligenceIPs from "./components/IntelligenceIPs";
 import TopCountries from "./components/TopCountries";
 import TopASNs from "./components/TopASNs";
 import Campaigns from "./components/Campaigns";
+import CampaignBriefPanel from "./components/CampaignBriefPanel";
 
 
 // keep <body> background in sync with dashboard theme
@@ -222,6 +223,12 @@ export default function App() {
         }}>
           <TopCountries dark={dark} />
           <TopASNs dark={dark} />
+        </div>
+
+        {/* 📋 AI Threat Brief */}
+        <div style={{ marginTop: 36 }}>
+          <h3 style={{ marginBottom: 10, fontSize: 18, opacity: 0.9 }}>AI Threat Brief</h3>
+          <CampaignBriefPanel dark={dark} />
         </div>
 
         {/* 🎯 Campaigns */}

--- a/ui/dashboard/src/components/CampaignBriefPanel.jsx
+++ b/ui/dashboard/src/components/CampaignBriefPanel.jsx
@@ -1,0 +1,408 @@
+/**
+ * CampaignBriefPanel — operator-triggered multi-campaign AI brief panel.
+ *
+ * Rendering rules:
+ *   - Brief is NEVER auto-generated; operator must click "Generate Brief"
+ *   - Warning/disclaimer is always visible, not dismissible
+ *   - AI output is plain text — never HTML, never dangerouslySetInnerHTML
+ *   - No output is cached or persisted locally
+ *   - Polls GET /api/jobs/{job_id} until terminal state
+ *   - Stops polling on completed / failed / cancelled
+ *   - Handles 429 rate limit at POST time
+ *
+ * Props:
+ *   dark   boolean
+ */
+import { useEffect, useRef, useState } from "react";
+import { getJob, postCampaignBrief } from "../lib/api";
+
+const POLL_INTERVAL_MS = 2000;
+const MAX_POLLS = 60; // 2 minutes max
+
+const _WARNING =
+  "AI-assisted analysis — not an asserted attribution. All factual claims " +
+  "are derived from deterministic campaign data. Operator review required.";
+
+export default function CampaignBriefPanel({ dark }) {
+  const [phase, setPhase] = useState("idle"); // idle | submitting | polling | done | error
+  const [jobId, setJobId] = useState(null);
+  const [result, setResult] = useState(null);
+  const [errorMsg, setErrorMsg] = useState(null);
+  const [maxCampaigns, setMaxCampaigns] = useState(10);
+  const [twStart, setTwStart] = useState(""); // date string YYYY-MM-DD
+  const [twEnd, setTwEnd] = useState("");
+
+  const pollCountRef = useRef(0);
+  const cancelledRef = useRef(false);
+
+  const fg = dark ? "#e5e7eb" : "#111827";
+  const mutedFg = dark ? "#9ca3af" : "#6b7280";
+  const labelFg = dark ? "#818cf8" : "#6366f1";
+  const panelBorder = dark ? "#4b5563" : "#c7d2fe";
+  const panelBg = dark ? "rgba(99,102,241,0.05)" : "rgba(238,242,255,0.6)";
+  const warnBg = dark ? "rgba(251,191,36,0.08)" : "rgba(255,251,235,0.9)";
+  const warnBorder = dark ? "#92400e" : "#d97706";
+  const warnFg = dark ? "#fbbf24" : "#92400e";
+  const btnBg = dark ? "rgba(99,102,241,0.18)" : "rgba(99,102,241,0.1)";
+  const btnBorder = "#6366f1";
+  const btnFg = dark ? "#a5b4fc" : "#4338ca";
+  const errorFg = dark ? "#f87171" : "#dc2626";
+  const inputBg = dark ? "#1f2937" : "#fff";
+  const inputFg = dark ? "#e5e7eb" : "#111827";
+  const inputBorder = dark ? "#374151" : "#d1d5db";
+  const dividerColor = dark ? "#374151" : "#e0e7ff";
+
+  // Polling effect — active only when phase === "polling"
+  useEffect(() => {
+    if (phase !== "polling" || !jobId) return;
+
+    cancelledRef.current = false;
+    pollCountRef.current = 0;
+
+    async function poll() {
+      if (cancelledRef.current) return;
+      if (pollCountRef.current >= MAX_POLLS) {
+        setErrorMsg("Brief timed out. The job may still be running — try again.");
+        setPhase("error");
+        return;
+      }
+      pollCountRef.current += 1;
+      try {
+        const job = await getJob(jobId);
+        if (cancelledRef.current) return;
+        if (job.status === "completed") {
+          setResult(job.result);
+          setPhase("done");
+        } else if (job.status === "failed" || job.status === "cancelled") {
+          setErrorMsg(job.error_message ?? "Brief generation failed.");
+          setPhase("error");
+        }
+        // pending or running → keep polling
+      } catch {
+        if (!cancelledRef.current) {
+          setErrorMsg("Poll request failed. Check your connection.");
+          setPhase("error");
+        }
+      }
+    }
+
+    poll(); // immediate first check
+    const t = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      cancelledRef.current = true;
+      clearInterval(t);
+    };
+  }, [phase, jobId]);
+
+  async function handleGenerate() {
+    setPhase("submitting");
+    setResult(null);
+    setErrorMsg(null);
+
+    const params = { max_campaigns: maxCampaigns };
+    if (twStart && twEnd) {
+      // Convert date inputs to ISO 8601 datetime strings (UTC)
+      params.time_window_start = `${twStart}T00:00:00+00:00`;
+      params.time_window_end = `${twEnd}T23:59:59+00:00`;
+    }
+
+    try {
+      const { status, data } = await postCampaignBrief(params);
+      if (status === 202) {
+        setJobId(data.job_id);
+        setPhase("polling");
+      } else if (status === 429) {
+        setErrorMsg("Rate limit reached. Please wait 60 seconds and try again.");
+        setPhase("error");
+      } else if (status === 422) {
+        const detail = data?.detail ?? "Invalid request.";
+        setErrorMsg(typeof detail === "string" ? detail : JSON.stringify(detail));
+        setPhase("error");
+      } else {
+        setErrorMsg(`Unexpected response (HTTP ${status}).`);
+        setPhase("error");
+      }
+    } catch {
+      setErrorMsg("Network error. Could not reach the API.");
+      setPhase("error");
+    }
+  }
+
+  function handleReset() {
+    setPhase("idle");
+    setResult(null);
+    setErrorMsg(null);
+    setJobId(null);
+  }
+
+  const isIdle = phase === "idle";
+  const isLoading = phase === "submitting" || phase === "polling";
+  const isDone = phase === "done";
+  const isError = phase === "error";
+
+  return (
+    <div
+      style={{
+        padding: "16px 18px",
+        borderRadius: 10,
+        border: `1px solid ${panelBorder}`,
+        background: panelBg,
+      }}
+    >
+      {/* ── Header ─────────────────────────────────────────────── */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 12,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 12,
+            fontWeight: 700,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color: labelFg,
+          }}
+        >
+          Multi-Campaign AI Threat Brief
+        </span>
+        {(isDone || isError) && (
+          <button
+            onClick={handleReset}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              fontSize: 12,
+              color: mutedFg,
+              padding: "2px 6px",
+              borderRadius: 4,
+            }}
+          >
+            Reset
+          </button>
+        )}
+      </div>
+
+      {/* ── Warning — always visible ────────────────────────────── */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 8,
+          padding: "8px 10px",
+          borderRadius: 6,
+          background: warnBg,
+          border: `1px solid ${warnBorder}`,
+          color: warnFg,
+          fontSize: 12,
+          lineHeight: 1.5,
+          marginBottom: 14,
+        }}
+      >
+        <span style={{ flexShrink: 0, fontWeight: 700 }}>⚠</span>
+        <span>{_WARNING}</span>
+      </div>
+
+      {/* ── Idle: controls + generate button ───────────────────── */}
+      {isIdle && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          {/* max_campaigns */}
+          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            <label
+              htmlFor="brief-max"
+              style={{ fontSize: 12, color: mutedFg, minWidth: 110 }}
+            >
+              Max campaigns
+            </label>
+            <select
+              id="brief-max"
+              value={maxCampaigns}
+              onChange={(e) => setMaxCampaigns(Number(e.target.value))}
+              style={{
+                padding: "4px 8px",
+                borderRadius: 5,
+                border: `1px solid ${inputBorder}`,
+                background: inputBg,
+                color: inputFg,
+                fontSize: 12,
+              }}
+            >
+              {[5, 10, 15, 20, 25].map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Time window */}
+          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            <label
+              htmlFor="brief-tw-start"
+              style={{ fontSize: 12, color: mutedFg, minWidth: 110 }}
+            >
+              Time window
+            </label>
+            <input
+              id="brief-tw-start"
+              type="date"
+              value={twStart}
+              onChange={(e) => setTwStart(e.target.value)}
+              style={{
+                padding: "4px 8px",
+                borderRadius: 5,
+                border: `1px solid ${inputBorder}`,
+                background: inputBg,
+                color: inputFg,
+                fontSize: 12,
+              }}
+            />
+            <span style={{ fontSize: 12, color: mutedFg }}>to</span>
+            <input
+              id="brief-tw-end"
+              type="date"
+              value={twEnd}
+              onChange={(e) => setTwEnd(e.target.value)}
+              style={{
+                padding: "4px 8px",
+                borderRadius: 5,
+                border: `1px solid ${inputBorder}`,
+                background: inputBg,
+                color: inputFg,
+                fontSize: 12,
+              }}
+            />
+            {(twStart || twEnd) && (
+              <button
+                onClick={() => { setTwStart(""); setTwEnd(""); }}
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  fontSize: 11,
+                  color: mutedFg,
+                  padding: "2px 4px",
+                }}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+
+          <div>
+            <button
+              onClick={handleGenerate}
+              style={{
+                padding: "7px 16px",
+                borderRadius: 6,
+                border: `1px solid ${btnBorder}`,
+                background: btnBg,
+                color: btnFg,
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              Generate Brief
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Loading / polling ───────────────────────────────────── */}
+      {isLoading && (
+        <div style={{ fontSize: 12, color: mutedFg, fontStyle: "italic" }}>
+          {phase === "submitting" ? "Submitting request…" : "Generating brief — polling for result…"}
+        </div>
+      )}
+
+      {/* ── Error ───────────────────────────────────────────────── */}
+      {isError && (
+        <div style={{ fontSize: 12, color: errorFg, marginBottom: 8 }}>
+          {errorMsg ?? "Brief generation failed."}
+        </div>
+      )}
+
+      {/* ── Done ────────────────────────────────────────────────── */}
+      {isDone && result && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {result.rejected ? (
+            <div style={{ fontSize: 12, color: errorFg }}>
+              Brief unavailable — output did not pass safety checks.
+              {result.rejection_reason === "ip_detected" && (
+                <span style={{ marginLeft: 4 }}>(Output contained an IP address pattern.)</span>
+              )}
+              {result.rejection_reason === "no_campaigns" && (
+                <span style={{ marginLeft: 4 }}>(No campaigns matched the selected criteria.)</span>
+              )}
+            </div>
+          ) : (
+            <>
+              <p
+                style={{
+                  fontSize: 13,
+                  color: fg,
+                  lineHeight: 1.65,
+                  margin: 0,
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                }}
+              >
+                {result.summary}
+              </p>
+              {result.truncated && (
+                <span style={{ fontSize: 11, color: mutedFg, fontStyle: "italic" }}>
+                  Output truncated to 2,500 characters.
+                </span>
+              )}
+            </>
+          )}
+
+          {/* ── Metadata footer ─────────────────────────────────── */}
+          <div
+            style={{
+              display: "flex",
+              gap: 14,
+              flexWrap: "wrap",
+              fontSize: 11,
+              color: mutedFg,
+              borderTop: `1px solid ${dividerColor}`,
+              paddingTop: 8,
+            }}
+          >
+            {result.generated_at && (
+              <span>Generated {new Date(result.generated_at).toLocaleTimeString()}</span>
+            )}
+            {result.campaign_count != null && (
+              <span>Campaigns: {result.campaign_count}</span>
+            )}
+            {result.source_records?.campaign_count != null && (
+              <span>Source campaigns: {result.source_records.campaign_count}</span>
+            )}
+            {result.source_records?.time_window_start && (
+              <span>
+                Window: {result.source_records.time_window_start.slice(0, 10)}
+                {" — "}
+                {result.source_records.time_window_end?.slice(0, 10)}
+              </span>
+            )}
+            {result.ai_backend && (
+              <span>Backend: {result.ai_backend}</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ── Done but result is null (edge case) ─────────────────── */}
+      {isDone && !result && (
+        <div style={{ fontSize: 12, color: errorFg }}>
+          Brief completed but no result data was returned.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/dashboard/src/lib/api.js
+++ b/ui/dashboard/src/lib/api.js
@@ -54,3 +54,30 @@ export async function postCampaignSummary(campaignId) {
   const body = await r.json();
   return { status: r.status, data: body };
 }
+
+export async function postCampaignBrief({
+  max_campaigns = 10,
+  time_window_start = null,
+  time_window_end = null,
+} = {}) {
+  const body = { max_campaigns };
+  if (time_window_start && time_window_end) {
+    body.time_window_start = time_window_start;
+    body.time_window_end = time_window_end;
+  }
+  const r = await fetch('/api/campaigns/brief', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-api-key': 'dev-123' },
+    body: JSON.stringify(body),
+  });
+  const data = await r.json();
+  return { status: r.status, data };
+}
+
+export async function getJob(jobId) {
+  const r = await fetch(`/api/jobs/${encodeURIComponent(jobId)}`, {
+    headers: { 'x-api-key': 'dev-123' },
+  });
+  if (!r.ok) throw new Error(`jobs/${jobId} ${r.status}`);
+  return r.json();
+}


### PR DESCRIPTION
## Summary

- Extends `POST /api/campaigns/brief` to accept optional `time_window_start` / `time_window_end` (ISO 8601 strings). Both-or-neither enforced; start < end enforced; invalid ISO strings rejected — all at 422 before job creation.
- Runner filters campaigns by `last_seen` within the window after status filter, then applies `max_campaigns` cap. `source_records` includes `time_window_start`/`time_window_end` when a window is provided; omitted otherwise (backward compatible).
- New `CampaignBriefPanel` React component: idle → submitting → polling → done/error state machine. Warning disclaimer always visible. Operator must click "Generate Brief" — no auto-generation. Optional date-range inputs (converted to ISO 8601) + max_campaigns selector. Polls `GET /api/jobs/{job_id}` every 2 s until terminal state, max 60 polls. 429/422/network error handling. Plain text output only — no `dangerouslySetInnerHTML`, no markdown, no localStorage.
- Added `postCampaignBrief` and `getJob` to `lib/api.js`. Integrated panel into `App.jsx` above the Campaigns section.

## Test plan

- [ ] 13 new backend tests in `test_analyze_endpoints.py`: both-side-required, start-after-end, invalid ISO, campaign inside/outside window, source_records fields, max_campaigns after filter, empty-window → no_campaigns, backward compat
- [ ] Full suite: 1275 passed, 0 failures
- [ ] Pre-commit: all hooks pass
- [ ] ESLint: 0 errors on changed frontend files

## Out of scope (deferred)

- Auto-generation / scheduling
- Markdown rendering of briefs
- Brief history / AI output persistence changes
- Streaming
- localStorage persistence
- Conversational AI