### PR TITLE
docs(roadmap): split actor intelligence and behavioral federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,13 @@ Known limitations: the actor identity schema is present but has no attribution l
 
 ## Direction
 
-Phase 7 addresses two architectural problems that Phase 6 prepared for. The first is actor identity: campaigns currently represent coordinated activity without linking to an explicit actor record. Phase 7 introduces operator-assigned actor profiles, connecting campaigns to inferred actor identities through explicit relationship types and confidence values. Attribution is always operator-confirmed; no automated assignment is planned. The Phase 6 foundations — `actor_profiles` and `campaign_lineage` schema, `ActorRepository` — are the prepared substrate for this work.
+Phase 7 addresses three architectural problems that Phase 6 left open. The first is that operator judgment — encoded in months of analyst review decisions on uncertain clustering associations — is being collected and discarded. No consumer reads those decisions. Phase 7 closes the feedback loop: confirmed associations adjust per-campaign similarity weight profiles, making the clustering algorithm responsive to the operator's own judgment over time.
 
-The second problem is the boundary of the behavioral record. A single deployment's fingerprint history is specific to its own attack surface, which is both its strength and its limit. An actor targeting multiple operators will be independently discovered by each one. Federation is the mechanism for sharing behavioral patterns across deployments without sharing the observation data those patterns were derived from. A fingerprint encodes behavioral characteristics — timing distributions, probe sequences, protocol behavior — not IP addresses. The pattern can be shared without sharing the source.
+The second is behavioral drift. Fingerprint history is accumulating. Phase 7 activates it with configurable per-dimension alerting: when behavioral stability crosses a threshold, the operator is surfaced a signal. Drift detection does not replace operator judgment — it gives the operator something to judge.
 
-Privacy-preserving behavioral federation is the logical continuation of the thesis: if behavioral patterns are more durable than indicators, then a network of operators sharing behavioral patterns gains intelligence that no individual deployment can produce alone. A campaign fingerprint observed for the first time in one deployment may match a fingerprint another operator has been tracking for months. The match is made without either operator revealing their observation infrastructure to the other. No timelines. The foundation is built.
+The third is actor identity. Campaigns currently represent coordinated activity without linking to an explicit actor record. Phase 7 introduces operator-assigned actor profiles, connecting campaigns to inferred actor identities through explicit relationship types and confidence values. A suggestion engine surfaces campaign pairs whose representative fingerprints are sufficiently similar as candidates for manual linking. Attribution is always operator-confirmed; no automated assignment runs. The Phase 6 foundations — `actor_profiles` and `campaign_lineage` schema, `ActorRepository` — are the prepared substrate.
+
+Phase 8 addresses the boundary of the behavioral record. A single deployment's fingerprint history is specific to its own attack surface, which is both its strength and its limit. Federation is the mechanism for sharing behavioral patterns across independent deployments without sharing the observation data those patterns were derived from. A fingerprint encodes behavioral characteristics — timing distributions, probe sequences, protocol behavior — not IP addresses. The pattern can be shared without sharing the source. Phase 8 begins when two real operators are willing to participate in a pilot exchange and the fingerprint serialization format has been validated against both deployments' data. The foundation is built.
 
 ---
 
@@ -144,7 +146,8 @@ Privacy-preserving behavioral federation is the logical continuation of the thes
 | **Phase 4** | Campaign Intelligence & Export Maturity | ✅ Complete |
 | **Phase 5** | AI Integration | ✅ Complete |
 | **Phase 6** | Async AI, Output Persistence & Brief UI | ✅ Complete |
-| **Phase 7** | Actor Identity and Behavioral Federation | ⏳ Next |
+| **Phase 7** | Actor Intelligence | ⏳ Next |
+| **Phase 8** | Behavioral Federation | ○ Conditional on operational prerequisites |
 
 Each phase builds on the previous. See [docs/ROADMAP.md](docs/ROADMAP.md) for full detail.
 

