### PR TITLE
docs: close Phase 6 and prepare actor identity foundations

### DIFF
--- a/app/db/connection.py
+++ b/app/db/connection.py
@@ -313,6 +313,38 @@ def create_all_tables(engine: Engine) -> None:
                 "created_at TEXT NOT NULL)"
             )
         )
+
+        # Phase 6 Group D — actor identity schema foundations for Phase 7.
+        # actor_profiles and campaign_lineage are empty containers.  No row is
+        # created automatically by clustering, lifecycle, or AI code paths.
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS actor_profiles ("
+                "id TEXT PRIMARY KEY, "
+                "display_name TEXT NOT NULL, "
+                "confidence REAL NOT NULL DEFAULT 0.5, "
+                "status TEXT NOT NULL DEFAULT 'active', "
+                "representative_fingerprint_json TEXT, "
+                "behavioral_stability_json TEXT, "
+                "notes TEXT, "
+                "created_at TEXT NOT NULL, "
+                "updated_at TEXT NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS campaign_lineage ("
+                "id TEXT PRIMARY KEY, "
+                "actor_profile_id TEXT NOT NULL, "
+                "campaign_id TEXT NOT NULL, "
+                "relationship_type TEXT NOT NULL, "
+                "confidence REAL NOT NULL DEFAULT 0.5, "
+                "evidence_json TEXT, "
+                "created_at TEXT NOT NULL, "
+                "FOREIGN KEY (actor_profile_id) REFERENCES actor_profiles(id), "
+                "FOREIGN KEY (campaign_id) REFERENCES campaigns(id))"
+            )
+        )
         conn.commit()
 
 

