### PR TITLE
feat(phase7): implement campaign actor linking

### DIFF
--- a/app/db/repositories/actor.py
+++ b/app/db/repositories/actor.py
@@ -1,16 +1,12 @@
-"""Actor identity repository — Phase 6 Group D schema foundations.
+"""Actor identity repository — Phase 6 Group D foundations, Phase 7 B1/B2 activation.
 
 Read/write methods for actor_profiles and campaign_lineage tables.
-
-These tables are empty scaffolding created in Phase 6 to prepare Phase 7
-actor-level intelligence without implementing actor attribution yet.
 
 Invariants:
   - No method here performs automatic actor attribution.
   - No method here merges or splits campaigns.
   - No method here reads from or writes to the clustering path.
-  - campaign_lineage records are created only by explicit operator or future
-    Phase 7 automation — never by clustering.py or any existing job runner.
+  - campaign_lineage records are created only by explicit operator API calls.
 """
 
 from __future__ import annotations
@@ -51,6 +47,38 @@ def _lineage_row_to_dict(row) -> dict[str, Any]:
         "confidence": row[4],
         "evidence_json": row[5],
         "created_at": row[6],
+    }
+
+
+def _lineage_with_campaign_to_dict(row) -> dict[str, Any]:
+    return {
+        "id": row[0],
+        "actor_profile_id": row[1],
+        "campaign_id": row[2],
+        "relationship_type": row[3],
+        "confidence": row[4],
+        "evidence_json": row[5],
+        "created_at": row[6],
+        "campaign_name": row[7],
+        "campaign_status": row[8],
+        "campaign_last_seen": row[9],
+        "campaign_member_ip_count": row[10],
+        "campaign_has_fingerprint": bool(row[11]) if row[11] is not None else False,
+    }
+
+
+def _lineage_with_actor_to_dict(row) -> dict[str, Any]:
+    return {
+        "id": row[0],
+        "actor_profile_id": row[1],
+        "campaign_id": row[2],
+        "relationship_type": row[3],
+        "confidence": row[4],
+        "evidence_json": row[5],
+        "created_at": row[6],
+        "actor_display_name": row[7],
+        "actor_confidence": row[8],
+        "actor_status": row[9],
     }
 
 
@@ -275,3 +303,94 @@ class ActorRepository(RepositoryBase):
             params,
         ).fetchall()
         return [_lineage_row_to_dict(r) for r in rows]
+
+    def get_lineage_record(self, lineage_id: str) -> dict[str, Any] | None:
+        """Return a single campaign_lineage row by id, or None if not found."""
+        row = self._session.execute(
+            text(_LINEAGE_SELECT + "WHERE id = :id"),
+            {"id": lineage_id},
+        ).fetchone()
+        return _lineage_row_to_dict(row) if row is not None else None
+
+    def find_duplicate_lineage(
+        self, actor_profile_id: str, campaign_id: str
+    ) -> dict[str, Any] | None:
+        """Return the existing lineage row for (actor_profile_id, campaign_id), or None.
+
+        Used for 409 duplicate-link detection before inserting a new record.
+        The check is on the (actor, campaign) pair regardless of relationship_type —
+        an actor may only be linked to a given campaign once.
+        """
+        row = self._session.execute(
+            text(_LINEAGE_SELECT + "WHERE actor_profile_id = :apid AND campaign_id = :cid LIMIT 1"),
+            {"apid": actor_profile_id, "cid": campaign_id},
+        ).fetchone()
+        return _lineage_row_to_dict(row) if row is not None else None
+
+    def delete_lineage_record(self, lineage_id: str) -> bool:
+        """Hard-delete a campaign_lineage row by id.
+
+        Returns True if a row was deleted, False if the id was not found.
+        Does not modify campaigns, actor_profiles, or any other table.
+        """
+        result = self._session.execute(
+            text("DELETE FROM campaign_lineage WHERE id = :id"),
+            {"id": lineage_id},
+        )
+        return result.rowcount > 0
+
+    def list_actor_campaigns_with_metadata(
+        self,
+        actor_profile_id: str,
+        *,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return lineage rows for an actor, enriched with basic campaign metadata.
+
+        Each row contains the full lineage record plus: campaign_name,
+        campaign_status, campaign_last_seen, campaign_member_ip_count,
+        campaign_has_fingerprint.  Ordered newest-first by lineage.created_at.
+        """
+        rows = self._session.execute(
+            text("""
+                SELECT
+                    cl.id, cl.actor_profile_id, cl.campaign_id,
+                    cl.relationship_type, cl.confidence, cl.evidence_json, cl.created_at,
+                    c.name, c.status, c.last_seen, c.member_ip_count,
+                    (c.representative_fingerprint_json IS NOT NULL)
+                FROM campaign_lineage cl
+                LEFT JOIN campaigns c ON cl.campaign_id = c.id
+                WHERE cl.actor_profile_id = :actor_id
+                ORDER BY cl.created_at DESC
+                LIMIT :limit
+            """),
+            {"actor_id": actor_profile_id, "limit": limit},
+        ).fetchall()
+        return [_lineage_with_campaign_to_dict(r) for r in rows]
+
+    def list_campaign_actors_with_metadata(
+        self,
+        campaign_id: str,
+        *,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return lineage rows for a campaign, enriched with basic actor metadata.
+
+        Each row contains the full lineage record plus: actor_display_name,
+        actor_confidence, actor_status.  Ordered newest-first by lineage.created_at.
+        """
+        rows = self._session.execute(
+            text("""
+                SELECT
+                    cl.id, cl.actor_profile_id, cl.campaign_id,
+                    cl.relationship_type, cl.confidence, cl.evidence_json, cl.created_at,
+                    ap.display_name, ap.confidence, ap.status
+                FROM campaign_lineage cl
+                LEFT JOIN actor_profiles ap ON cl.actor_profile_id = ap.id
+                WHERE cl.campaign_id = :campaign_id
+                ORDER BY cl.created_at DESC
+                LIMIT :limit
+            """),
+            {"campaign_id": campaign_id, "limit": limit},
+        ).fetchall()
+        return [_lineage_with_actor_to_dict(r) for r in rows]

--- a/app/routers/actors.py
+++ b/app/routers/actors.py
@@ -1,9 +1,12 @@
-"""Actor profile CRUD endpoints — Phase 7 Group B1.
+"""Actor profile CRUD and campaign-linking endpoints — Phase 7 Group B1/B2.
 
-POST   /api/actors              — create actor profile (201)
-GET    /api/actors              — list actor profiles
-GET    /api/actors/{id}         — get actor profile detail (404 if not found)
-PATCH  /api/actors/{id}         — partial update (display_name, notes, confidence, status)
+POST   /api/actors                              — create actor profile (201)
+GET    /api/actors                              — list actor profiles
+POST   /api/actors/{id}/campaigns               — link campaign to actor (201)
+GET    /api/actors/{id}/campaigns               — list actor's linked campaigns
+DELETE /api/actors/{id}/campaigns/{lineage_id}  — remove a lineage record (204)
+GET    /api/actors/{id}                         — get actor profile (404 if not found)
+PATCH  /api/actors/{id}                         — partial update actor profile
 
 All endpoints require API key or JWT authentication via require_jwt_or_api_key.
 No SQL belongs here — all queries go through EventRepository.
@@ -11,8 +14,9 @@ No SQL belongs here — all queries go through EventRepository.
 Invariants:
   - No automatic actor attribution.
   - No AI involvement.
-  - All actor records are created by explicit operator action only.
+  - All actor records and lineage records are created by explicit operator action only.
   - relationship_type vocabulary is enforced by actor_constants.VALID_RELATIONSHIP_TYPES.
+  - Duplicate (actor_id, campaign_id) pairs return 409 Conflict.
 """
 
 from __future__ import annotations
@@ -22,7 +26,7 @@ from pydantic import BaseModel, field_validator
 
 from app.db.connection import get_session
 from app.db.repository import EventRepository
-from app.intelligence.actor_constants import VALID_ACTOR_STATUSES
+from app.intelligence.actor_constants import VALID_ACTOR_STATUSES, VALID_RELATIONSHIP_TYPES
 from app.utils.auth import require_jwt_or_api_key
 
 router = APIRouter(prefix="/api/actors", tags=["actors"])
@@ -126,6 +130,138 @@ def list_actors(
     with get_session() as session:
         items = EventRepository(session).list_actor_profiles(status=status, limit=limit)
     return {"items": items, "count": len(items)}
+
+
+class LinkCampaignRequest(BaseModel):
+    campaign_id: str
+    relationship_type: str
+    confidence: float = 0.5
+    evidence: str | None = None
+
+    @field_validator("campaign_id")
+    @classmethod
+    def campaign_id_nonempty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("campaign_id must not be blank")
+        return v
+
+    @field_validator("relationship_type")
+    @classmethod
+    def relationship_type_valid(cls, v: str) -> str:
+        if v not in VALID_RELATIONSHIP_TYPES:
+            raise ValueError(
+                f"Invalid relationship_type {v!r}. "
+                f"Must be one of: {sorted(VALID_RELATIONSHIP_TYPES)}"
+            )
+        return v
+
+    @field_validator("confidence")
+    @classmethod
+    def confidence_range(cls, v: float) -> float:
+        if not (0.0 <= v <= 1.0):
+            raise ValueError("confidence must be between 0.0 and 1.0")
+        return v
+
+
+@router.post("/{actor_id}/campaigns", status_code=status.HTTP_201_CREATED)
+def link_campaign(
+    actor_id: str,
+    body: LinkCampaignRequest,
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Link a campaign to an actor profile.
+
+    Validation order: actor exists → campaign exists → relationship_type in
+    VALID_RELATIONSHIP_TYPES (validated by Pydantic) → duplicate check.
+
+    Returns 409 Conflict when the same (actor_id, campaign_id) pair already
+    exists.  The operator can delete the existing link and re-create it with a
+    corrected relationship_type.
+
+    No automatic attribution.  No AI involvement.  All links are operator-created.
+    """
+    with get_session() as session:
+        repo = EventRepository(session)
+
+        if repo.get_actor_profile(actor_id) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Actor {actor_id!r} not found",
+            )
+        if repo.get_campaign(body.campaign_id) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Campaign {body.campaign_id!r} not found",
+            )
+
+        existing = repo.find_duplicate_lineage(actor_id, body.campaign_id)
+        if existing is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "message": (
+                        f"Campaign {body.campaign_id!r} is already linked to actor {actor_id!r}"
+                    ),
+                    "existing_lineage_id": existing["id"],
+                },
+            )
+
+        lineage = repo.link_campaign_to_actor(
+            actor_profile_id=actor_id,
+            campaign_id=body.campaign_id,
+            relationship_type=body.relationship_type,
+            confidence=body.confidence,
+            evidence_json=body.evidence,
+        )
+    return lineage
+
+
+@router.get("/{actor_id}/campaigns")
+def list_actor_campaigns(
+    actor_id: str,
+    limit: int = Query(default=100, ge=1, le=500),
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return campaigns linked to this actor, enriched with campaign metadata.
+
+    Each item includes the full lineage record (relationship_type, confidence,
+    evidence_json, created_at) plus campaign name, status, last_seen,
+    member_ip_count, and has_fingerprint.  404 if actor not found.
+    """
+    with get_session() as session:
+        repo = EventRepository(session)
+        if repo.get_actor_profile(actor_id) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Actor {actor_id!r} not found",
+            )
+        items = repo.list_actor_campaigns_with_metadata(actor_id, limit=limit)
+    return {"items": items, "count": len(items)}
+
+
+@router.delete("/{actor_id}/campaigns/{lineage_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_actor_campaign_link(
+    actor_id: str,
+    lineage_id: str,
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Remove a campaign-to-actor lineage record.
+
+    Hard-deletes the lineage row only.  The campaign and actor profile are
+    not modified.  The original clustering decision is not modified.
+
+    Returns 204 on success.  Returns 404 if the lineage_id does not exist or
+    does not belong to actor_id.
+    """
+    with get_session() as session:
+        repo = EventRepository(session)
+        record = repo.get_lineage_record(lineage_id)
+        if record is None or record["actor_profile_id"] != actor_id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Lineage record {lineage_id!r} not found for actor {actor_id!r}",
+            )
+        repo.delete_lineage_record(lineage_id)
 
 
 @router.get("/{actor_id}")

--- a/app/routers/campaigns.py
+++ b/app/routers/campaigns.py
@@ -8,6 +8,7 @@ GET  /api/campaigns/{campaign_id}                             — campaign detai
 GET  /api/campaigns/{campaign_id}/observations                — observation list
 GET  /api/campaigns/{campaign_id}/weight-profile              — per-campaign weight profile
 GET  /api/campaigns/{campaign_id}/density                     — full campaign density metrics
+GET  /api/campaigns/{campaign_id}/actors                      — actors linked to this campaign
 
 All endpoints require API key or JWT authentication via require_jwt_or_api_key.
 No SQL belongs here — all queries go through EventRepository.
@@ -345,3 +346,28 @@ def get_campaign_density(
             "density_established": _DENSITY_ESTABLISHED_THRESHOLD,
         },
     }
+
+
+@router.get("/{campaign_id}/actors")
+def get_campaign_actors(
+    campaign_id: str,
+    limit: int = Query(default=100, ge=1, le=500),
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return actors linked to this campaign, with lineage metadata.
+
+    Each item includes the full lineage record (relationship_type, confidence,
+    evidence_json, created_at) plus actor display_name, confidence, and status.
+    Ordered newest-first by lineage.created_at.  404 if campaign not found.
+
+    Read-only.  Does not create or modify any records.
+    """
+    with get_session() as session:
+        repo = EventRepository(session)
+        if repo.get_campaign(campaign_id) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Campaign {campaign_id!r} not found",
+            )
+        items = repo.list_campaign_actors_with_metadata(campaign_id, limit=limit)
+    return {"items": items, "count": len(items)}

--- a/tests/db/test_actor_linking_repository.py
+++ b/tests/db/test_actor_linking_repository.py
@@ -1,0 +1,361 @@
+"""Repository tests for Phase 7 Group B2 — campaign-to-actor linking.
+
+Tests cover:
+  - get_lineage_record: returns row or None
+  - find_duplicate_lineage: detects existing (actor, campaign) pair
+  - delete_lineage_record: hard-deletes, returns True/False
+  - list_actor_campaigns_with_metadata: enriched with campaign fields
+  - list_campaign_actors_with_metadata: enriched with actor fields
+  - No automatic lineage creation
+  - Invariants: no AI imports
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+
+from app.db.repository import EventRepository
+
+_TS = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _ts() -> str:
+    return _TS.isoformat()
+
+
+def _create_actor(session, *, display_name: str = "Test Actor") -> str:
+    aid = str(uuid.uuid4())
+    EventRepository(session).create_actor_profile(
+        actor_id=aid,
+        display_name=display_name,
+        created_at=_ts(),
+        updated_at=_ts(),
+    )
+    return aid
+
+
+def _create_campaign(session, *, name: str | None = None, has_fingerprint: bool = False) -> str:
+    cid = str(uuid.uuid4())
+    now = _ts()
+    session.execute(
+        text("""
+            INSERT INTO campaigns (id, name, status, confidence, first_seen, last_seen,
+                member_ip_count, created_at, updated_at)
+            VALUES (:id, :name, 'active', 0.7, :now, :now, 3, :now, :now)
+        """),
+        {"id": cid, "name": name or f"campaign-{cid[:8]}", "now": now},
+    )
+    if has_fingerprint:
+        session.execute(
+            text("UPDATE campaigns SET representative_fingerprint_json = :fp WHERE id = :id"),
+            {"fp": '{"timing_features": null}', "id": cid},
+        )
+    session.flush()
+    return cid
+
+
+def _link(session, actor_id: str, campaign_id: str, rtype: str = "tactic_match") -> dict:
+    return EventRepository(session).link_campaign_to_actor(
+        actor_profile_id=actor_id,
+        campaign_id=campaign_id,
+        relationship_type=rtype,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_lineage_record
+# ---------------------------------------------------------------------------
+
+
+def test_get_lineage_record_returns_row(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+    lineage = _link(db_session, aid, cid)
+
+    result = EventRepository(db_session).get_lineage_record(lineage["id"])
+    assert result is not None
+    assert result["id"] == lineage["id"]
+    assert result["actor_profile_id"] == aid
+    assert result["campaign_id"] == cid
+
+
+def test_get_lineage_record_returns_none_for_unknown(db_session):
+    result = EventRepository(db_session).get_lineage_record(str(uuid.uuid4()))
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# find_duplicate_lineage
+# ---------------------------------------------------------------------------
+
+
+def test_find_duplicate_lineage_returns_existing(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+    lineage = _link(db_session, aid, cid, "primary_campaign")
+
+    dup = EventRepository(db_session).find_duplicate_lineage(aid, cid)
+    assert dup is not None
+    assert dup["id"] == lineage["id"]
+
+
+def test_find_duplicate_lineage_returns_none_when_no_link(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+    result = EventRepository(db_session).find_duplicate_lineage(aid, cid)
+    assert result is None
+
+
+def test_find_duplicate_lineage_is_actor_campaign_pair_specific(db_session):
+    aid1 = _create_actor(db_session)
+    aid2 = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+
+    _link(db_session, aid1, cid, "tactic_match")
+
+    dup = EventRepository(db_session).find_duplicate_lineage(aid2, cid)
+    assert dup is None
+
+
+def test_find_duplicate_matches_regardless_of_relationship_type(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+    _link(db_session, aid, cid, "infrastructure_reuse")
+
+    dup = EventRepository(db_session).find_duplicate_lineage(aid, cid)
+    assert dup is not None
+    assert dup["relationship_type"] == "infrastructure_reuse"
+
+
+# ---------------------------------------------------------------------------
+# delete_lineage_record
+# ---------------------------------------------------------------------------
+
+
+def test_delete_lineage_returns_true_when_found(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+    lineage = _link(db_session, aid, cid)
+
+    result = EventRepository(db_session).delete_lineage_record(lineage["id"])
+    assert result is True
+
+
+def test_delete_lineage_returns_false_when_not_found(db_session):
+    result = EventRepository(db_session).delete_lineage_record(str(uuid.uuid4()))
+    assert result is False
+
+
+def test_delete_lineage_removes_row(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+    lineage = _link(db_session, aid, cid)
+    EventRepository(db_session).delete_lineage_record(lineage["id"])
+
+    remaining = EventRepository(db_session).get_lineage_record(lineage["id"])
+    assert remaining is None
+
+
+def test_delete_lineage_does_not_delete_campaign(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+    lineage = _link(db_session, aid, cid)
+    EventRepository(db_session).delete_lineage_record(lineage["id"])
+
+    campaign = EventRepository(db_session).get_campaign(cid)
+    assert campaign is not None
+
+
+def test_delete_lineage_does_not_delete_actor(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+    lineage = _link(db_session, aid, cid)
+    EventRepository(db_session).delete_lineage_record(lineage["id"])
+
+    actor = EventRepository(db_session).get_actor_profile(aid)
+    assert actor is not None
+
+
+# ---------------------------------------------------------------------------
+# list_actor_campaigns_with_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_list_actor_campaigns_returns_linked_campaigns(db_session):
+    aid = _create_actor(db_session)
+    cid1 = _create_campaign(db_session, name="camp-one")
+    cid2 = _create_campaign(db_session, name="camp-two")
+
+    repo = EventRepository(db_session)
+    repo.link_campaign_to_actor(
+        actor_profile_id=aid, campaign_id=cid1, relationship_type="primary_campaign"
+    )
+    repo.link_campaign_to_actor(
+        actor_profile_id=aid, campaign_id=cid2, relationship_type="tactic_match"
+    )
+
+    items = repo.list_actor_campaigns_with_metadata(aid)
+    campaign_ids = {i["campaign_id"] for i in items}
+    assert cid1 in campaign_ids
+    assert cid2 in campaign_ids
+
+
+def test_list_actor_campaigns_includes_campaign_metadata(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session, name="named-camp", has_fingerprint=True)
+    _link(db_session, aid, cid, "tactic_match")
+
+    items = EventRepository(db_session).list_actor_campaigns_with_metadata(aid)
+    assert len(items) == 1
+    item = items[0]
+    assert item["campaign_name"] == "named-camp"
+    assert item["campaign_status"] == "active"
+    assert item["campaign_last_seen"] is not None
+    assert item["campaign_member_ip_count"] == 3
+    assert item["campaign_has_fingerprint"] is True
+
+
+def test_list_actor_campaigns_has_fingerprint_false_when_null(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session, has_fingerprint=False)
+    _link(db_session, aid, cid)
+
+    items = EventRepository(db_session).list_actor_campaigns_with_metadata(aid)
+    assert items[0]["campaign_has_fingerprint"] is False
+
+
+def test_list_actor_campaigns_includes_relationship_type(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+    _link(db_session, aid, cid, "infrastructure_reuse")
+
+    items = EventRepository(db_session).list_actor_campaigns_with_metadata(aid)
+    assert items[0]["relationship_type"] == "infrastructure_reuse"
+
+
+def test_list_actor_campaigns_empty_for_no_links(db_session):
+    aid = _create_actor(db_session)
+    items = EventRepository(db_session).list_actor_campaigns_with_metadata(aid)
+    assert items == []
+
+
+def test_list_actor_campaigns_only_returns_own_actor_links(db_session):
+    aid1 = _create_actor(db_session)
+    aid2 = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+
+    _link(db_session, aid2, cid)
+
+    items = EventRepository(db_session).list_actor_campaigns_with_metadata(aid1)
+    assert items == []
+
+
+def test_list_actor_campaigns_respects_limit(db_session):
+    aid = _create_actor(db_session)
+    for _ in range(5):
+        cid = _create_campaign(db_session)
+        _link(db_session, aid, cid)
+
+    items = EventRepository(db_session).list_actor_campaigns_with_metadata(aid, limit=2)
+    assert len(items) == 2
+
+
+# ---------------------------------------------------------------------------
+# list_campaign_actors_with_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_list_campaign_actors_returns_linked_actors(db_session):
+    aid1 = _create_actor(db_session, display_name="Actor One")
+    aid2 = _create_actor(db_session, display_name="Actor Two")
+    cid = _create_campaign(db_session)
+
+    _link(db_session, aid1, cid, "tactic_match")
+    _link(db_session, aid2, cid, "temporal_overlap")
+
+    items = EventRepository(db_session).list_campaign_actors_with_metadata(cid)
+    actor_ids = {i["actor_profile_id"] for i in items}
+    assert aid1 in actor_ids
+    assert aid2 in actor_ids
+
+
+def test_list_campaign_actors_includes_actor_metadata(db_session):
+    aid = _create_actor(db_session, display_name="Named Actor")
+    cid = _create_campaign(db_session)
+    _link(db_session, aid, cid, "primary_campaign")
+
+    items = EventRepository(db_session).list_campaign_actors_with_metadata(cid)
+    assert len(items) == 1
+    item = items[0]
+    assert item["actor_display_name"] == "Named Actor"
+    assert item["actor_status"] == "active"
+    assert item["actor_confidence"] == pytest.approx(0.5)
+
+
+def test_list_campaign_actors_includes_relationship_type(db_session):
+    aid = _create_actor(db_session)
+    cid = _create_campaign(db_session)
+    _link(db_session, aid, cid, "temporal_overlap")
+
+    items = EventRepository(db_session).list_campaign_actors_with_metadata(cid)
+    assert items[0]["relationship_type"] == "temporal_overlap"
+
+
+def test_list_campaign_actors_empty_for_no_links(db_session):
+    cid = _create_campaign(db_session)
+    items = EventRepository(db_session).list_campaign_actors_with_metadata(cid)
+    assert items == []
+
+
+def test_list_campaign_actors_only_returns_own_campaign_links(db_session):
+    aid = _create_actor(db_session)
+    cid1 = _create_campaign(db_session)
+    cid2 = _create_campaign(db_session)
+
+    _link(db_session, aid, cid2)
+
+    items = EventRepository(db_session).list_campaign_actors_with_metadata(cid1)
+    assert items == []
+
+
+def test_list_campaign_actors_respects_limit(db_session):
+    cid = _create_campaign(db_session)
+    for _ in range(4):
+        aid = _create_actor(db_session)
+        _link(db_session, aid, cid)
+
+    items = EventRepository(db_session).list_campaign_actors_with_metadata(cid, limit=2)
+    assert len(items) == 2
+
+
+# ---------------------------------------------------------------------------
+# No automatic lineage creation
+# ---------------------------------------------------------------------------
+
+
+def test_creating_actor_and_campaign_does_not_create_lineage(db_session):
+    _create_actor(db_session)
+    _create_campaign(db_session)
+    lineage = EventRepository(db_session).list_campaign_lineage()
+    assert lineage == []
+
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+
+
+def test_no_ai_imports_in_actor_repository():
+    import importlib
+
+    mod = importlib.import_module("app.db.repositories.actor")
+    src = mod.__file__
+    assert src is not None
+    with open(src) as f:
+        content = f.read()
+    assert "from app.ai" not in content
+    assert "import app.ai" not in content

--- a/tests/integration/test_actor_linking_endpoints.py
+++ b/tests/integration/test_actor_linking_endpoints.py
@@ -1,0 +1,525 @@
+"""Integration tests for Phase 7 Group B2 — campaign-to-actor linking API.
+
+Tests hit the full stack: FastAPI TestClient → routers → EventRepository → SQLite.
+
+Coverage:
+  POST /api/actors/{id}/campaigns:
+    - valid link creation returns 201 with lineage record
+    - unknown actor returns 404
+    - unknown campaign returns 404
+    - invalid relationship_type returns 422
+    - duplicate (actor, campaign) pair returns 409 with existing_lineage_id
+    - confidence out of range returns 422
+    - requires authentication
+
+  GET /api/actors/{id}/campaigns:
+    - returns linked campaigns with metadata
+    - empty list when actor has no links
+    - unknown actor returns 404
+    - requires authentication
+
+  DELETE /api/actors/{id}/campaigns/{lineage_id}:
+    - valid delete returns 204
+    - lineage belonging to different actor returns 404
+    - unknown lineage_id returns 404
+    - does not delete campaign
+    - does not delete actor
+    - requires authentication
+
+  GET /api/campaigns/{id}/actors:
+    - returns linked actors with metadata
+    - empty list when campaign has no links
+    - unknown campaign returns 404
+    - requires authentication
+
+  Invariants:
+    - no automatic lineage creation on ingest
+    - actors router does not import from app.ai
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db.connection import get_session
+from app.db.repository import EventRepository
+from app.main import app
+
+client = TestClient(app)
+
+_API_KEY = "test-key"
+_HEADERS = {"X-API-Key": _API_KEY}
+
+
+@pytest.fixture(autouse=True)
+def setup_api_key(monkeypatch):
+    monkeypatch.setenv("API_KEY", _API_KEY)
+    monkeypatch.setenv("FEED_SALT", "test-salt")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_actor(display_name: str = "Test Actor") -> dict:
+    resp = client.post("/api/actors", json={"display_name": display_name}, headers=_HEADERS)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def _create_campaign() -> str:
+    from datetime import UTC, datetime
+
+    cid = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    with get_session() as session:
+        EventRepository(session).create_campaign(
+            campaign_id=cid,
+            name=f"test-{cid[:8]}",
+            status="active",
+            confidence=0.7,
+            first_seen=now,
+            last_seen=now,
+            member_ip_count=2,
+            created_at=now,
+            updated_at=now,
+        )
+    return cid
+
+
+def _link(actor_id: str, campaign_id: str, rtype: str = "tactic_match") -> dict:
+    resp = client.post(
+        f"/api/actors/{actor_id}/campaigns",
+        json={"campaign_id": campaign_id, "relationship_type": rtype},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/actors/{id}/campaigns
+# ---------------------------------------------------------------------------
+
+
+def test_link_campaign_returns_201():
+    actor = _create_actor()
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "primary_campaign"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 201
+
+
+def test_link_campaign_response_fields():
+    actor = _create_actor()
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={
+            "campaign_id": cid,
+            "relationship_type": "tactic_match",
+            "confidence": 0.8,
+            "evidence": "observed same port sequence",
+        },
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["actor_profile_id"] == actor["id"]
+    assert data["campaign_id"] == cid
+    assert data["relationship_type"] == "tactic_match"
+    assert data["confidence"] == pytest.approx(0.8)
+    assert data["evidence_json"] == "observed same port sequence"
+    assert data["id"] is not None
+    assert data["created_at"] is not None
+
+
+def test_link_all_valid_relationship_types():
+    from app.intelligence.actor_constants import VALID_RELATIONSHIP_TYPES
+
+    for rtype in sorted(VALID_RELATIONSHIP_TYPES):
+        actor = _create_actor(f"Actor for {rtype}")
+        cid = _create_campaign()
+        resp = client.post(
+            f"/api/actors/{actor['id']}/campaigns",
+            json={"campaign_id": cid, "relationship_type": rtype},
+            headers=_HEADERS,
+        )
+        assert resp.status_code == 201, f"Expected 201 for {rtype}, got {resp.status_code}"
+        assert resp.json()["relationship_type"] == rtype
+
+
+def test_link_unknown_actor_returns_404():
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{uuid.uuid4()}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 404
+
+
+def test_link_unknown_campaign_returns_404():
+    actor = _create_actor()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": str(uuid.uuid4()), "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 404
+
+
+def test_link_invalid_relationship_type_returns_422():
+    actor = _create_actor()
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "made_up"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+def test_link_empty_relationship_type_returns_422():
+    actor = _create_actor()
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": ""},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+def test_link_confidence_out_of_range_returns_422():
+    actor = _create_actor()
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match", "confidence": 1.5},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+def test_link_duplicate_returns_409():
+    actor = _create_actor()
+    cid = _create_campaign()
+    first = _link(actor["id"], cid, "primary_campaign")
+
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["existing_lineage_id"] == first["id"]
+
+
+def test_link_duplicate_includes_existing_lineage_id_in_response():
+    actor = _create_actor()
+    cid = _create_campaign()
+    first = _link(actor["id"], cid)
+
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["existing_lineage_id"] == first["id"]
+
+
+def test_link_requires_auth():
+    actor = _create_actor()
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+    )
+    assert resp.status_code == 401
+
+
+def test_link_missing_campaign_id_returns_422():
+    actor = _create_actor()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+def test_link_missing_relationship_type_returns_422():
+    actor = _create_actor()
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/actors/{id}/campaigns
+# ---------------------------------------------------------------------------
+
+
+def test_list_actor_campaigns_returns_200():
+    actor = _create_actor()
+    resp = client.get(f"/api/actors/{actor['id']}/campaigns", headers=_HEADERS)
+    assert resp.status_code == 200
+
+
+def test_list_actor_campaigns_empty_when_no_links():
+    actor = _create_actor()
+    resp = client.get(f"/api/actors/{actor['id']}/campaigns", headers=_HEADERS)
+    data = resp.json()
+    assert data["items"] == []
+    assert data["count"] == 0
+
+
+def test_list_actor_campaigns_returns_linked_items():
+    actor = _create_actor()
+    cid1 = _create_campaign()
+    cid2 = _create_campaign()
+    _link(actor["id"], cid1, "primary_campaign")
+    _link(actor["id"], cid2, "tactic_match")
+
+    resp = client.get(f"/api/actors/{actor['id']}/campaigns", headers=_HEADERS)
+    data = resp.json()
+    assert data["count"] == 2
+    cids = {item["campaign_id"] for item in data["items"]}
+    assert cid1 in cids
+    assert cid2 in cids
+
+
+def test_list_actor_campaigns_includes_campaign_metadata():
+    actor = _create_actor()
+    cid = _create_campaign()
+    _link(actor["id"], cid)
+
+    resp = client.get(f"/api/actors/{actor['id']}/campaigns", headers=_HEADERS)
+    item = resp.json()["items"][0]
+    assert "campaign_name" in item
+    assert "campaign_status" in item
+    assert "campaign_last_seen" in item
+    assert "campaign_has_fingerprint" in item
+
+
+def test_list_actor_campaigns_unknown_actor_returns_404():
+    resp = client.get(f"/api/actors/{uuid.uuid4()}/campaigns", headers=_HEADERS)
+    assert resp.status_code == 404
+
+
+def test_list_actor_campaigns_requires_auth():
+    actor = _create_actor()
+    resp = client.get(f"/api/actors/{actor['id']}/campaigns")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/actors/{id}/campaigns/{lineage_id}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_link_returns_204():
+    actor = _create_actor()
+    cid = _create_campaign()
+    lineage = _link(actor["id"], cid)
+
+    resp = client.delete(f"/api/actors/{actor['id']}/campaigns/{lineage['id']}", headers=_HEADERS)
+    assert resp.status_code == 204
+
+
+def test_delete_link_removes_lineage_record():
+    actor = _create_actor()
+    cid = _create_campaign()
+    lineage = _link(actor["id"], cid)
+
+    client.delete(f"/api/actors/{actor['id']}/campaigns/{lineage['id']}", headers=_HEADERS)
+
+    with get_session() as session:
+        record = EventRepository(session).get_lineage_record(lineage["id"])
+    assert record is None
+
+
+def test_delete_link_does_not_delete_campaign():
+    actor = _create_actor()
+    cid = _create_campaign()
+    lineage = _link(actor["id"], cid)
+
+    client.delete(f"/api/actors/{actor['id']}/campaigns/{lineage['id']}", headers=_HEADERS)
+
+    with get_session() as session:
+        campaign = EventRepository(session).get_campaign(cid)
+    assert campaign is not None
+
+
+def test_delete_link_does_not_delete_actor():
+    actor = _create_actor()
+    cid = _create_campaign()
+    lineage = _link(actor["id"], cid)
+
+    client.delete(f"/api/actors/{actor['id']}/campaigns/{lineage['id']}", headers=_HEADERS)
+
+    resp = client.get(f"/api/actors/{actor['id']}", headers=_HEADERS)
+    assert resp.status_code == 200
+
+
+def test_delete_link_wrong_actor_returns_404():
+    actor1 = _create_actor("Actor One")
+    actor2 = _create_actor("Actor Two")
+    cid = _create_campaign()
+    lineage = _link(actor1["id"], cid)
+
+    resp = client.delete(f"/api/actors/{actor2['id']}/campaigns/{lineage['id']}", headers=_HEADERS)
+    assert resp.status_code == 404
+
+
+def test_delete_link_unknown_lineage_returns_404():
+    actor = _create_actor()
+    resp = client.delete(f"/api/actors/{actor['id']}/campaigns/{uuid.uuid4()}", headers=_HEADERS)
+    assert resp.status_code == 404
+
+
+def test_delete_link_allows_relink_after_deletion():
+    actor = _create_actor()
+    cid = _create_campaign()
+    lineage = _link(actor["id"], cid, "tactic_match")
+
+    client.delete(f"/api/actors/{actor['id']}/campaigns/{lineage['id']}", headers=_HEADERS)
+
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "primary_campaign"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["relationship_type"] == "primary_campaign"
+
+
+def test_delete_link_requires_auth():
+    actor = _create_actor()
+    cid = _create_campaign()
+    lineage = _link(actor["id"], cid)
+
+    resp = client.delete(f"/api/actors/{actor['id']}/campaigns/{lineage['id']}")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/campaigns/{id}/actors
+# ---------------------------------------------------------------------------
+
+
+def test_get_campaign_actors_returns_200():
+    cid = _create_campaign()
+    resp = client.get(f"/api/campaigns/{cid}/actors", headers=_HEADERS)
+    assert resp.status_code == 200
+
+
+def test_get_campaign_actors_empty_when_no_links():
+    cid = _create_campaign()
+    resp = client.get(f"/api/campaigns/{cid}/actors", headers=_HEADERS)
+    data = resp.json()
+    assert data["items"] == []
+    assert data["count"] == 0
+
+
+def test_get_campaign_actors_returns_linked_actors():
+    actor1 = _create_actor("Actor A")
+    actor2 = _create_actor("Actor B")
+    cid = _create_campaign()
+    _link(actor1["id"], cid, "tactic_match")
+    _link(actor2["id"], cid, "temporal_overlap")
+
+    resp = client.get(f"/api/campaigns/{cid}/actors", headers=_HEADERS)
+    data = resp.json()
+    assert data["count"] == 2
+    actor_ids = {item["actor_profile_id"] for item in data["items"]}
+    assert actor1["id"] in actor_ids
+    assert actor2["id"] in actor_ids
+
+
+def test_get_campaign_actors_includes_actor_metadata():
+    actor = _create_actor("Named Actor")
+    cid = _create_campaign()
+    _link(actor["id"], cid, "primary_campaign")
+
+    resp = client.get(f"/api/campaigns/{cid}/actors", headers=_HEADERS)
+    item = resp.json()["items"][0]
+    assert item["actor_display_name"] == "Named Actor"
+    assert "actor_status" in item
+    assert "actor_confidence" in item
+
+
+def test_get_campaign_actors_includes_relationship_type():
+    actor = _create_actor()
+    cid = _create_campaign()
+    _link(actor["id"], cid, "infrastructure_reuse")
+
+    resp = client.get(f"/api/campaigns/{cid}/actors", headers=_HEADERS)
+    assert resp.json()["items"][0]["relationship_type"] == "infrastructure_reuse"
+
+
+def test_get_campaign_actors_unknown_campaign_returns_404():
+    resp = client.get(f"/api/campaigns/{uuid.uuid4()}/actors", headers=_HEADERS)
+    assert resp.status_code == 404
+
+
+def test_get_campaign_actors_requires_auth():
+    cid = _create_campaign()
+    resp = client.get(f"/api/campaigns/{cid}/actors")
+    assert resp.status_code == 401
+
+
+def test_get_campaign_actors_only_returns_own_campaign_links():
+    actor = _create_actor()
+    cid1 = _create_campaign()
+    cid2 = _create_campaign()
+    _link(actor["id"], cid1)
+
+    resp = client.get(f"/api/campaigns/{cid2}/actors", headers=_HEADERS)
+    assert resp.json()["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+
+
+def test_no_automatic_lineage_on_ingest():
+    event = {
+        "id": str(uuid.uuid4()),
+        "ts": "2026-05-01T00:00:00+00:00",
+        "src_ip": "10.0.0.1",
+        "event_type": "ssh_login",
+        "dst_port": 22,
+    }
+    client.post("/api/ingest", json={"events": [event]}, headers=_HEADERS)
+
+    with get_session() as session:
+        lineage = EventRepository(session).list_campaign_lineage()
+    assert lineage == []
+
+
+def test_actors_router_does_not_import_ai():
+    import importlib
+
+    mod = importlib.import_module("app.routers.actors")
+    src = mod.__file__
+    assert src is not None
+    with open(src) as f:
+        content = f.read()
+    assert "from app.ai" not in content
+    assert "import app.ai" not in content


### PR DESCRIPTION
## Summary

Implements Phase 7 Group B2 — Campaign-to-Actor Linking.

This PR adds explicit operator-controlled linking between actor profiles and campaigns.

### Included

- POST /api/actors/{id}/campaigns
- GET /api/actors/{id}/campaigns
- GET /api/campaigns/{id}/actors
- DELETE /api/actors/{id}/campaigns/{lineage_id}
- Duplicate link protection
- Relationship type validation
- Actor and campaign existence checks
- Repository support
- Integration and DB tests

### Design Principles

- No automatic attribution
- No AI actor linking
- No actor suggestions yet
- No campaign merging
- No federation
- Explicit operator action only

### Validation

- Black passed
- Ruff passed
- Pre-commit passed
- 1546 tests passed
- No regressions detected