--- a/docs/AI_REASONING_ARCHITECTURE.md
+++ b/docs/AI_REASONING_ARCHITECTURE.md
@@ -456,7 +456,7 @@ WHERE c.status IN ('active', 'dormant')
 ORDER BY c.last_seen DESC;
 ```
 
-### Federation fingerprint matching (Phase 7+)
+### Federation fingerprint matching (Phase 8+)
 
 ```sql
 SELECT

--- a/docs/AI_ROADMAP.md
+++ b/docs/AI_ROADMAP.md
@@ -211,7 +211,7 @@ This is a background task, not a synchronous API operation. It must not block th
 
 **Goal:** Specialized AI agents operating as a coordinated pipeline for complex threat analysis.
 
-This stage requires the federation layer (Phase 7 of main roadmap) to be meaningful at scale. It is a long-term architectural direction, not a near-term implementation plan.
+This stage requires the federation layer (Phase 8 of main roadmap) to be meaningful at scale. It is a long-term architectural direction, not a near-term implementation plan.
 
 ### Agent roles in the pipeline:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -318,7 +318,7 @@ These are directional, not commitments. They represent the infrastructure that w
 | SQLite | Phase 1 | In use — WAL mode, FK enforcement, indexed |
 | Alembic migrations | Phase 1 | In use — `alembic upgrade head` manages schema |
 | Background task worker | Phase 5 (AI) | FastAPI BackgroundTasks initially |
-| Redis (optional) | Phase 7 (Federation) | Session store, rate limiting, pub/sub |
+| Redis (optional) | Phase 8 (Federation) | Session store, rate limiting, pub/sub |
 | PostgreSQL | High-volume scale-out | When SQLite limits are reached |
 | Reverse proxy (Caddy/nginx) | Production deployment | TLS termination, rate limiting |
 | Object storage (MinIO/S3) | Long-term | PCAP storage, large artifact storage |

--- a/docs/BUSINESS_MODEL.md
+++ b/docs/BUSINESS_MODEL.md
@@ -248,7 +248,7 @@ Multi-site enterprise deployments with SLA-backed support, SSO integration, and 
 
 A commercial service that manages trust circle membership, verifies participant identities, and provides curated behavioral fingerprint feeds for organizations that want federation benefits without managing peer relationships themselves.
 
-**Prerequisite:** Phase 7 (federation) completion and sufficient network scale to make curated feeds valuable.
+**Prerequisite:** Phase 8 (federation) completion and sufficient network scale to make curated feeds valuable.
 
 ---
 

--- a/docs/COMPETITIVE_POSITIONING.md
+++ b/docs/COMPETITIVE_POSITIONING.md
@@ -330,7 +330,7 @@ The compounding advantage that makes LegionTrap's position durable once achieved
 
 **Behavioral memory is not purchasable.** An operator's attack history is specific to their exposure profile and accumulates only through continuous observation. No competitor can sell a substitute. The operator who has been running LegionTrap for three years has a behavioral history that a deployment started today cannot replicate.
 
-**Federation amplifies the moat.** When the privacy-preserving federation network reaches sufficient scale `[planned: Phase 7]`, collective behavioral memory across the operator community creates network effects that individual operators cannot access outside the network. The value of participation grows with network scale.
+**Federation amplifies the moat.** When the privacy-preserving federation network reaches sufficient scale `[planned: Phase 8]`, collective behavioral memory across the operator community creates network effects that individual operators cannot access outside the network. The value of participation grows with network scale.
 
 **Community trust is slow to build and fast to destroy.** A platform that has never violated its sovereignty principles and has always been honest about its capabilities builds trust with the sovereign operator segment that a well-funded competitor cannot quickly replicate. Trust is the prerequisite for adoption in this segment; it is not purchased.
 

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -369,7 +369,7 @@ app/db/migrations/versions/
   0002_phase2_intelligence_indexes.py    -- Phase 2E: intelligence query indexes (live)
   0003_ai_analysis_table.py             -- Phase 5: adds ai_analyses (future)
   0004_behavioral_tables.py             -- Phase 6: adds fingerprints, campaigns, campaign_id FK (future)