--- a/app/db/migrations/versions/0010_phase6d_actor_identity.py
+++ b/app/db/migrations/versions/0010_phase6d_actor_identity.py
@@ -1,0 +1,69 @@
+"""Phase 6 Group D — actor identity schema foundations.
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-05-28
+
+Creates two empty schema foundations for Phase 7 actor-level intelligence:
+
+  actor_profiles  — one row per inferred actor identity. Populated only by
+                    explicit operator or future automated assignment.  No row
+                    is created automatically during clustering or campaign
+                    lifecycle transitions.
+
+  campaign_lineage — links a campaign to an actor_profile with an explicit
+                     relationship_type and analyst-supplied evidence.  Does not
+                     mutate campaign membership, clustering decisions, or any
+                     existing table.
+
+Intentionally absent in this migration:
+  - No automatic actor attribution logic
+  - No campaign merging or splitting
+  - No AI actor naming
+  - No federation endpoints
+  - No API endpoints (deferred to Phase 7)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0010"
+down_revision: str | None = "0009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "actor_profiles",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("display_name", sa.Text, nullable=False),
+        sa.Column("confidence", sa.Real, nullable=False, server_default="0.5"),
+        sa.Column("status", sa.Text, nullable=False, server_default="'active'"),
+        sa.Column("representative_fingerprint_json", sa.Text, nullable=True),
+        sa.Column("behavioral_stability_json", sa.Text, nullable=True),
+        sa.Column("notes", sa.Text, nullable=True),
+        sa.Column("created_at", sa.Text, nullable=False),
+        sa.Column("updated_at", sa.Text, nullable=False),
+    )
+    op.create_table(
+        "campaign_lineage",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("actor_profile_id", sa.Text, nullable=False),
+        sa.Column("campaign_id", sa.Text, nullable=False),
+        sa.Column("relationship_type", sa.Text, nullable=False),
+        sa.Column("confidence", sa.Real, nullable=False, server_default="0.5"),
+        sa.Column("evidence_json", sa.Text, nullable=True),
+        sa.Column("created_at", sa.Text, nullable=False),
+        sa.ForeignKeyConstraint(["actor_profile_id"], ["actor_profiles.id"]),
+        sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("campaign_lineage")
+    op.drop_table("actor_profiles")

--- a/app/db/repositories/actor.py
+++ b/app/db/repositories/actor.py
@@ -1,0 +1,227 @@
+"""Actor identity repository — Phase 6 Group D schema foundations.
+
+Read/write methods for actor_profiles and campaign_lineage tables.
+
+These tables are empty scaffolding created in Phase 6 to prepare Phase 7
+actor-level intelligence without implementing actor attribution yet.
+
+Invariants:
+  - No method here performs automatic actor attribution.
+  - No method here merges or splits campaigns.
+  - No method here reads from or writes to the clustering path.
+  - campaign_lineage records are created only by explicit operator or future
+    Phase 7 automation — never by clustering.py or any existing job runner.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import text
+
+from app.db.repositories._base import RepositoryBase
+
+
+def _actor_row_to_dict(row) -> dict[str, Any]:
+    return {
+        "id": row[0],
+        "display_name": row[1],
+        "confidence": row[2],
+        "status": row[3],
+        "representative_fingerprint_json": row[4],
+        "behavioral_stability_json": row[5],
+        "notes": row[6],
+        "created_at": row[7],
+        "updated_at": row[8],
+    }
+
+
+def _lineage_row_to_dict(row) -> dict[str, Any]:
+    return {
+        "id": row[0],
+        "actor_profile_id": row[1],
+        "campaign_id": row[2],
+        "relationship_type": row[3],
+        "confidence": row[4],
+        "evidence_json": row[5],
+        "created_at": row[6],
+    }
+
+
+_ACTOR_SELECT = """
+    SELECT id, display_name, confidence, status,
+           representative_fingerprint_json, behavioral_stability_json,
+           notes, created_at, updated_at
+    FROM actor_profiles
+"""
+
+_LINEAGE_SELECT = """
+    SELECT id, actor_profile_id, campaign_id, relationship_type,
+           confidence, evidence_json, created_at
+    FROM campaign_lineage
+"""
+
+
+class ActorRepository(RepositoryBase):
+    def create_actor_profile(
+        self,
+        *,
+        actor_id: str | None = None,
+        display_name: str,
+        confidence: float = 0.5,
+        status: str = "active",
+        representative_fingerprint_json: dict | str | None = None,
+        behavioral_stability_json: dict | str | None = None,
+        notes: str | None = None,
+        created_at: str | None = None,
+        updated_at: str | None = None,
+    ) -> dict[str, Any]:
+        """Insert a new actor_profile row and return it.
+
+        actor_id is caller-generated or auto-assigned as UUID4.
+        No automatic actor attribution occurs here or downstream.
+        """
+        aid = actor_id or str(uuid.uuid4())
+        now = created_at or datetime.now(UTC).isoformat()
+        updated = updated_at or now
+
+        rep_fp = (
+            json.dumps(representative_fingerprint_json)
+            if isinstance(representative_fingerprint_json, dict)
+            else representative_fingerprint_json
+        )
+        beh_stab = (
+            json.dumps(behavioral_stability_json)
+            if isinstance(behavioral_stability_json, dict)
+            else behavioral_stability_json
+        )
+
+        self._session.execute(
+            text("""
+                INSERT INTO actor_profiles (
+                    id, display_name, confidence, status,
+                    representative_fingerprint_json, behavioral_stability_json,
+                    notes, created_at, updated_at
+                ) VALUES (
+                    :id, :display_name, :confidence, :status,
+                    :representative_fingerprint_json, :behavioral_stability_json,
+                    :notes, :created_at, :updated_at
+                )
+            """),
+            {
+                "id": aid,
+                "display_name": display_name,
+                "confidence": confidence,
+                "status": status,
+                "representative_fingerprint_json": rep_fp,
+                "behavioral_stability_json": beh_stab,
+                "notes": notes,
+                "created_at": now,
+                "updated_at": updated,
+            },
+        )
+        return self.get_actor_profile(aid)  # type: ignore[return-value]
+
+    def get_actor_profile(self, actor_id: str) -> dict[str, Any] | None:
+        """Return a single actor_profile row by id, or None if not found."""
+        row = self._session.execute(
+            text(_ACTOR_SELECT + "WHERE id = :id"),
+            {"id": actor_id},
+        ).fetchone()
+        return _actor_row_to_dict(row) if row is not None else None
+
+    def list_actor_profiles(
+        self,
+        *,
+        status: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return actor_profiles ordered by created_at DESC.
+
+        Optionally filtered by status (e.g. 'active', 'archived').
+        """
+        params: dict[str, Any] = {"limit": limit}
+        where = ""
+        if status is not None:
+            where = "WHERE status = :status "
+            params["status"] = status
+        rows = self._session.execute(
+            text(_ACTOR_SELECT + where + "ORDER BY created_at DESC LIMIT :limit"),
+            params,
+        ).fetchall()
+        return [_actor_row_to_dict(r) for r in rows]
+
+    def link_campaign_to_actor(
+        self,
+        *,
+        lineage_id: str | None = None,
+        actor_profile_id: str,
+        campaign_id: str,
+        relationship_type: str,
+        confidence: float = 0.5,
+        evidence_json: dict | str | None = None,
+        created_at: str | None = None,
+    ) -> dict[str, Any]:
+        """Insert a campaign_lineage row linking a campaign to an actor.
+
+        Does not modify campaign membership, clustering decisions, or any
+        existing table outside campaign_lineage.
+        """
+        lid = lineage_id or str(uuid.uuid4())
+        now = created_at or datetime.now(UTC).isoformat()
+        ev_str = json.dumps(evidence_json) if isinstance(evidence_json, dict) else evidence_json
+
+        self._session.execute(
+            text("""
+                INSERT INTO campaign_lineage (
+                    id, actor_profile_id, campaign_id,
+                    relationship_type, confidence, evidence_json, created_at
+                ) VALUES (
+                    :id, :actor_profile_id, :campaign_id,
+                    :relationship_type, :confidence, :evidence_json, :created_at
+                )
+            """),
+            {
+                "id": lid,
+                "actor_profile_id": actor_profile_id,
+                "campaign_id": campaign_id,
+                "relationship_type": relationship_type,
+                "confidence": confidence,
+                "evidence_json": ev_str,
+                "created_at": now,
+            },
+        )
+        row = self._session.execute(
+            text(_LINEAGE_SELECT + "WHERE id = :id"),
+            {"id": lid},
+        ).fetchone()
+        return _lineage_row_to_dict(row)  # type: ignore[arg-type]
+
+    def list_campaign_lineage(
+        self,
+        *,
+        actor_profile_id: str | None = None,
+        campaign_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return campaign_lineage rows, newest first.
+
+        Filter by actor_profile_id, campaign_id, or both.
+        """
+        params: dict[str, Any] = {"limit": limit}
+        clauses: list[str] = []
+        if actor_profile_id is not None:
+            clauses.append("actor_profile_id = :actor_profile_id")
+            params["actor_profile_id"] = actor_profile_id
+        if campaign_id is not None:
+            clauses.append("campaign_id = :campaign_id")
+            params["campaign_id"] = campaign_id
+        where = ("WHERE " + " AND ".join(clauses) + " ") if clauses else ""
+        rows = self._session.execute(
+            text(_LINEAGE_SELECT + where + "ORDER BY created_at DESC LIMIT :limit"),
+            params,
+        ).fetchall()
+        return [_lineage_row_to_dict(r) for r in rows]

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -29,6 +29,7 @@ No FastAPI, router, or application imports belong in the sub-modules.
 
 from __future__ import annotations
 
+from app.db.repositories.actor import ActorRepository
 from app.db.repositories.ai_audit_log import AiAuditLogRepository
 from app.db.repositories.ai_outputs import AiOutputRepository
 from app.db.repositories.campaign import CampaignRepository
@@ -50,9 +51,10 @@ class EventRepository(
     AiOutputRepository,
     AiAuditLogRepository,
     FingerprintHistoryRepository,
+    ActorRepository,
 ):
     """
-    Unified repository class. Inherits all SQL methods from the nine concern
+    Unified repository class. Inherits all SQL methods from the ten concern
     mixins. Callers see a single object with the full method surface; the
     internal split is an organisation detail invisible to callers.
 
@@ -60,5 +62,6 @@ class EventRepository(
                 IntelligenceRepository → FingerprintRepository →
                 CampaignRepository → JobRepository →
                 AiOutputRepository → AiAuditLogRepository →
-                FingerprintHistoryRepository → RepositoryBase → object
+                FingerprintHistoryRepository → ActorRepository →
+                RepositoryBase → object
     """

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 **Document type:** Technical architecture reference
 **Audience:** Engineers, autonomous agents, contributors
-**Last reviewed:** 2026-05-26 (Phase 5)
+**Last reviewed:** 2026-05-28 (Phase 6)
 
 ---
 
@@ -19,14 +19,17 @@ Browser (React 19 + Vite)
   │     └── POST /api/login → JWT token stored in localStorage
   │
   ├── Dashboard (authenticated)
-  │     ├── GET /api/stats                      → KPI counters
-  │     ├── GET /api/iocs/pf.conf               → Firewall block table preview
-  │     ├── GET /api/events                     → Recent events table + trends chart
-  │     ├── GET /api/intelligence/ips           → Top Source IPs panel
-  │     ├── GET /api/intelligence/top-countries → Top Countries panel
-  │     ├── GET /api/intelligence/top-asns      → Top ASNs panel
-  │     ├── GET /api/campaigns                  → Campaign Intelligence panel
-  │     └── POST /api/campaigns/{id}/summary    → CampaignAiPanel (operator-triggered)
+  │     ├── GET /api/stats                                   → KPI counters
+  │     ├── GET /api/iocs/pf.conf                            → Firewall block table preview
+  │     ├── GET /api/events                                  → Recent events table + trends chart
+  │     ├── GET /api/intelligence/ips                        → Top Source IPs panel
+  │     ├── GET /api/intelligence/top-countries              → Top Countries panel
+  │     ├── GET /api/intelligence/top-asns                   → Top ASNs panel
+  │     ├── GET /api/campaigns                               → Campaign Intelligence panel
+  │     ├── POST /api/campaigns/{id}/summary                 → CampaignAiPanel (operator-triggered, 202)
+  │     ├── POST /api/campaigns/brief                        → CampaignBriefPanel (operator-triggered, 202)
+  │     ├── GET /api/jobs/{job_id}                           → async polling for AI job status
+  │     └── GET /api/campaigns/{id}/ai-outputs              → CampaignAiOutputHistory panel
   │
   └── Auto-refresh: 10–30s interval per component
 
@@ -42,7 +45,11 @@ FastAPI Backend (app/)
   │     ├── intelligence.py     GET /api/intelligence/* (top IPs, countries, ASNs, IP detail)
   │     ├── exports.py          GET /api/exports/attack-navigator, /api/exports/stix
   │     ├── campaigns.py        GET /api/campaigns, /api/campaigns/{id}, /api/campaigns/{id}/observations
-  │     └── analyze.py          POST /api/campaigns/{id}/summary, POST /api/campaigns/brief
+  │     │                       GET /api/campaigns/uncertain-associations
+  │     │                       POST /api/campaigns/uncertain-associations/{id}/review
+  │     ├── analyze.py          POST /api/campaigns/{id}/summary (202), POST /api/campaigns/brief (202)
+  │     ├── jobs.py             GET /api/jobs/{job_id}, GET /api/jobs
+  │     └── ai_outputs.py       GET /api/ai/outputs/{id}, GET /api/campaigns/{id}/ai-outputs
   ├── app/ai/
   │     ├── __init__.py          Public API — re-exports all AI layer symbols
   │     ├── backend.py           AIBackend ABC + DisabledAIBackend, MockAIBackend,
@@ -61,12 +68,17 @@ FastAPI Backend (app/)
   │     ├── connection.py        SQLAlchemy engine, session factory, create_all_tables()
   │     ├── repository.py        EventRepository public facade (re-exports mixin composition)
   │     └── repositories/
-  │           ├── _base.py            RepositoryBase (session holder)
-  │           ├── read.py             ReadRepository — event and source_ip queries
-  │           ├── write.py            WriteRepository — ingest, audit_log
-  │           ├── intelligence.py     IntelligenceRepository — top IPs, countries, ASNs, STIX/ATT&CK queries
-  │           ├── fingerprint.py      FingerprintRepository — behavioral fingerprint upserts and lookups
-  │           └── campaign.py         CampaignRepository — campaign CRUD, members, observations, export queries
+  │           ├── _base.py               RepositoryBase (session holder)
+  │           ├── read.py                ReadRepository — event and source_ip queries
+  │           ├── write.py               WriteRepository — ingest, audit_log
+  │           ├── intelligence.py        IntelligenceRepository — top IPs, countries, ASNs, STIX/ATT&CK queries
+  │           ├── fingerprint.py         FingerprintRepository — behavioral fingerprint upserts and lookups
+  │           ├── fingerprint_history.py FingerprintHistoryRepository — append-only longitudinal snapshots
+  │           ├── campaign.py            CampaignRepository — campaign CRUD, members, observations, export queries
+  │           ├── jobs.py                JobRepository — processing_jobs CRUD, dedup, TTL enforcement
+  │           ├── ai_outputs.py          AiOutputRepository — write-once AI output records
+  │           ├── ai_audit_log.py        AiAuditLogRepository — AI call metadata audit records
+  │           └── actor.py               ActorRepository — actor_profiles and campaign_lineage (Phase 7 foundations)
   ├── app/schemas/
   │     └── models.py           RawEvent, HoneypotEvent, IngestRequest, IngestReceipt
   ├── app/utils/
@@ -156,15 +168,18 @@ ui/dashboard/
     pages/
       Login.jsx          Login form → POST /api/login → stores JWT in localStorage
     components/
-      EventTrends.jsx      Recharts line chart of events over time
-      RecentEvents.jsx     Tabular view of most recent events
-      IntelligenceIPs.jsx  Top Source IPs table with expandable IP detail rows
-      TopCountries.jsx     Top Countries panel (country, event count, unique IPs)
-      TopASNs.jsx          Top ASNs panel (ASN, organization, event count, unique IPs)
-      Campaigns.jsx        Campaign Intelligence panel (lifecycle badges, confidence bars, expandable detail + AI panel)
-      CampaignAiPanel.jsx  Operator-triggered AI summary panel; warning always visible; never auto-generates
+      EventTrends.jsx             Recharts line chart of events over time
+      RecentEvents.jsx            Tabular view of most recent events
+      IntelligenceIPs.jsx         Top Source IPs table with expandable IP detail rows
+      TopCountries.jsx            Top Countries panel (country, event count, unique IPs)
+      TopASNs.jsx                 Top ASNs panel (ASN, organization, event count, unique IPs)
+      Campaigns.jsx               Campaign Intelligence panel (lifecycle badges, confidence bars, expandable detail)
+      CampaignAiPanel.jsx         Operator-triggered AI summary panel; warning always visible; never auto-generates
+      CampaignBriefPanel.jsx      Multi-campaign threat brief panel; time-window inputs; async 202 polling
+      CampaignAiOutputHistory.jsx Persisted AI output history per campaign; regenerate button; historical warning
     lib/
-      api.js               Authenticated fetch helpers (stats, events, intelligence, exports, campaigns, AI summary)
+      api.js               Authenticated fetch helpers (stats, events, intelligence, exports, campaigns,
+                           AI summary/brief, job polling, AI output history)
     utils/
       format.js          Date/time formatting utilities
     index.css            Global styles + dark/light mode variables
@@ -212,11 +227,11 @@ For high-volume distributed deployments, an event streaming layer (Redis Streams
 
 ---
 
-## AI Reasoning Architecture (Phase 5)
+## AI Reasoning Architecture (Phase 5–6)
 
-Phase 5 added the `app/ai/` module as a read-only reasoning layer over the existing campaign data model. The AI layer is strictly additive: removing it leaves the rest of the system fully functional.
+Phase 5 added the `app/ai/` module as a read-only reasoning layer over the existing campaign data model. Phase 6 made that layer async, persistent, and auditable. The AI layer is strictly additive: removing it leaves the rest of the system fully functional.
 
-### AI request flow
+### AI request flow (Phase 6 — async)
 
 ```
 Operator (dashboard or API client)
@@ -225,7 +240,20 @@ Operator (dashboard or API client)
     ▼
 app/routers/analyze.py
     │  Privacy check (PRIVACY_MODE + AI_BACKEND=claude → 422)
+    │  Campaign existence check (summary only; 404 if not found)
+    │  Deduplication check (summary only; returns existing job_id if pending/running)
+    │  Per-operator rate limit check (DB-backed; 429 + audit record if exceeded)
+    │  Create processing_jobs row (status=pending)
+    │
+    ▼
+HTTP 202 Accepted  { job_id, status: "pending", poll_url }
+    │
+    │  FastAPI BackgroundTasks executes the job function after HTTP response sent
+    ▼
+app/jobs/runner.py
+    │  Set job status=running
     │  Read-only DB fetch via EventRepository (campaign, fingerprint, observations)
+    │  Apply time-window filter if provided (brief only)
     │
     ▼
 app/ai/prompt_builder.py
@@ -234,7 +262,7 @@ app/ai/prompt_builder.py
     │
     ▼
 app/ai/backend.py  (get_ai_backend())
-    │  DisabledAIBackend → AIDisabledError → 503
+    │  DisabledAIBackend → job fails with AI features disabled
     │  OllamaAIBackend   → POST http://OLLAMA_HOST/api/generate
     │  ClaudeAIBackend   → anthropic SDK → Anthropic API
     │
@@ -243,23 +271,27 @@ app/ai/safety.py  (validate_ai_output)
     │  Reject if empty, contains IP pattern, or exceeds length limit
     │
     ▼
-JSON response envelope (no DB writes at any step)
+AiOutputRepository.create_ai_output()
+    │  Write immutable row to ai_outputs (content, backend, prompt_hash, source_records, safety_flags, etc.)
+    │  Write metadata row to ai_audit_log (no content — byte counts and latency only)
+    │
+    ▼
+Job status=completed, ai_output_id set in processing_jobs
+    │
+    │  Operator polls GET /api/jobs/{job_id} until terminal state
+    │  On completed: fetch result from GET /api/ai/outputs/{ai_output_id}
+    │  Or: view full history at GET /api/campaigns/{id}/ai-outputs
 ```
 
 ### AI layer isolation invariants
 
-- The AI layer never calls `get_session()` for writes. No AI code path modifies the database.
+- The AI layer never calls `get_session()` for writes to campaign, fingerprint, event, or observation tables.
 - The ingest path (`app/routers/ingest.py`, `app/intelligence/`) has no imports from `app/ai/`.
 - `app/intelligence/clustering.py` is immutable from the AI layer's perspective. AI may describe similarity scores; it cannot change them.
 - `MockAIBackend` exists exclusively for test injection. It must not appear in production code paths.
+- AI outputs are never fed back into any prompt. The chain from `ai_outputs` back to the prompt builder is never traversed.
 
-### Phase 6 AI infrastructure prerequisites
-
-1. **Async processing:** AI analysis must eventually run asynchronously to avoid blocking the API under load. A background task queue (FastAPI `BackgroundTasks` initially, Celery or asyncio worker later) is required.
-2. **Output persistence:** A new `ai_outputs` table is needed before output history, audit requirements, or operator recall are implementable.
-3. **AI call audit logging:** Every external AI API call should be logged to `audit_log` with timestamp and payload byte count.
-
-See [AI_ROADMAP.md](AI_ROADMAP.md) for the broader AI integration strategy and [PHASE_5_CLOSEOUT.md](PHASE_5_CLOSEOUT.md) for the Phase 5 delivery record.
+See [AI_ROADMAP.md](AI_ROADMAP.md) for the broader AI integration strategy, [PHASE_5_CLOSEOUT.md](PHASE_5_CLOSEOUT.md) for the Phase 5 delivery record, and [PHASE_6_CLOSEOUT.md](PHASE_6_CLOSEOUT.md) for the Phase 6 delivery record.
 
 ---
 

--- a/docs/PHASE_6_BLUEPRINT.md
+++ b/docs/PHASE_6_BLUEPRINT.md
@@ -1,7 +1,7 @@
 # LegionTrap TI — Phase 6 Architecture Blueprint
 
 **Document type:** Pre-implementation architecture blueprint
-**Status:** Under review — do not begin implementation until this document is approved
+**Status:** Complete — see [PHASE_6_CLOSEOUT.md](PHASE_6_CLOSEOUT.md) for the delivery record
 **Audience:** Engineers, contributors
 **Date:** 2026-05-27
 

--- a/docs/PHASE_6_CLOSEOUT.md
+++ b/docs/PHASE_6_CLOSEOUT.md
@@ -1,0 +1,244 @@
+# Phase 6 Close-Out — Behavioral Memory and Campaign Intelligence
+
+**Document type:** Phase completion record and architectural handoff
+**Audience:** Engineers, contributors
+**Date:** 2026-05-28
+
+---
+
+## 1. What Phase 6 Delivered
+
+Phase 6 closed the infrastructure and accountability gaps that Phase 5 left open, then deepened the behavioral memory model in preparation for Phase 7 actor-level intelligence.
+
+Phase 5 proved that AI-assisted analysis could produce useful natural-language intelligence from structured campaign data. Phase 6 made that AI layer accountable: every output is now persisted, every API call is audited, every job is trackable, and every operator-triggered request returns immediately with a job ID. Phase 6 also extended the memory model from a point-in-time fingerprint snapshot to a longitudinal history that Phase 7 can use for drift and metamorphic detection.
+
+### Pull Requests
+
+| PR | Branch | Group | Title |
+|----|--------|-------|-------|
+| #50 | `docs/phase6-blueprint` | — | Phase 6 architecture blueprint |
+| #51 | `feat/phase6-processing-jobs` | A | Processing job infrastructure and async AI workflow |
+| #52 | `feat/phase6-ai-output-persistence` | A | Persist immutable AI outputs |
+| #53 | `feat/phase6-ai-audit-rate-limit` | A | AI audit logging and rate limiting |
+| #54 | `feat/phase6-fingerprint-history` | B | Fingerprint history and representative campaign fingerprints |
+| #55 | `feat/phase6-behavioral-stability` | B | Behavioral stability scoring |
+| #56 | `feat/phase6-uncertain-association-review` | B | Uncertain association review queue |
+| #57 | `feat/phase6-brief-time-window` | C | Time-window campaign briefs and dashboard brief panel |
+| #58 | `feat/phase6-ai-output-history` | C | Campaign AI output history panel |
+| D1+D2 | `feat/phase6-closeout` | D | Actor identity schema foundations and Phase 6 close-out |
+
+---
+
+## 2. What Changed Architecturally
+
+Phase 6 introduced five new database tables, four new repository modules, three new API routers, and three new dashboard components. The ingest path, clustering algorithm, export layer, and privacy model are unchanged.
+
+**New tables (Phase 6):**
+
+| Table | Group | Purpose |
+|-------|-------|---------|
+| `processing_jobs` | A | Central coordination for all async AI operations |
+| `ai_outputs` | A | Immutable, write-once record of every AI-generated artifact |
+| `ai_audit_log` | A | Metadata-only audit record for every external AI API call |
+| `fingerprint_history` | B | Append-only longitudinal snapshots of behavioral fingerprints |
+| `actor_profiles` | D | Empty foundation for Phase 7 actor-level intelligence |
+| `campaign_lineage` | D | Empty foundation linking campaigns to actor profiles |
+
+**Schema additions to existing tables:**
+
+| Table | Column | Group | Purpose |
+|-------|--------|-------|---------|
+| `campaign_observations` | `analyst_review_json` | B | Analyst interpretation of uncertain associations |
+| `campaigns` | `representative_fingerprint_json` | B | Cluster centroid fingerprint |
+| `campaigns` | `behavioral_stability_json` | B | Longitudinal stability metrics |
+
+**New routers:**
+
+| File | Endpoints | Group |
+|------|-----------|-------|
+| `app/routers/jobs.py` | `GET /api/jobs/{job_id}`, `GET /api/jobs` | A |
+| `app/routers/ai_outputs.py` | `GET /api/ai/outputs/{id}`, `GET /api/campaigns/{id}/ai-outputs` | A |
+| Additions to `campaigns.py` | `GET /api/campaigns/uncertain-associations`, `POST /api/campaigns/uncertain-associations/{id}/review` | B |
+
+**API contract change:** `POST /api/campaigns/{id}/summary` and `POST /api/campaigns/brief` changed from synchronous 200 OK to 202 Accepted with `job_id` + `poll_url`. This is a permanent, breaking change to the async contract.
+
+**New repository modules:** `ActorRepository`, `AiAuditLogRepository`, `AiOutputRepository`, `FingerprintHistoryRepository`, `JobRepository` — all added as mixins to `EventRepository`.
+
+---
+
+## 3. Async/Job Infrastructure Summary
+
+Phase 5 AI calls were synchronous and untracked. Phase 6 Group A replaced this with a permanent async contract backed by the `processing_jobs` table.
+
+**202 Accepted contract:**
+- `POST /api/campaigns/{id}/summary` returns immediately with `{ job_id, status: "pending", poll_url }`.
+- `POST /api/campaigns/brief` returns immediately with the same shape.
+- Callers poll `GET /api/jobs/{job_id}` until `status` reaches a terminal state: `completed` or `failed`.
+- Terminal states are permanent — they never revert.
+
+**Job execution:** FastAPI `BackgroundTasks` runs the job function in the same process after the HTTP response is sent. The runner sets `status=running` on start, `status=completed` on success with `ai_output_id` set, and `status=failed` with `error_message` on any exception.
+
+**Deduplication:** `POST /api/campaigns/{id}/summary` checks for an existing `pending` or `running` job for the same campaign before creating a new one. If a duplicate exists, the existing `job_id` is returned immediately. No duplicate jobs are created.
+
+**TTL enforcement:** `GET /api/jobs/{job_id}` applies a TTL check on read: a job stuck in `running` for longer than `AI_TIMEOUT_SECONDS × 2` is transitioned to `failed` before the response is built. This prevents ghost records from accumulating after process restarts.
+
+**Rate limiting:** AI endpoints count jobs created by the same operator in the last 60 seconds via `processing_jobs`. The limit is `AI_MAX_REQUESTS_PER_MINUTE` (default: 10). Rate-limited requests write to `ai_audit_log` in a separate session before raising HTTP 429, so the audit record commits even though the main request fails.
+
+---
+
+## 4. AI Persistence and Audit Summary
+
+**AI output persistence (`ai_outputs`):**
+
+Every AI-generated artifact is written to `ai_outputs` before being returned. The table is write-once: there is no `UPDATE` or `DELETE` path. Fields include:
+
+- `content` — the raw AI text
+- `backend`, `model_name` — which AI system produced it
+- `prompt_hash` — SHA-256 of the assembled prompt (for audit; prompt content is never stored)
+- `source_records_json` — the specific data used as AI context
+- `safety_flags_json` — any safety check results
+- `rejected`, `rejection_reason` — whether the output passed safety validation
+- `truncated` — whether the output exceeded the length limit
+- `data_quality_score` — a 0–1 quality metric from the runner
+- `generated_at`, `triggered_by` — provenance
+
+The `ai_output_id` foreign key in `processing_jobs` links the job to its persisted result.
+
+**AI audit logging (`ai_audit_log`):**
+
+Every external AI API call writes a metadata-only record: timestamp, job_id, backend, model, operation type, payload bytes, response bytes, latency in milliseconds, and status. Content is never stored — only byte counts. This answers the compliance question "what data left this system and when" without reconstructing prompts.
+
+Rate-limited requests are logged with `status=rate_limited`. Rejected outputs are logged with `status=rejected`. Every call to the AI backend produces one audit row regardless of outcome.
+
+---
+
+## 5. Behavioral Memory Improvements
+
+**Fingerprint history (`fingerprint_history`):**
+
+The `fingerprint_history` table appends a snapshot of `behavioral_fingerprints` every time a fingerprint is recomputed for a source IP. Each row is immutable and append-only. The history enables Phase 7 behavioral drift detection — comparing today's fingerprint against the fingerprint from 6 months ago to detect deliberate behavioral adaptation.
+
+**Representative campaign fingerprints:**
+
+The `campaigns` table gained `representative_fingerprint_json`, which stores the cluster centroid fingerprint — the most representative behavioral pattern across all member IPs. This is the reference fingerprint used for reactivation detection: an incoming fingerprint is compared against the representative fingerprint of all existing campaigns, not individual member fingerprints.
+
+**Behavioral stability scoring:**
+
+The `campaigns` table gained `behavioral_stability_json`, which stores longitudinal stability metrics across the dimensions tracked by the fingerprint (timing, sequence, protocol, credential, target). Stability is computed from the fingerprint history. A campaign with high stability has behaved consistently over time. A campaign with declining stability may be adapting its tooling. Both are intelligence signals.
+
+**Uncertain association review queue:**
+
+Clustering observations with `decision=uncertain_association` in their notes JSON are exposed via `GET /api/campaigns/uncertain-associations`. Analysts can submit `POST /api/campaigns/uncertain-associations/{id}/review` with `analyst_confirmed` or `analyst_denied` to record their interpretation. The review is stored in `analyst_review_json` on the observation row. It does not mutate campaign membership or alter the original clustering decision.
+
+---
+
+## 6. Dashboard and Operator-Facing Changes
+
+**Campaign AI summary panel (inherited from Phase 5, unchanged):**
+The `CampaignAiPanel` component is unchanged. It generates an in-memory AI summary for a single campaign on operator demand. No auto-generation.
+
+**Multi-campaign threat brief panel (Phase 6 Group C — PR #57):**
+The `CampaignBriefPanel` component allows an operator to request a multi-campaign threat brief with optional time-window filtering (`time_window_start`, `time_window_end`). The panel uses the async 202 contract: it submits the brief, then polls `GET /api/jobs/{job_id}` until completion. Results are displayed as plain text. No auto-generation. No markdown rendering. No localStorage persistence.
+
+**Campaign AI output history panel (Phase 6 Group C — PR #58):**
+The `CampaignAiOutputHistory` component is rendered below `CampaignAiPanel` in each campaign's expanded row. It fetches all persisted AI output records for the campaign from `GET /api/campaigns/{id}/ai-outputs` on expand. Each output card shows: `generated_at`, backend/model, quality score, rejected/truncated badges, source record counts, and plain text content. A "Regenerate Summary" button submits a new summary job and polls until completion, then refreshes the history list. A "Historical AI output" warning banner is always visible.
+
+**New API helpers (Phase 6 Group C):**
+`ui/dashboard/src/lib/api.js` gained: `postCampaignBrief`, `getJob`, `getCampaignAiOutputs`, `getAiOutput`.
+
+---
+
+## 7. Actor Identity Preparation
+
+Phase 6 Group D created two empty schema foundations to enable Phase 7 actor-level intelligence without implementing actor attribution in Phase 6.
+
+**`actor_profiles`:** One row per inferred actor identity. Fields include `display_name`, `confidence`, `status`, `representative_fingerprint_json`, `behavioral_stability_json`, `notes`, `created_at`, `updated_at`. No row is created automatically by clustering, lifecycle transitions, or AI code paths.
+
+**`campaign_lineage`:** Links a campaign to an actor profile with an explicit `relationship_type`, `confidence`, and analyst-supplied `evidence_json`. Does not mutate campaign membership or clustering decisions.
+
+**Repository support:** `ActorRepository` provides `create_actor_profile()`, `get_actor_profile()`, `list_actor_profiles()`, `link_campaign_to_actor()`, `list_campaign_lineage()`. All five methods are purely explicit — no automatic assignment logic exists.
+
+**What is absent by design:**
+- No automatic actor attribution from clustering
+- No campaign merging or splitting
+- No AI actor naming
+- No API endpoints for actor profiles (deferred to Phase 7)
+- No dashboard actor UI
+
+---
+
+## 8. What Was Intentionally Deferred
+
+The following items were scoped, understood, and explicitly deferred from Phase 6:
+
+**From Group A:**
+- Celery or asyncio worker process (using FastAPI `BackgroundTasks`; worker replacement is an implementation swap, not an API change)
+- `GET /api/jobs/{job_id}/result` convenience endpoint (callers fetch from `/api/ai/outputs/{ai_output_id}` directly)
+- Job cancellation endpoint
+
+**From Group B:**
+- Bulk analyst review (single-observation review only)
+- Dashboard review panel for uncertain associations
+- Automated behavioral drift alerts
+
+**From Group C:**
+- Time-window filter UI on the campaign list (time window is available on the brief endpoint only)
+- AI output pagination UI (backend limit=20 applies; UI shows all returned outputs)
+- AI output filter by type in the history panel
+
+**From Group D:**
+- All actor attribution logic
+- Actor profile API endpoints
+- Campaign lineage API endpoints
+- Dashboard actor UI
+- Federation implementation
+
+---
+
+## 9. Known Limitations
+
+**`BackgroundTasks` process model:** Jobs run in the same OS process as the HTTP server. A server restart while a job is running leaves the job in `running` state indefinitely. The TTL enforcement in `GET /api/jobs/{job_id}` mitigates this: a job stuck in `running` past `AI_TIMEOUT_SECONDS × 2` is transitioned to `failed` on first read. However, no job is retried automatically after a crash.
+
+**SQLite write serialization:** `processing_jobs` and `ai_outputs` writes are serialized by SQLite's WAL-mode writer lock. Under concurrent AI job submissions, write latency can spike. This is acceptable for single-operator deployments and low-volume research use. High-concurrency production deployments require PostgreSQL.
+
+**Fingerprint history is not yet used for alerting:** The `fingerprint_history` table is populated and queryable, but no automated alert fires when behavioral drift exceeds a threshold. Drift detection is a Phase 7 feature; Phase 6 only collects the longitudinal data.
+
+**Analyst review does not propagate:** A review decision (`analyst_confirmed` or `analyst_denied`) on an uncertain observation is stored but not surfaced to the clustering algorithm, the campaign confidence score, or any downstream consumer. Phase 7 may use these signals to adjust future similarity thresholds.
+
+**`representative_fingerprint_json` and `behavioral_stability_json` require the analytics job:** These columns are populated by the behavioral stability scoring job. They are `NULL` for campaigns that have not yet had the job run against them. The job must be triggered manually or via the scheduled lifecycle job.
+
+---
+
+## 10. Phase 7 Recommended Direction
+
+Phase 7 should be named **Actor Identity and Behavioral Federation**.
+
+The work falls into two parallel tracks:
+
+**Track 1 — Actor Intelligence (builds on Phase 6 Group D foundations):**
+
+1. Define `relationship_type` vocabulary for `campaign_lineage` (e.g., `primary_campaign`, `infrastructure_reuse`, `tactic_match`, `temporal_overlap`).
+2. Implement operator-facing API endpoints for actor profile CRUD (`POST /api/actors`, `GET /api/actors/{id}`, `PATCH /api/actors/{id}`).
+3. Implement `GET /api/actors/{id}/campaigns` to list campaigns linked to an actor.
+4. Add dashboard actor profile panel — read-only view of linked campaigns, stability trends, and analyst notes. No automatic attribution.
+5. Consider a deterministic actor-linking suggestion engine: surface campaigns with high representative fingerprint similarity as *candidates* for manual linking. No automatic assignment. Analyst confirms or denies.
+
+**Track 2 — Behavioral Federation (builds on Phase 4–6 fingerprint infrastructure):**
+
+1. Define a standardized, privacy-safe fingerprint serialization format. Raw IPs must not appear in shared fingerprints; only behavioral feature vectors.
+2. Implement operator identity management: each deployment has a cryptographic keypair for signing contributed fingerprints.
+3. Build `POST /api/federation/contribute` — publishes a behavioral fingerprint to a trusted peer.
+4. Build `GET /api/federation/fingerprints` — imports fingerprints from trusted peers.
+5. Integrate received fingerprints into the local clustering algorithm as additional comparison targets (without writing to `behavioral_fingerprints` — separate `received_fingerprints` table).
+
+**Prerequisite order:** Track 1 actor attribution APIs should be complete before Track 2 federation begins. Federation of actor identities (as opposed to raw fingerprints) is a Phase 8 concern.
+
+**What must not happen in Phase 7:**
+- Automatic actor attribution from clustering (humans assign actors to campaigns)
+- AI actor naming (actor display names are operator-assigned)
+- Merging campaigns into a single canonical record (campaigns are immutable history; lineage records the relationship)
+- Any change to the clustering algorithm or similarity scoring
+
+---
+
+*Cross-references: [PHASE_6_BLUEPRINT.md](PHASE_6_BLUEPRINT.md) · [PHASE_5_CLOSEOUT.md](PHASE_5_CLOSEOUT.md) · [ROADMAP.md](ROADMAP.md) · [ARCHITECTURE.md](ARCHITECTURE.md)*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Document type:** Phased development plan and architectural evolution order
 **Audience:** Engineers, autonomous agents, contributors
-**Last reviewed:** 2026-05-26
+**Last reviewed:** 2026-05-28
 
 ---
 
@@ -14,7 +14,7 @@ The order of this roadmap is not arbitrary. Each phase is a prerequisite for the
 
 ---
 
-## Current State (as of Phase 5)
+## Current State (as of Phase 6)
 
 | Capability | Status | Notes |
 |---|---|---|
@@ -29,20 +29,30 @@ The order of this roadmap is not arbitrary. Each phase is a prerequisite for the
 | JWT + API key auth | Working | bcrypt password verification; hardcoded defaults removed |
 | Audit logging | Working | `audit_log` table; one row per ingest batch |
 | Data retention | Working | `delete_events_before()` + `make db-prune` |
-| React dashboard | Working | KPI cards, event chart, recent events, intelligence panels, campaign panel + AI summary panel |
+| React dashboard | Working | KPI cards, event chart, recent events, intelligence panels, campaign panel, AI summary panel, brief panel, AI output history panel |
 | CI/CD | Working | Lint, test, semantic release; Black 26.5.1 pinned |
 | Docker Compose | Working | Edge deployment profile |
 | Behavioral fingerprinting | Working | 5-dimension behavioral fingerprint per source IP; stored in `behavioral_fingerprints` |
+| Fingerprint history | Working | Append-only longitudinal snapshots in `fingerprint_history`; enables Phase 7 drift detection |
+| Representative fingerprints | Working | Cluster centroid fingerprint stored per campaign in `representative_fingerprint_json` |
+| Behavioral stability scoring | Working | Longitudinal stability metrics stored per campaign in `behavioral_stability_json` |
 | Campaign clustering | Working | Deterministic similarity clustering; reactivation detection; `app/intelligence/clustering.py` |
 | Campaign lifecycle | Working | Automatic active→dormant→historical transitions; manual trigger via `POST /api/admin/run-lifecycle-job` |
 | Campaign analytics | Working | `attack_tactic_dist` and `top_target_ports` populated per campaign by analytics job |
 | Configurable weights | Working | Similarity weights and lifecycle thresholds are environment variables with sane defaults |
 | Campaign API | Working | `GET /api/campaigns`, `GET /api/campaigns/{id}`, `GET /api/campaigns/{id}/observations` |
+| Uncertain association review | Working | `GET /api/campaigns/uncertain-associations`, `POST /api/campaigns/uncertain-associations/{id}/review` |
 | AI backend abstraction | Working | `DisabledAIBackend` (default), `OllamaAIBackend`, `ClaudeAIBackend`; swapped via `AI_BACKEND` env var |
 | AI safety layer | Working | Field sanitization, injection pattern detection, IP-in-output rejection, length limits |
-| Campaign AI summary | Working | `POST /api/campaigns/{id}/summary`; operator-triggered; no persistence |
-| Multi-campaign brief | Working | `POST /api/campaigns/brief`; operator-triggered; no persistence |
-| Dashboard AI panel | Working | `CampaignAiPanel` — operator-triggered, plain text, warning always visible |
+| Async AI job infrastructure | Working | 202 Accepted contract; `processing_jobs` table; `GET /api/jobs/{job_id}` polling; TTL enforcement |
+| AI output persistence | Working | Every AI artifact written to `ai_outputs` (write-once, immutable); linked to job via `ai_output_id` |
+| AI audit logging | Working | Every AI API call logged to `ai_audit_log`; metadata only (no content); rate-limited requests logged |
+| AI rate limiting | Working | DB-backed per-operator rate limit; `AI_MAX_REQUESTS_PER_MINUTE` env var (default: 10) |
+| Campaign AI summary | Working | `POST /api/campaigns/{id}/summary`; 202 Accepted; operator-triggered; persisted to `ai_outputs` |
+| Multi-campaign brief | Working | `POST /api/campaigns/brief`; 202 Accepted; optional time-window filter; persisted to `ai_outputs` |
+| Campaign AI output history | Working | `GET /api/campaigns/{id}/ai-outputs`; newest-first; `CampaignAiOutputHistory` dashboard panel |
+| Dashboard AI brief panel | Working | `CampaignBriefPanel` — time-window inputs, async polling, plain text, warning always visible |
+| Actor identity foundations | Schema only | `actor_profiles` + `campaign_lineage` tables; `ActorRepository`; no attribution logic yet |
 
 ---
 
@@ -188,42 +198,46 @@ Phase 3 delivered the foundation: enriched events, a queryable intelligence laye
 
 ---
 
-## Phase 6 — Behavioral Memory and Campaign Tracking
+## Phase 6 — Behavioral Memory and Campaign Intelligence — **Complete**
 
-**Duration:** 4–6 weeks
-**Goal:** Persistent behavioral fingerprinting that enables campaign recognition across time.
+**Duration:** ~2 weeks (Phase 5 infrastructure build-out + Phase 6 delivery)
+**Goal:** Make AI-generated intelligence accountable, auditable, and recallable. Deepen behavioral memory into a longitudinal model. Prepare actor identity foundations for Phase 7.
 
-This is the strategic core of the platform. Events are not isolated incidents; they are data points in persistent behavioral patterns.
+Phase 6 delivered in four groups. Group A shipped the async job infrastructure and AI persistence layer before any AI feature expansion. Groups B and C built on that foundation. Group D created empty schema foundations for Phase 7 without implementing attribution.
 
-| Task | Notes |
-|---|---|
-| Behavioral fingerprint schema | Encode port sequences, timing distributions, User-Agent patterns, tool signatures |
-| Campaign cluster model | Group events into campaigns based on behavioral similarity |
-| Actor persistence table | Track campaigns across multiple observation periods |
-| `GET /api/campaigns` | Return active and historical campaign clusters |
-| Campaign recurrence detection | Alert when a known campaign fingerprint reappears |
-| Threat scoring | Score actors by frequency, behavioral diversity, targeting patterns |
+| Group | PRs | Title |
+|-------|-----|-------|
+| A | #51–#53 | Async job infrastructure, AI output persistence, audit logging, rate limiting |
+| B | #54–#56 | Fingerprint history, representative fingerprints, behavioral stability scoring, uncertain association review queue |
+| C | #57–#58 | Time-window campaign briefs, dashboard brief panel, AI output history panel |
+| D | D1+D2 | Actor identity schema foundations, Phase 6 close-out documentation |
 
-**Exit criteria:** The system identifies that a campaign observed today shares behavioral characteristics with a campaign observed three months ago, even if the IP infrastructure is entirely different.
+**Exit criteria met:** The system persists, audits, and serves every AI-generated artifact. Behavioral fingerprints are recorded longitudinally. Clustering decisions with uncertain confidence are surfaced to analysts for review. Actor identity tables are in place for Phase 7 assignment.
+
+**Delivered:** See [PHASE_6_CLOSEOUT.md](PHASE_6_CLOSEOUT.md) for the complete delivery record, architectural changes, known limitations, and Phase 7 recommended direction.
 
 ---
 
-## Phase 7 — Privacy-Preserving Federation
+## Phase 7 — Actor Identity and Behavioral Federation
 
 **Duration:** 6–10 weeks
-**Goal:** Enable consenting operators to share behavioral fingerprints without exposing raw telemetry.
+**Goal:** Build on Phase 6 actor identity foundations to enable campaign-to-actor assignment, then enable consenting operators to share behavioral fingerprints without exposing raw telemetry.
 
-See [FEDERATION_VISION.md](FEDERATION_VISION.md) for detailed design.
+Phase 6 Group D created the `actor_profiles` and `campaign_lineage` tables and repository layer. Phase 7 activates them with API endpoints, operator tooling, and a federation protocol.
 
-| Task | Notes |
-|---|---|
-| Behavioral fingerprint serialization format | Standardized, privacy-safe representation of behavioral patterns |
-| Federation protocol design | Push/pull model; signed submissions; operator identity management |
-| Opt-in contribution mechanism | Operators explicitly choose what to share |
-| Received intelligence integration | Imported fingerprints enrich local campaign detection |
-| Federation API endpoints | `POST /api/federation/contribute`, `GET /api/federation/fingerprints` |
+See [FEDERATION_VISION.md](FEDERATION_VISION.md) for detailed federation design. See [PHASE_6_CLOSEOUT.md](PHASE_6_CLOSEOUT.md) §10 for the recommended Phase 7 direction.
 
-**Exit criteria:** Two independent LegionTrap deployments can exchange behavioral fingerprints. Each deployment's campaign detection improves measurably from the shared data.
+| Task | Track | Notes |
+|------|-------|-------|
+| Actor profile CRUD API | 1 | `POST /api/actors`, `GET /api/actors/{id}`, `PATCH /api/actors/{id}` |
+| Campaign-to-actor linking API | 1 | `POST /api/actors/{id}/campaigns`, `GET /api/actors/{id}/campaigns` |
+| Actor profile dashboard panel | 1 | Read-only; no automatic attribution |
+| Behavioral fingerprint serialization format | 2 | Standardized, privacy-safe representation; no raw IPs |
+| Operator identity management | 2 | Cryptographic keypair per deployment for signing |
+| Federation push/pull API | 2 | `POST /api/federation/contribute`, `GET /api/federation/fingerprints` |
+| Received intelligence integration | 2 | Imported fingerprints enrich local campaign detection |
+
+**Exit criteria:** An operator can assign campaigns to actor profiles via API. Two independent LegionTrap deployments can exchange behavioral fingerprints. Each deployment's campaign detection improves measurably from the shared data.
 
 ---
 


### PR DESCRIPTION
## Summary

- **D1 — Actor identity schema foundations:** Creates `actor_profiles` and `campaign_lineage` tables (Alembic migration 0010, `create_all_tables()` DDL), `ActorRepository` with five methods (`create_actor_profile`, `get_actor_profile`, `list_actor_profiles`, `link_campaign_to_actor`, `list_campaign_lineage`), wired into `EventRepository` as the tenth mixin. No automatic attribution logic anywhere in the path.
- **D2 — Phase 6 close-out documentation:** New `PHASE_6_CLOSEOUT.md` with all ten required sections. `ROADMAP.md` updated (Phase 6 marked complete, Phase 7 renamed and expanded with two-track task table). `ARCHITECTURE.md` updated (component map, router list, repository list, AI request flow diagram rewritten for the Phase 6 async model). `PHASE_6_BLUEPRINT.md` status updated to complete.

## What is intentionally absent

- No automatic actor attribution from clustering or any job runner
- No API endpoints for actor profiles or campaign lineage (Phase 7)
- No dashboard actor UI (Phase 7)
- No campaign merging, splitting, or AI actor naming

## Test plan

- [ ] `python -m pytest tests/ -x -q` — 1275 passed, 3 skipped
- [ ] `pre-commit run --files <changed files>` — all hooks pass
- [ ] `alembic upgrade head` applies migration 0010 cleanly on a local DB
- [ ] `create_all_tables()` creates `actor_profiles` and `campaign_lineage` in test fixtures (confirmed by test suite passing)
- [ ] `ActorRepository` methods callable via `EventRepository` session (no import errors)
- [ ] PHASE_6_CLOSEOUT.md renders correctly on GitHub