-  0005_federation_table.py              -- Phase 7: adds federation_fingerprints (future)
+  0005_federation_table.py              -- Phase 8: adds federation_fingerprints (future)
 ```
 
 **Rule:** Never manually ALTER a table that Alembic manages. All schema changes go through a new migration file.
@@ -388,7 +388,7 @@ app/db/migrations/versions/
 | `campaigns` | Phase 6 | Permanent | No (outlives events) |
 | `campaign_events` | Phase 6 | With `events` | Yes (CASCADE) |
 | `ai_analyses` | Phase 5 | Separate (90d default) | Yes |
-| `federation_fingerprints` | Phase 7 | Separate configurable | Yes |
+| `federation_fingerprints` | Phase 8 | Separate configurable | Yes |
 | `audit_log` | Phase 1 | Separate (90d default) | Yes |
 
 ---

--- a/docs/FEDERATION_VISION.md
+++ b/docs/FEDERATION_VISION.md
@@ -225,7 +225,7 @@ Operators maintain direct peer relationships. Each deployment is a node in the n
 
 For large trust circles, a gossip protocol (similar to how distributed databases synchronize state) enables fingerprint propagation without each operator needing to maintain N explicit peer connections. A fingerprint contributed by one node propagates through the network within a configurable number of hops.
 
-Gossip protocol implementation is a Phase 7+ concern. The initial implementation uses explicit peer configuration.
+Gossip protocol implementation is a Phase 8+ concern. The initial implementation uses explicit peer configuration.
 
 ---
 

--- a/docs/FOUNDING_PRINCIPLES.md
+++ b/docs/FOUNDING_PRINCIPLES.md
@@ -245,7 +245,7 @@ The architectural decision that determines LegionTrap's long-term strategic posi
 
 This is the endgame: not a platform that one operator uses, but a protocol that many operators participate in, each benefiting from the collective intelligence of all participants without any participant sacrificing the sovereignty that defines why they chose a self-hosted platform.
 
-**Current status:** The federation design is fully specified (see FEDERATION_VISION.md). Implementation is planned for Phase 7, following the behavioral memory layer (Phase 6) on which it depends.
+**Current status:** The federation design is fully specified (see FEDERATION_VISION.md). Implementation is planned for Phase 8, following the actor intelligence layer (Phase 7) on which it depends.
 
 ### Governance must match the principles
 

--- a/docs/PHASE_6_CLOSEOUT.md
+++ b/docs/PHASE_6_CLOSEOUT.md
@@ -201,9 +201,9 @@ The following items were scoped, understood, and explicitly deferred from Phase 
 
 **SQLite write serialization:** `processing_jobs` and `ai_outputs` writes are serialized by SQLite's WAL-mode writer lock. Under concurrent AI job submissions, write latency can spike. This is acceptable for single-operator deployments and low-volume research use. High-concurrency production deployments require PostgreSQL.
 
-**Fingerprint history is not yet used for alerting:** The `fingerprint_history` table is populated and queryable, but no automated alert fires when behavioral drift exceeds a threshold. Drift detection is a Phase 7 feature; Phase 6 only collects the longitudinal data.
+**Fingerprint history is not yet used for alerting:** The `fingerprint_history` table is populated and queryable, but no automated alert fires when behavioral drift exceeds a threshold. Drift alerting is Phase 7 Group A; Phase 6 only collects the longitudinal data.
 
-**Analyst review does not propagate:** A review decision (`analyst_confirmed` or `analyst_denied`) on an uncertain observation is stored but not surfaced to the clustering algorithm, the campaign confidence score, or any downstream consumer. Phase 7 may use these signals to adjust future similarity thresholds.
+**Analyst review does not propagate:** A review decision (`analyst_confirmed` or `analyst_denied`) on an uncertain observation is stored but not surfaced to the clustering algorithm, the campaign confidence score, or any downstream consumer. Phase 7 Group A uses these signals to adjust per-campaign similarity weight profiles.
 
 **`representative_fingerprint_json` and `behavioral_stability_json` require the analytics job:** These columns are populated by the behavioral stability scoring job. They are `NULL` for campaigns that have not yet had the job run against them. The job must be triggered manually or via the scheduled lifecycle job.
 
@@ -211,33 +211,33 @@ The following items were scoped, understood, and explicitly deferred from Phase 
 
 ## 10. Phase 7 Recommended Direction
 
-Phase 7 should be named **Actor Identity and Behavioral Federation**.
+Phase 7 is named **Actor Intelligence**.
 
-The work falls into two parallel tracks:
+The architectural review conducted before Phase 7 planning identified that two categories of Phase 6 output are not yet used: analyst review decisions on uncertain associations, and longitudinal fingerprint drift signals. Building actor identity before closing those feedback loops would produce attribution on uncalibrated data. Phase 7 addresses this by making Group A (feedback loop closure) a hard prerequisite for Group B (actor identity).
 
-**Track 1 — Actor Intelligence (builds on Phase 6 Group D foundations):**
+**Group A — Feedback Loop Closure (must ship before Group B):**
 
-1. Define `relationship_type` vocabulary for `campaign_lineage` (e.g., `primary_campaign`, `infrastructure_reuse`, `tactic_match`, `temporal_overlap`).
-2. Implement operator-facing API endpoints for actor profile CRUD (`POST /api/actors`, `GET /api/actors/{id}`, `PATCH /api/actors/{id}`).
-3. Implement `GET /api/actors/{id}/campaigns` to list campaigns linked to an actor.
-4. Add dashboard actor profile panel — read-only view of linked campaigns, stability trends, and analyst notes. No automatic attribution.
-5. Consider a deterministic actor-linking suggestion engine: surface campaigns with high representative fingerprint similarity as *candidates* for manual linking. No automatic assignment. Analyst confirms or denies.
+1. Review decision propagation: confirmed uncertain associations adjust per-campaign similarity weight profiles. The operator can inspect current effective weights and trace them to source review decisions. This does not eliminate clustering determinism — it makes the configurable weights respond to accumulated operator judgment rather than remaining permanently static.
+2. Drift alerting: configurable per-dimension thresholds on behavioral stability. Threshold crossings write to a `behavioral_alerts` table and surface in the dashboard. No automated response. The operator decides what a drift signal means.
+3. Sparse campaign surface: campaigns that accumulated insufficient evidence to confirm are surfaced with a distinct lifecycle status, separate from active, dormant, and historical.
 
-**Track 2 — Behavioral Federation (builds on Phase 4–6 fingerprint infrastructure):**
+**Group B — Actor Identity (builds on Group A and Phase 6 Group D foundations):**
 
-1. Define a standardized, privacy-safe fingerprint serialization format. Raw IPs must not appear in shared fingerprints; only behavioral feature vectors.
-2. Implement operator identity management: each deployment has a cryptographic keypair for signing contributed fingerprints.
-3. Build `POST /api/federation/contribute` — publishes a behavioral fingerprint to a trusted peer.
-4. Build `GET /api/federation/fingerprints` — imports fingerprints from trusted peers.
-5. Integrate received fingerprints into the local clustering algorithm as additional comparison targets (without writing to `behavioral_fingerprints` — separate `received_fingerprints` table).
+1. Define `relationship_type` vocabulary for `campaign_lineage` before writing any API: `primary_campaign`, `infrastructure_reuse`, `tactic_match`, `temporal_overlap`. Open strings are not accepted.
+2. Implement actor profile CRUD API: `POST /api/actors`, `GET /api/actors`, `GET /api/actors/{id}`, `PATCH /api/actors/{id}`.
+3. Implement `POST /api/actors/{id}/campaigns` and `GET /api/actors/{id}/campaigns` with relationship_type validation.
+4. Implement actor suggestion engine: `GET /api/actors/suggestions` surfaces campaign pairs whose representative fingerprints exceed a configurable similarity threshold and have no existing lineage. Read-only. Never writes automatically. Analyst confirms or denies.
+5. Implement actor-level stability view: `GET /api/actors/{id}/stability` aggregates behavioral stability across all campaigns linked to the actor.
+6. Add dashboard actor profile panel — read-only view of linked campaigns, similarity suggestions, and stability trends. No automatic attribution.
 
-**Prerequisite order:** Track 1 actor attribution APIs should be complete before Track 2 federation begins. Federation of actor identities (as opposed to raw fingerprints) is a Phase 8 concern.
+**Federation is deferred to Phase 8.** Federation is not a code prerequisite problem — the fingerprint model and privacy architecture are already designed. It is an operational prerequisite problem: building the protocol before two real operators are willing to exchange fingerprints produces infrastructure that cannot be validated. Phase 8 has explicit entry criteria; it begins when those criteria are confirmed, not on a timeline.
 
 **What must not happen in Phase 7:**
 - Automatic actor attribution from clustering (humans assign actors to campaigns)
 - AI actor naming (actor display names are operator-assigned)
 - Merging campaigns into a single canonical record (campaigns are immutable history; lineage records the relationship)
-- Any change to the clustering algorithm or similarity scoring
+- Any change to the clustering algorithm's core similarity logic
+- Any federation implementation (belongs to Phase 8)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -171,7 +171,7 @@ Prerequisite reading: `AI_ROADMAP.md` Stage 0 checklist → `ROADMAP.md` Phase 1
 
 ### "I want to understand the federation design."
 
-Start: `FEDERATION_VISION.md` → `BEHAVIORAL_INTELLIGENCE.md` → `ROADMAP.md` Phase 7
+Start: `FEDERATION_VISION.md` → `BEHAVIORAL_INTELLIGENCE.md` → `ROADMAP.md` Phase 8
 
 ### "I am an autonomous agent about to make changes."
 
@@ -194,7 +194,8 @@ Required: `SECURITY_AUDIT.md` → `ARCHITECTURE.md` → `AUTONOMOUS_OPERATIONS.m
 | Phase 4 | ATT&CK / standard exports | `DATABASE_SCHEMA.md` | `BEHAVIORAL_INTELLIGENCE.md` |
 | Phase 5 | First AI integration | `AI_REASONING_ARCHITECTURE.md` | `AI_ROADMAP.md`, `ROADMAP.md` |
 | Phase 6 | Behavioral memory | `BEHAVIORAL_INTELLIGENCE.md` | `AI_ROADMAP.md` |
-| Phase 7 | Federation | `FEDERATION_VISION.md` | `BEHAVIORAL_INTELLIGENCE.md` |
+| Phase 7 | Actor Intelligence | `ROADMAP.md` | `BEHAVIORAL_INTELLIGENCE.md` |
+| Phase 8 | Behavioral Federation | `FEDERATION_VISION.md` | `BEHAVIORAL_INTELLIGENCE.md` |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -218,26 +218,81 @@ Phase 6 delivered in four groups. Group A shipped the async job infrastructure a
 
 ---
 
-## Phase 7 — Actor Identity and Behavioral Federation
+## Phase 7 — Actor Intelligence
 
-**Duration:** 6–10 weeks
-**Goal:** Build on Phase 6 actor identity foundations to enable campaign-to-actor assignment, then enable consenting operators to share behavioral fingerprints without exposing raw telemetry.
+**Duration:** 6–9 weeks
+**Goal:** Close the behavioral feedback loops that Phase 6 opened, then activate the actor identity foundations Phase 6 prepared.
 
-Phase 6 Group D created the `actor_profiles` and `campaign_lineage` tables and repository layer. Phase 7 activates them with API endpoints, operator tooling, and a federation protocol.
+Phase 6 collected two categories of operator intelligence that are not yet used: analyst review decisions on uncertain clustering associations, and longitudinal fingerprint drift signals. Phase 7 Group A closes those loops — making operator judgment a real input to the clustering model and making behavioral drift a surfaced signal. Group B builds actor identity on top of that calibrated foundation. Actor profiles built before feedback loops are closed are labels. Actor profiles built after are intelligence.
 
-See [FEDERATION_VISION.md](FEDERATION_VISION.md) for detailed federation design. See [PHASE_6_CLOSEOUT.md](PHASE_6_CLOSEOUT.md) §10 for the recommended Phase 7 direction.
+Phase 6 Group D created the `actor_profiles` and `campaign_lineage` tables and repository layer. Phase 7 Group B activates them with API endpoints, an operator-facing suggestion engine, and a dashboard panel.
 
-| Task | Track | Notes |
-|------|-------|-------|
-| Actor profile CRUD API | 1 | `POST /api/actors`, `GET /api/actors/{id}`, `PATCH /api/actors/{id}` |
-| Campaign-to-actor linking API | 1 | `POST /api/actors/{id}/campaigns`, `GET /api/actors/{id}/campaigns` |
-| Actor profile dashboard panel | 1 | Read-only; no automatic attribution |
-| Behavioral fingerprint serialization format | 2 | Standardized, privacy-safe representation; no raw IPs |
-| Operator identity management | 2 | Cryptographic keypair per deployment for signing |
-| Federation push/pull API | 2 | `POST /api/federation/contribute`, `GET /api/federation/fingerprints` |
-| Received intelligence integration | 2 | Imported fingerprints enrich local campaign detection |
+**Group A — Feedback Loop Closure (prerequisite; must ship before Group B begins):**
 
-**Exit criteria:** An operator can assign campaigns to actor profiles via API. Two independent LegionTrap deployments can exchange behavioral fingerprints. Each deployment's campaign detection improves measurably from the shared data.
+| Task | Notes |
+|------|-------|
+| Review decision propagation | Confirmed uncertain associations adjust per-campaign similarity weight profiles. Operator can inspect current effective weights and trace them to source review decisions. |
+| Drift alerting | Configurable per-dimension thresholds on behavioral stability; threshold crossings write to a `behavioral_alerts` table and surface in the dashboard. No automated response. |
+| Sparse campaign surface | Campaigns that have accumulated insufficient evidence to confirm are surfaced with a distinct lifecycle status, separate from active, dormant, and historical. |
+
+**Group B — Actor Identity:**
+
+| Task | Notes |
+|------|-------|
+| Relationship type vocabulary | Define valid `relationship_type` values before any API is built: `primary_campaign`, `infrastructure_reuse`, `tactic_match`, `temporal_overlap`. Open strings are not accepted. |
+| Actor profile CRUD API | `POST /api/actors`, `GET /api/actors`, `GET /api/actors/{id}`, `PATCH /api/actors/{id}` |
+| Campaign-to-actor linking API | `POST /api/actors/{id}/campaigns`, `GET /api/actors/{id}/campaigns` with relationship_type validation |
+| Actor suggestion engine | `GET /api/actors/suggestions` — campaign pairs whose representative fingerprints exceed a configurable similarity threshold and have no existing lineage. Read-only. Never writes automatically. |
+| Actor-level stability view | `GET /api/actors/{id}/stability` — aggregated behavioral stability across all campaigns linked to the actor. |
+| Actor profile dashboard panel | Read-only view of linked campaigns, similarity suggestions, and stability trends. No automatic attribution. |
+
+**Exit criteria (all satisfied by a single operator; no external dependencies):**
+
+- Analyst review confirmations demonstrably affect per-campaign similarity weight profiles; weight lineage is auditable.
+- Drift threshold crossings produce surfaced alerts within one analytics job cycle.
+- Operator can create an actor profile, link campaigns to it via a defined relationship type, and view or dismiss similarity suggestions.
+- No path exists by which the system writes to `actor_profiles` or `campaign_lineage` without explicit operator action.
+- Actor identity UI does not auto-generate names, does not auto-link campaigns, and does not surface AI-derived attribution.
+
+See [PHASE_6_CLOSEOUT.md](PHASE_6_CLOSEOUT.md) §10 for the Phase 6 handoff context.
+
+---
+
+## Phase 8 — Behavioral Federation
+
+**Status:** Conditional — does not begin until all operational prerequisites are confirmed.
+**Goal:** Enable consenting operators to share behavioral fingerprints across independent deployments without exposing raw telemetry, source IPs, or observation context.
+
+Federation is not a code prerequisite problem — the fingerprint model, privacy architecture, and separation of local and received intelligence are already designed. It is an operational prerequisite problem. Building the federation protocol before the operational prerequisites exist produces unvalidated infrastructure with no users.
+
+**Entry criteria (all must be confirmed before Phase 8 begins):**
+
+1. At least two independent LegionTrap deployments are willing to participate in a pilot bilateral exchange.
+2. The behavioral fingerprint serialization format has been validated against real data from both deployments and confirmed compatible.
+3. A key management runbook — covering keypair generation, public key distribution to peers, key rotation, and revocation — has been documented and tested against a real deployment.
+
+**Duration:** 8–12 weeks after entry criteria are confirmed.
+
+**Scope:**
+
+| Task | Notes |
+|------|-------|
+| Fingerprint serialization format | Standardized, privacy-safe format: no source IPs, no raw event content, behavioral feature vectors only. Schema versioned. |
+| Operator identity management | Ed25519 keypair per deployment. Pseudonymous deployment identifier. Signature generation and verification. |
+| Federation push/pull API | `POST /api/federation/contribute`, `GET /api/federation/fingerprints`, `GET /api/federation/status` |
+| Received fingerprint validation | Schema check, signature verification, plausibility filter. Invalid fingerprints rejected and logged before storage. |
+| Received intelligence storage | Separate `federation_fingerprints` table, distinct from `behavioral_fingerprints`. Two populations are never conflated. |
+| Local clustering integration | Received fingerprints used as additional comparison targets in campaign detection. Never written to local fingerprint tables. |
+
+**Exit criteria:**
+
+- Two deployments exchange behavioral fingerprints via the REST federation API.
+- At least one cross-deployment campaign match is detected and surfaced to both operators.
+- Received fingerprints contain no source IPs, destination IPs, operator identifiers, or raw event content.
+- Federation can be completely disabled without affecting the local intelligence pipeline.
+- Received fingerprints and locally derived fingerprints are stored and queried from separate tables at all times.
+
+See [FEDERATION_VISION.md](FEDERATION_VISION.md) for the full federation design and privacy analysis.
 
 ---
 
@@ -264,7 +319,8 @@ Phase 3:  Raw events → enriched events + intelligence API + standard exports (
 Phase 4:  Events → campaign clusters + export maturity (memory layer foundation)
 Phase 5:  Data → AI-reasoned intelligence (reasoning layer addition)
 Phase 6:  Events → behavioral memory + campaigns (memory layer maturation)
-Phase 7:  Local memory → federated collective intelligence (network layer addition)
+Phase 7:  Behavioral memory → operator-calibrated actor intelligence (feedback loop closure + attribution layer)
+Phase 8:  Local actor intelligence → federated collective intelligence (network layer; conditional on operational prerequisites)
 ```
 
 Each arrow represents a step that builds on the previous. No step can be safely skipped.


### PR DESCRIPTION
## Summary

Architectural roadmap revision based on the Phase 7 architecture review.

Changes:

* Split the original Phase 7 into two distinct phases
* Rename Phase 7 to Actor Intelligence
* Move Behavioral Federation into a dedicated Phase 8
* Introduce explicit operational entry criteria for federation
* Add Feedback Loop Closure as Group A of Phase 7
* Define Actor Identity as Group B of Phase 7
* Update roadmap sequencing, architecture evolution summaries, and supporting documentation
* Align all planning documents with the revised phase structure

Why:

The review identified that federation depends on operational prerequisites outside the control of a single deployment, while feedback-loop closure and actor intelligence can be fully implemented, tested, and validated by a single operator.

The revised roadmap ensures that:

* intelligence compounds before it is shared,
* actor attribution is built on calibrated behavioral data,
* federation begins only when real operational prerequisites exist.

This PR establishes the authoritative Phase 7 and Phase 8 structure that future blueprints and implementation work will follow.
