### PR TITLE
feat(phase7): implement actor suggestion engine

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -72,6 +72,12 @@ class Settings(BaseSettings):
     SPARSE_AGE_HOURS_MATURE: float = 168.0  # age span (hours) for a mature score (1 week)
     SPARSE_AGE_HOURS_ESTABLISHED: float = 24.0  # age span (hours) for established (1 day)
 
+    # ---------------------------------------------------------------------------
+    # Phase 7 — actor suggestion engine (B3)
+    # ---------------------------------------------------------------------------
+    ACTOR_SUGGESTION_MIN_SCORE: float = 0.85
+    ACTOR_SUGGESTION_LIMIT: int = 20
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     @field_validator(
@@ -92,6 +98,7 @@ class Settings(BaseSettings):
         "SIMILARITY_UNCERTAIN_LOW",
         "TEMPORAL_THRESHOLD_6M",
         "TEMPORAL_THRESHOLD_12M",
+        "ACTOR_SUGGESTION_MIN_SCORE",
     )
     @classmethod
     def threshold_in_range(cls, v: float) -> float:
@@ -99,7 +106,12 @@ class Settings(BaseSettings):
             raise ValueError(f"Similarity threshold must be in (0, 1]; got {v}")
         return v
 
-    @field_validator("MIN_EVENTS_FOR_CLUSTERING", "CAMPAIGN_ACTIVE_DAYS", "CAMPAIGN_DORMANT_DAYS")
+    @field_validator(
+        "MIN_EVENTS_FOR_CLUSTERING",
+        "CAMPAIGN_ACTIVE_DAYS",
+        "CAMPAIGN_DORMANT_DAYS",
+        "ACTOR_SUGGESTION_LIMIT",
+    )
     @classmethod
     def positive_int(cls, v: int) -> int:
         if v < 1:

--- a/app/db/repositories/actor.py
+++ b/app/db/repositories/actor.py
@@ -275,3 +275,75 @@ class ActorRepository(RepositoryBase):
             params,
         ).fetchall()
         return [_lineage_row_to_dict(r) for r in rows]
+
+    def list_campaigns_for_suggestions(self, *, limit: int = 500) -> list[dict[str, Any]]:
+        """Return campaigns eligible for actor suggestion comparison.
+
+        Only campaigns with a non-NULL representative_fingerprint_json and
+        status in (active, dormant, reactivated) are returned.  The feature
+        columns are extracted from the fingerprint JSON so callers can pass
+        the result directly to compute_weighted_similarity.
+
+        Campaigns whose fingerprint JSON cannot be parsed are silently skipped.
+        """
+        rows = self._session.execute(
+            text("""
+                SELECT id, name, status, last_seen, member_ip_count,
+                       representative_fingerprint_json
+                FROM campaigns
+                WHERE representative_fingerprint_json IS NOT NULL
+                  AND status IN ('active', 'dormant', 'reactivated')
+                ORDER BY last_seen DESC
+                LIMIT :limit
+            """),
+            {"limit": limit},
+        ).fetchall()
+
+        results: list[dict[str, Any]] = []
+        for row in rows:
+            cid, name, status, last_seen, member_ip_count, rep_fp_json = row
+            try:
+                fp_data = json.loads(rep_fp_json)
+            except (json.JSONDecodeError, TypeError, AttributeError):
+                continue
+            results.append(
+                {
+                    "id": cid,
+                    "name": name,
+                    "status": status,
+                    "last_seen": last_seen,
+                    "member_ip_count": member_ip_count,
+                    "timing_features": fp_data.get("timing_features"),
+                    "sequence_features": fp_data.get("sequence_features"),
+                    "protocol_features": fp_data.get("protocol_features"),
+                    "credential_features": fp_data.get("credential_features"),
+                    "target_features": fp_data.get("target_features"),
+                }
+            )
+        return results
+
+    def get_coattributed_campaign_pairs(self) -> set[frozenset[str]]:
+        """Return campaign pairs already linked through a common actor.
+
+        Two campaigns are co-attributed when both appear in campaign_lineage
+        under the same actor_profile_id — regardless of relationship_type.
+        These pairs are excluded from actor suggestions.
+        """
+        rows = self._session.execute(
+            text(
+                "SELECT actor_profile_id, campaign_id"
+                " FROM campaign_lineage ORDER BY actor_profile_id"
+            ),
+        ).fetchall()
+
+        actor_campaigns: dict[str, list[str]] = {}
+        for actor_id, campaign_id in rows:
+            actor_campaigns.setdefault(actor_id, []).append(campaign_id)
+
+        pairs: set[frozenset[str]] = set()
+        for cids in actor_campaigns.values():
+            if len(cids) >= 2:
+                for i in range(len(cids)):
+                    for j in range(i + 1, len(cids)):
+                        pairs.add(frozenset({cids[i], cids[j]}))
+        return pairs

--- a/app/intelligence/actor_suggestions.py
+++ b/app/intelligence/actor_suggestions.py
@@ -1,0 +1,100 @@
+"""Actor suggestion engine — Phase 7 Group B3.
+
+Pure computation: no database access, no I/O, no side effects.
+Advisory only — results are never written to any table automatically.
+
+build_actor_suggestions() compares campaign representative fingerprints
+pairwise and returns candidate pairs above a configurable similarity
+threshold.  The operator decides whether to act on any suggestion.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+from app.intelligence.similarity import SimilarityResult, compute_weighted_similarity
+
+
+def _derive_relationship_type(result: SimilarityResult) -> str:
+    """Return an advisory relationship_type hint based on per-dimension scores.
+
+    Heuristic thresholds (blueprint §7.4):
+      sequence >= 0.85 AND timing >= 0.80  → primary_campaign
+      timing   >= 0.80 AND sequence < 0.70 → infrastructure_reuse
+      protocol >= 0.80                     → tactic_match
+      otherwise                            → temporal_overlap
+
+    This is a suggestion only — never used to write to any table.
+    """
+    ts = result.timing_similarity or 0.0
+    ss = result.sequence_similarity or 0.0
+    ps = result.protocol_similarity or 0.0
+
+    if ss >= 0.85 and ts >= 0.80:
+        return "primary_campaign"
+    if ts >= 0.80 and ss < 0.70:
+        return "infrastructure_reuse"
+    if ps >= 0.80:
+        return "tactic_match"
+    return "temporal_overlap"
+
+
+def _campaign_summary(c: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": c["id"],
+        "name": c["name"],
+        "status": c["status"],
+        "last_seen": c["last_seen"],
+        "member_ip_count": c["member_ip_count"],
+    }
+
+
+def build_actor_suggestions(
+    campaigns: list[dict[str, Any]],
+    coattributed_pairs: set[frozenset[str]],
+    *,
+    min_score: float,
+    limit: int,
+) -> tuple[list[dict[str, Any]], int]:
+    """Compute pairwise campaign similarity and return top suggestions.
+
+    campaigns — list of campaign dicts from list_campaigns_for_suggestions().
+      Each dict must contain: id, name, status, last_seen, member_ip_count
+      and the feature columns accepted by compute_weighted_similarity().
+
+    coattributed_pairs — frozenset pairs from get_coattributed_campaign_pairs().
+      Any pair already linked under a common actor is skipped.
+
+    Returns (suggestions, total_pairs_evaluated).
+      suggestions: sorted by similarity_score DESC, capped at limit.
+      total_pairs_evaluated: count of pairs scored (coattributed pairs excluded).
+
+    This function never reads from or writes to any table.
+    """
+    suggestions: list[dict[str, Any]] = []
+    total_evaluated = 0
+
+    for c_a, c_b in itertools.combinations(campaigns, 2):
+        pair = frozenset({c_a["id"], c_b["id"]})
+        if pair in coattributed_pairs:
+            continue
+
+        total_evaluated += 1
+        result = compute_weighted_similarity(c_a, c_b)
+
+        if result.weighted_total < min_score:
+            continue
+
+        suggestions.append(
+            {
+                "campaign_a": _campaign_summary(c_a),
+                "campaign_b": _campaign_summary(c_b),
+                "similarity_score": result.weighted_total,
+                "breakdown": result.as_dict(),
+                "suggested_relationship_type": _derive_relationship_type(result),
+            }
+        )
+
+    suggestions.sort(key=lambda x: x["similarity_score"], reverse=True)
+    return suggestions[:limit], total_evaluated

--- a/app/routers/actors.py
+++ b/app/routers/actors.py
@@ -1,7 +1,8 @@
-"""Actor profile CRUD endpoints — Phase 7 Group B1.
+"""Actor profile CRUD and suggestion endpoints — Phase 7 Group B1/B3.
 
 POST   /api/actors              — create actor profile (201)
 GET    /api/actors              — list actor profiles
+GET    /api/actors/suggestions  — candidate campaign pairs for attribution review (read-only)
 GET    /api/actors/{id}         — get actor profile detail (404 if not found)
 PATCH  /api/actors/{id}         — partial update (display_name, notes, confidence, status)
 
@@ -20,9 +21,11 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, field_validator
 
+from app.core.config import settings as _settings
 from app.db.connection import get_session
 from app.db.repository import EventRepository
 from app.intelligence.actor_constants import VALID_ACTOR_STATUSES
+from app.intelligence.actor_suggestions import build_actor_suggestions
 from app.utils.auth import require_jwt_or_api_key
 
 router = APIRouter(prefix="/api/actors", tags=["actors"])
@@ -126,6 +129,51 @@ def list_actors(
     with get_session() as session:
         items = EventRepository(session).list_actor_profiles(status=status, limit=limit)
     return {"items": items, "count": len(items)}
+
+
+@router.get("/suggestions")
+def get_actor_suggestions(
+    min_score: float | None = Query(default=None, ge=0.0, le=1.0),
+    limit: int | None = Query(default=None, ge=1, le=100),
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return candidate campaign pairs for actor attribution review.
+
+    Compares representative fingerprints of active/dormant/reactivated
+    campaigns pairwise.  Pairs already co-attributed to the same actor
+    via campaign_lineage are excluded.
+
+    Results are sorted by similarity_score DESC and capped at limit.
+    suggested_relationship_type is advisory only — it is never written
+    to any table automatically.  Campaigns without a representative
+    fingerprint are excluded from comparison.
+
+    Read-only.  No writes to actor_profiles, campaign_lineage, or campaigns.
+    """
+    effective_min_score = (
+        min_score if min_score is not None else _settings.ACTOR_SUGGESTION_MIN_SCORE
+    )
+    effective_limit = limit if limit is not None else _settings.ACTOR_SUGGESTION_LIMIT
+
+    with get_session() as session:
+        repo = EventRepository(session)
+        campaigns = repo.list_campaigns_for_suggestions()
+        coattributed_pairs = repo.get_coattributed_campaign_pairs()
+
+    suggestions, total_evaluated = build_actor_suggestions(
+        campaigns,
+        coattributed_pairs,
+        min_score=effective_min_score,
+        limit=effective_limit,
+    )
+
+    return {
+        "suggestions": suggestions,
+        "count": len(suggestions),
+        "total_pairs_evaluated": total_evaluated,
+        "min_score_applied": effective_min_score,
+        "campaigns_evaluated": len(campaigns),
+    }
 
 
 @router.get("/{actor_id}")

--- a/tests/db/test_actor_suggestion_repository.py
+++ b/tests/db/test_actor_suggestion_repository.py
@@ -1,0 +1,321 @@
+"""Repository tests for Phase 7 Group B3 — actor suggestion support queries.
+
+Tests cover:
+  list_campaigns_for_suggestions:
+    - returns empty list when no eligible campaigns
+    - excludes campaigns with NULL representative_fingerprint_json
+    - excludes campaigns with status 'archived' or 'merged'
+    - includes active, dormant, reactivated campaigns with fingerprints
+    - parses fingerprint JSON and exposes feature columns
+    - skips rows with unparseable fingerprint JSON
+    - respects limit parameter
+    - returns newest last_seen first
+
+  get_coattributed_campaign_pairs:
+    - returns empty set when campaign_lineage is empty
+    - returns empty set when actors have only one campaign each
+    - returns pairs for actors with two or more campaigns
+    - pair is a frozenset (order-independent)
+    - multiple actors each contribute independent pairs
+    - same pair from two actors is deduplicated
+
+All tests use an isolated in-memory SQLite database via the db_session fixture.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from app.db.repository import EventRepository
+
+_TS = "2026-05-01T12:00:00+00:00"
+_TS2 = "2026-05-02T12:00:00+00:00"
+_TS3 = "2026-05-03T12:00:00+00:00"
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+def _insert_campaign(
+    session,
+    *,
+    cid: str | None = None,
+    status: str = "active",
+    last_seen: str = _TS,
+    representative_fingerprint_json: str | None = None,
+    member_ip_count: int = 1,
+) -> str:
+    from sqlalchemy import text
+
+    cid = cid or _uid()
+    session.execute(
+        text("""
+            INSERT INTO campaigns (
+                id, name, status, confidence,
+                first_seen, last_seen, member_ip_count,
+                representative_fingerprint_json,
+                created_at, updated_at
+            ) VALUES (
+                :id, :name, :status, 0.7,
+                :ts, :last_seen, :member_ip_count,
+                :fp_json,
+                :ts, :ts
+            )
+        """),
+        {
+            "id": cid,
+            "name": f"campaign-{cid[:8]}",
+            "status": status,
+            "ts": _TS,
+            "last_seen": last_seen,
+            "member_ip_count": member_ip_count,
+            "fp_json": representative_fingerprint_json,
+        },
+    )
+    session.flush()
+    return cid
+
+
+def _make_fingerprint_json(
+    timing: str | None = None,
+    sequence: str | None = None,
+) -> str:
+    """Build a minimal representative_fingerprint_json string."""
+    return json.dumps(
+        {
+            "timing_features": timing,
+            "sequence_features": sequence,
+            "protocol_features": None,
+            "credential_features": None,
+            "target_features": None,
+        }
+    )
+
+
+def _insert_actor(session, *, aid: str | None = None) -> str:
+    aid = aid or _uid()
+    now = _TS
+    session.execute(
+        __import__("sqlalchemy").text("""
+            INSERT INTO actor_profiles (
+                id, display_name, confidence, status, created_at, updated_at
+            ) VALUES (:id, :name, 0.5, 'active', :now, :now)
+        """),
+        {"id": aid, "name": f"actor-{aid[:8]}", "now": now},
+    )
+    session.flush()
+    return aid
+
+
+def _link(session, *, actor_id: str, campaign_id: str) -> None:
+    from sqlalchemy import text
+
+    lid = _uid()
+    session.execute(
+        text("""
+            INSERT INTO campaign_lineage (
+                id, actor_profile_id, campaign_id,
+                relationship_type, confidence, created_at
+            ) VALUES (:id, :actor_id, :campaign_id, 'temporal_overlap', 0.5, :now)
+        """),
+        {"id": lid, "actor_id": actor_id, "campaign_id": campaign_id, "now": _TS},
+    )
+    session.flush()
+
+
+# ---------------------------------------------------------------------------
+# list_campaigns_for_suggestions
+# ---------------------------------------------------------------------------
+
+
+def test_list_campaigns_for_suggestions_empty(db_session):
+    items = EventRepository(db_session).list_campaigns_for_suggestions()
+    assert items == []
+
+
+def test_list_campaigns_for_suggestions_excludes_null_fingerprint(db_session):
+    _insert_campaign(db_session, status="active", representative_fingerprint_json=None)
+    items = EventRepository(db_session).list_campaigns_for_suggestions()
+    assert items == []
+
+
+def test_list_campaigns_for_suggestions_excludes_archived(db_session):
+    fp = _make_fingerprint_json()
+    _insert_campaign(db_session, status="archived", representative_fingerprint_json=fp)
+    items = EventRepository(db_session).list_campaigns_for_suggestions()
+    assert items == []
+
+
+def test_list_campaigns_for_suggestions_includes_active(db_session):
+    fp = _make_fingerprint_json()
+    cid = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    items = EventRepository(db_session).list_campaigns_for_suggestions()
+    assert len(items) == 1
+    assert items[0]["id"] == cid
+
+
+def test_list_campaigns_for_suggestions_includes_dormant(db_session):
+    fp = _make_fingerprint_json()
+    cid = _insert_campaign(db_session, status="dormant", representative_fingerprint_json=fp)
+    items = EventRepository(db_session).list_campaigns_for_suggestions()
+    assert len(items) == 1
+    assert items[0]["id"] == cid
+
+
+def test_list_campaigns_for_suggestions_includes_reactivated(db_session):
+    fp = _make_fingerprint_json()
+    cid = _insert_campaign(db_session, status="reactivated", representative_fingerprint_json=fp)
+    items = EventRepository(db_session).list_campaigns_for_suggestions()
+    assert len(items) == 1
+    assert items[0]["id"] == cid
+
+
+def test_list_campaigns_for_suggestions_has_expected_fields(db_session):
+    timing_json = json.dumps({"interval": {"mean": 60.0}})
+    fp = _make_fingerprint_json(timing=timing_json)
+    cid = _insert_campaign(
+        db_session,
+        status="active",
+        representative_fingerprint_json=fp,
+        member_ip_count=3,
+    )
+    items = EventRepository(db_session).list_campaigns_for_suggestions()
+    assert len(items) == 1
+    item = items[0]
+    assert item["id"] == cid
+    assert item["status"] == "active"
+    assert item["member_ip_count"] == 3
+    assert "timing_features" in item
+    assert "sequence_features" in item
+    assert "protocol_features" in item
+    assert "credential_features" in item
+    assert "target_features" in item
+
+
+def test_list_campaigns_for_suggestions_feature_columns_match_fingerprint(db_session):
+    timing_json = json.dumps({"interval": {"mean": 60.0}})
+    fp = _make_fingerprint_json(timing=timing_json)
+    _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    items = EventRepository(db_session).list_campaigns_for_suggestions()
+    assert items[0]["timing_features"] == timing_json
+    assert items[0]["sequence_features"] is None
+
+
+def test_list_campaigns_for_suggestions_skips_unparseable_fingerprint(db_session):
+    _insert_campaign(db_session, status="active", representative_fingerprint_json="not-valid-json")
+    items = EventRepository(db_session).list_campaigns_for_suggestions()
+    assert items == []
+
+
+def test_list_campaigns_for_suggestions_respects_limit(db_session):
+    fp = _make_fingerprint_json()
+    for _i in range(5):
+        _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    items = EventRepository(db_session).list_campaigns_for_suggestions(limit=3)
+    assert len(items) == 3
+
+
+def test_list_campaigns_for_suggestions_newest_first(db_session):
+    fp = _make_fingerprint_json()
+    c1 = _insert_campaign(
+        db_session, status="active", last_seen=_TS, representative_fingerprint_json=fp
+    )
+    c2 = _insert_campaign(
+        db_session, status="active", last_seen=_TS3, representative_fingerprint_json=fp
+    )
+    c3 = _insert_campaign(
+        db_session, status="active", last_seen=_TS2, representative_fingerprint_json=fp
+    )
+    items = EventRepository(db_session).list_campaigns_for_suggestions()
+    assert [i["id"] for i in items] == [c2, c3, c1]
+
+
+# ---------------------------------------------------------------------------
+# get_coattributed_campaign_pairs
+# ---------------------------------------------------------------------------
+
+
+def test_get_coattributed_pairs_empty_lineage(db_session):
+    pairs = EventRepository(db_session).get_coattributed_campaign_pairs()
+    assert pairs == set()
+
+
+def test_get_coattributed_pairs_single_campaign_per_actor(db_session):
+    fp = _make_fingerprint_json()
+    cid = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    aid = _insert_actor(db_session)
+    _link(db_session, actor_id=aid, campaign_id=cid)
+    pairs = EventRepository(db_session).get_coattributed_campaign_pairs()
+    assert pairs == set()
+
+
+def test_get_coattributed_pairs_two_campaigns_under_same_actor(db_session):
+    fp = _make_fingerprint_json()
+    c1 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    c2 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    aid = _insert_actor(db_session)
+    _link(db_session, actor_id=aid, campaign_id=c1)
+    _link(db_session, actor_id=aid, campaign_id=c2)
+    pairs = EventRepository(db_session).get_coattributed_campaign_pairs()
+    assert pairs == {frozenset({c1, c2})}
+
+
+def test_get_coattributed_pairs_is_order_independent(db_session):
+    fp = _make_fingerprint_json()
+    c1 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    c2 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    aid = _insert_actor(db_session)
+    _link(db_session, actor_id=aid, campaign_id=c1)
+    _link(db_session, actor_id=aid, campaign_id=c2)
+    pairs = EventRepository(db_session).get_coattributed_campaign_pairs()
+    assert frozenset({c1, c2}) in pairs
+    assert frozenset({c2, c1}) in pairs  # same frozenset
+
+
+def test_get_coattributed_pairs_three_campaigns_produce_three_pairs(db_session):
+    fp = _make_fingerprint_json()
+    c1 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    c2 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    c3 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    aid = _insert_actor(db_session)
+    _link(db_session, actor_id=aid, campaign_id=c1)
+    _link(db_session, actor_id=aid, campaign_id=c2)
+    _link(db_session, actor_id=aid, campaign_id=c3)
+    pairs = EventRepository(db_session).get_coattributed_campaign_pairs()
+    assert pairs == {
+        frozenset({c1, c2}),
+        frozenset({c1, c3}),
+        frozenset({c2, c3}),
+    }
+
+
+def test_get_coattributed_pairs_multiple_actors_independent(db_session):
+    fp = _make_fingerprint_json()
+    c1 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    c2 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    c3 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    c4 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    aid1 = _insert_actor(db_session)
+    aid2 = _insert_actor(db_session)
+    _link(db_session, actor_id=aid1, campaign_id=c1)
+    _link(db_session, actor_id=aid1, campaign_id=c2)
+    _link(db_session, actor_id=aid2, campaign_id=c3)
+    _link(db_session, actor_id=aid2, campaign_id=c4)
+    pairs = EventRepository(db_session).get_coattributed_campaign_pairs()
+    assert pairs == {frozenset({c1, c2}), frozenset({c3, c4})}
+
+
+def test_get_coattributed_pairs_deduplicates_same_pair_from_multiple_actors(db_session):
+    fp = _make_fingerprint_json()
+    c1 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    c2 = _insert_campaign(db_session, status="active", representative_fingerprint_json=fp)
+    aid1 = _insert_actor(db_session)
+    aid2 = _insert_actor(db_session)
+    _link(db_session, actor_id=aid1, campaign_id=c1)
+    _link(db_session, actor_id=aid1, campaign_id=c2)
+    _link(db_session, actor_id=aid2, campaign_id=c1)
+    _link(db_session, actor_id=aid2, campaign_id=c2)
+    pairs = EventRepository(db_session).get_coattributed_campaign_pairs()
+    assert pairs == {frozenset({c1, c2})}

--- a/tests/integration/test_actor_suggestions_endpoints.py
+++ b/tests/integration/test_actor_suggestions_endpoints.py
@@ -1,0 +1,485 @@
+"""Integration tests for Phase 7 Group B3 — GET /api/actors/suggestions.
+
+Tests hit the full stack: FastAPI TestClient → routers → EventRepository → SQLite.
+
+Coverage:
+  GET /api/actors/suggestions:
+    - requires authentication (401 without key)
+    - returns 200 with expected response shape when no campaigns
+    - returns empty suggestions when no campaigns have fingerprints
+    - returns empty suggestions when only one campaign has a fingerprint
+    - returns a suggestion when two similar campaigns exist
+    - suggestion contains all expected fields
+    - suggestion contains campaign_a and campaign_b summaries
+    - suggestion breakdown has per-dimension scores
+    - coattributed pair is excluded from suggestions
+    - min_score query param overrides config default
+    - limit query param overrides config default
+    - /suggestions route does not conflict with /{actor_id} route
+
+  Invariants:
+    - GET /suggestions never writes to actor_profiles
+    - GET /suggestions never writes to campaign_lineage
+    - suggested_relationship_type is advisory (one of valid types)
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db.connection import get_session
+from app.db.repository import EventRepository
+from app.intelligence.actor_constants import VALID_RELATIONSHIP_TYPES
+from app.main import app
+
+client = TestClient(app)
+
+_API_KEY = "test-key"
+_HEADERS = {"X-API-Key": _API_KEY}
+
+
+@pytest.fixture(autouse=True)
+def setup_env(monkeypatch):
+    monkeypatch.setenv("API_KEY", _API_KEY)
+    monkeypatch.setenv("FEED_SALT", "test-salt")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+_TS = "2026-05-01T12:00:00+00:00"
+
+_TIMING_FEATURES_A = json.dumps(
+    {
+        "interval": {"mean": 60.0, "stddev": 5.0, "p25": 55.0, "p75": 65.0, "p95": 70.0},
+        "burst_cv": 0.1,
+    }
+)
+_SEQ_FEATURES_A = json.dumps({"port_sequence": [22, 80, 443]})
+
+_REP_FP_A = json.dumps(
+    {
+        "timing_features": _TIMING_FEATURES_A,
+        "sequence_features": _SEQ_FEATURES_A,
+        "protocol_features": None,
+        "credential_features": None,
+        "target_features": None,
+    }
+)
+
+_REP_FP_B = json.dumps(
+    {
+        "timing_features": _TIMING_FEATURES_A,
+        "sequence_features": _SEQ_FEATURES_A,
+        "protocol_features": None,
+        "credential_features": None,
+        "target_features": None,
+    }
+)
+
+_REP_FP_DIFFERENT = json.dumps(
+    {
+        "timing_features": json.dumps(
+            {
+                "interval": {
+                    "mean": 3600.0,
+                    "stddev": 200.0,
+                    "p25": 3400.0,
+                    "p75": 3800.0,
+                    "p95": 3900.0,
+                },
+                "burst_cv": 0.9,
+            }
+        ),
+        "sequence_features": json.dumps({"port_sequence": [8080, 3389, 5900]}),
+        "protocol_features": None,
+        "credential_features": None,
+        "target_features": None,
+    }
+)
+
+
+def _create_campaign(
+    *,
+    status: str = "active",
+    representative_fingerprint_json: str | None = None,
+) -> str:
+    cid = _uid()
+    with get_session() as session:
+        from sqlalchemy import text
+
+        session.execute(
+            text("""
+                INSERT INTO campaigns (
+                    id, name, status, confidence,
+                    first_seen, last_seen, member_ip_count,
+                    representative_fingerprint_json,
+                    created_at, updated_at
+                ) VALUES (
+                    :id, :name, :status, 0.7,
+                    :ts, :ts, 1,
+                    :fp_json,
+                    :ts, :ts
+                )
+            """),
+            {
+                "id": cid,
+                "name": f"campaign-{cid[:8]}",
+                "status": status,
+                "ts": _TS,
+                "fp_json": representative_fingerprint_json,
+            },
+        )
+    return cid
+
+
+def _create_actor() -> str:
+    aid = _uid()
+    with get_session() as session:
+        EventRepository(session).create_actor_profile(
+            actor_id=aid,
+            display_name=f"actor-{aid[:8]}",
+            created_at=_TS,
+        )
+    return aid
+
+
+def _link_campaign(actor_id: str, campaign_id: str) -> None:
+    with get_session() as session:
+        EventRepository(session).link_campaign_to_actor(
+            actor_profile_id=actor_id,
+            campaign_id=campaign_id,
+            relationship_type="temporal_overlap",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+
+def test_suggestions_requires_auth():
+    resp = client.get("/api/actors/suggestions")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Empty / sparse states
+# ---------------------------------------------------------------------------
+
+
+def test_suggestions_no_campaigns_returns_200():
+    resp = client.get("/api/actors/suggestions", headers=_HEADERS)
+    assert resp.status_code == 200
+
+
+def test_suggestions_no_campaigns_empty_list():
+    resp = client.get("/api/actors/suggestions", headers=_HEADERS)
+    data = resp.json()
+    assert data["suggestions"] == []
+    assert data["count"] == 0
+    assert data["campaigns_evaluated"] == 0
+    assert data["total_pairs_evaluated"] == 0
+
+
+def test_suggestions_no_fingerprints_returns_empty():
+    _create_campaign(status="active", representative_fingerprint_json=None)
+    _create_campaign(status="active", representative_fingerprint_json=None)
+    resp = client.get("/api/actors/suggestions", headers=_HEADERS)
+    data = resp.json()
+    assert data["suggestions"] == []
+    assert data["campaigns_evaluated"] == 0
+
+
+def test_suggestions_single_fingerprinted_campaign_returns_empty():
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    resp = client.get("/api/actors/suggestions", headers=_HEADERS)
+    data = resp.json()
+    assert data["suggestions"] == []
+    assert data["total_pairs_evaluated"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Response structure
+# ---------------------------------------------------------------------------
+
+
+def test_suggestions_response_has_expected_top_level_keys():
+    resp = client.get("/api/actors/suggestions", headers=_HEADERS)
+    data = resp.json()
+    assert set(data.keys()) == {
+        "suggestions",
+        "count",
+        "total_pairs_evaluated",
+        "min_score_applied",
+        "campaigns_evaluated",
+    }
+
+
+def test_suggestions_min_score_applied_matches_default():
+    resp = client.get("/api/actors/suggestions", headers=_HEADERS)
+    data = resp.json()
+    assert isinstance(data["min_score_applied"], float)
+    # Default from config — just verify it's a valid threshold
+    assert 0.0 < data["min_score_applied"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Suggestion result when similar campaigns exist
+# ---------------------------------------------------------------------------
+
+
+def test_suggestions_returns_suggestion_for_identical_fingerprints():
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_B)
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    assert data["count"] >= 1
+    assert data["total_pairs_evaluated"] >= 1
+
+
+def test_suggestion_item_has_expected_keys():
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_B)
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    assert data["count"] >= 1
+    s = data["suggestions"][0]
+    assert set(s.keys()) == {
+        "campaign_a",
+        "campaign_b",
+        "similarity_score",
+        "breakdown",
+        "suggested_relationship_type",
+    }
+
+
+def test_suggestion_campaign_summary_has_expected_keys():
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_B)
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    s = data["suggestions"][0]
+    for side in ("campaign_a", "campaign_b"):
+        for key in ("id", "name", "status", "last_seen", "member_ip_count"):
+            assert key in s[side], f"missing {key!r} in {side}"
+
+
+def test_suggestion_breakdown_has_dimension_scores():
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_B)
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    breakdown = data["suggestions"][0]["breakdown"]
+    for key in (
+        "timing_similarity",
+        "sequence_similarity",
+        "protocol_similarity",
+        "credential_similarity",
+        "target_similarity",
+        "weighted_total",
+        "dimensions_used",
+    ):
+        assert key in breakdown
+
+
+def test_suggestion_relationship_type_is_valid():
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_B)
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    rtype = data["suggestions"][0]["suggested_relationship_type"]
+    assert rtype in VALID_RELATIONSHIP_TYPES
+
+
+def test_suggestion_similarity_score_is_float():
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_B)
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    score = data["suggestions"][0]["similarity_score"]
+    assert isinstance(score, float)
+    assert 0.0 <= score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Coattribution exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_coattributed_pair_excluded_from_suggestions():
+    c1 = _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    c2 = _create_campaign(status="active", representative_fingerprint_json=_REP_FP_B)
+    actor = _create_actor()
+    _link_campaign(actor, c1)
+    _link_campaign(actor, c2)
+
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    pair_ids = {
+        frozenset({s["campaign_a"]["id"], s["campaign_b"]["id"]}) for s in data["suggestions"]
+    }
+    assert frozenset({c1, c2}) not in pair_ids
+    assert data["total_pairs_evaluated"] == 0
+
+
+def test_non_coattributed_pair_not_excluded():
+    c1 = _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    c2 = _create_campaign(status="active", representative_fingerprint_json=_REP_FP_B)
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    actor = _create_actor()
+    _link_campaign(actor, c1)
+    _link_campaign(actor, c2)
+    # third campaign is not linked; (c1,c3) and (c2,c3) should still be evaluated
+
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    assert data["total_pairs_evaluated"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Query param overrides
+# ---------------------------------------------------------------------------
+
+
+def test_min_score_query_param_filters_dissimilar_pair():
+    # _REP_FP_A and _REP_FP_DIFFERENT have very different timing and sequences
+    # so their similarity is well below 1.0; a min_score=1.0 should exclude them.
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_DIFFERENT)
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 1.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    assert data["count"] == 0
+    assert data["min_score_applied"] == 1.0
+
+
+def test_limit_query_param_caps_results():
+    for _ in range(4):
+        _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0, "limit": 2},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    assert data["count"] <= 2
+    assert len(data["suggestions"]) <= 2
+
+
+def test_limit_invalid_returns_422():
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"limit": 0},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+def test_min_score_out_of_range_returns_422():
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 1.5},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Route ordering invariant — /suggestions must not conflict with /{actor_id}
+# ---------------------------------------------------------------------------
+
+
+def test_suggestions_route_does_not_shadow_actor_id_route():
+    actor = _create_actor()
+    resp = client.get(f"/api/actors/{actor}", headers=_HEADERS)
+    assert resp.status_code == 200
+    assert resp.json()["id"] == actor
+
+
+def test_suggestions_path_not_treated_as_actor_id():
+    resp = client.get("/api/actors/suggestions", headers=_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "suggestions" in data
+
+
+# ---------------------------------------------------------------------------
+# No-write invariant
+# ---------------------------------------------------------------------------
+
+
+def test_suggestions_does_not_write_to_actor_profiles():
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_B)
+
+    with get_session() as session:
+        before = EventRepository(session).list_actor_profiles()
+
+    client.get("/api/actors/suggestions", params={"min_score": 0.0}, headers=_HEADERS)
+
+    with get_session() as session:
+        after = EventRepository(session).list_actor_profiles()
+
+    assert len(before) == len(after)
+
+
+def test_suggestions_does_not_write_to_campaign_lineage():
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_A)
+    _create_campaign(status="active", representative_fingerprint_json=_REP_FP_B)
+
+    with get_session() as session:
+        before = EventRepository(session).list_campaign_lineage()
+
+    client.get("/api/actors/suggestions", params={"min_score": 0.0}, headers=_HEADERS)
+
+    with get_session() as session:
+        after = EventRepository(session).list_campaign_lineage()
+
+    assert len(before) == len(after)

--- a/tests/unit/test_actor_suggestions.py
+++ b/tests/unit/test_actor_suggestions.py
@@ -1,0 +1,322 @@
+"""Unit tests for app/intelligence/actor_suggestions.py — Phase 7 Group B3.
+
+Tests are pure: no database, no HTTP, no I/O.
+
+Coverage:
+  _derive_relationship_type:
+    - sequence >= 0.85 AND timing >= 0.80  → primary_campaign
+    - timing   >= 0.80 AND sequence < 0.70 → infrastructure_reuse
+    - protocol >= 0.80                     → tactic_match
+    - default fallback                     → temporal_overlap
+    - None dimension values treated as 0.0
+
+  build_actor_suggestions:
+    - empty campaigns list → 0 suggestions, 0 pairs evaluated
+    - single campaign → 0 suggestions, 0 pairs evaluated
+    - coattributed pair skipped, not counted in total_pairs_evaluated
+    - pair below min_score → not in suggestions
+    - pair above min_score → appears in suggestions with expected fields
+    - suggestions sorted by similarity_score DESC
+    - limit caps result count
+    - limit does not affect total_pairs_evaluated
+    - suggested_relationship_type is advisory (present in response)
+    - no writes occur (pure function)
+    - no AI imports in module
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.intelligence.actor_suggestions import (
+    _derive_relationship_type,
+    build_actor_suggestions,
+)
+from app.intelligence.similarity import SimilarityResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    *,
+    timing: float | None = None,
+    sequence: float | None = None,
+    protocol: float | None = None,
+    credential: float | None = None,
+    target: float | None = None,
+    total: float = 0.0,
+) -> SimilarityResult:
+    dims = sum(v is not None for v in [timing, sequence, protocol, credential, target])
+    return SimilarityResult(
+        timing_similarity=timing,
+        sequence_similarity=sequence,
+        protocol_similarity=protocol,
+        credential_similarity=credential,
+        target_similarity=target,
+        weighted_total=total,
+        dimensions_used=dims,
+    )
+
+
+def _make_campaign(cid: str, name: str = "c") -> dict:
+    return {
+        "id": cid,
+        "name": name,
+        "status": "active",
+        "last_seen": "2026-05-01T00:00:00+00:00",
+        "member_ip_count": 1,
+        "timing_features": None,
+        "sequence_features": None,
+        "protocol_features": None,
+        "credential_features": None,
+        "target_features": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _derive_relationship_type
+# ---------------------------------------------------------------------------
+
+
+def test_derive_primary_campaign():
+    result = _make_result(sequence=0.90, timing=0.85, total=0.90)
+    assert _derive_relationship_type(result) == "primary_campaign"
+
+
+def test_derive_primary_campaign_boundary():
+    result = _make_result(sequence=0.85, timing=0.80, total=0.85)
+    assert _derive_relationship_type(result) == "primary_campaign"
+
+
+def test_derive_infrastructure_reuse():
+    result = _make_result(timing=0.85, sequence=0.60, total=0.75)
+    assert _derive_relationship_type(result) == "infrastructure_reuse"
+
+
+def test_derive_infrastructure_reuse_boundary():
+    result = _make_result(timing=0.80, sequence=0.69, total=0.76)
+    assert _derive_relationship_type(result) == "infrastructure_reuse"
+
+
+def test_derive_tactic_match():
+    result = _make_result(timing=0.50, sequence=0.40, protocol=0.82, total=0.60)
+    assert _derive_relationship_type(result) == "tactic_match"
+
+
+def test_derive_temporal_overlap_default():
+    result = _make_result(timing=0.60, sequence=0.65, protocol=0.55, total=0.62)
+    assert _derive_relationship_type(result) == "temporal_overlap"
+
+
+def test_derive_none_dimensions_treated_as_zero():
+    result = _make_result(timing=None, sequence=None, protocol=None, total=0.50)
+    assert _derive_relationship_type(result) == "temporal_overlap"
+
+
+def test_derive_primary_campaign_takes_precedence_over_tactic_match():
+    result = _make_result(sequence=0.90, timing=0.85, protocol=0.90, total=0.90)
+    assert _derive_relationship_type(result) == "primary_campaign"
+
+
+# ---------------------------------------------------------------------------
+# build_actor_suggestions — empty / trivial cases
+# ---------------------------------------------------------------------------
+
+
+def test_build_no_campaigns():
+    suggestions, total = build_actor_suggestions([], set(), min_score=0.85, limit=20)
+    assert suggestions == []
+    assert total == 0
+
+
+def test_build_single_campaign():
+    suggestions, total = build_actor_suggestions(
+        [_make_campaign("c1")], set(), min_score=0.85, limit=20
+    )
+    assert suggestions == []
+    assert total == 0
+
+
+# ---------------------------------------------------------------------------
+# build_actor_suggestions — filtering and skipping
+# ---------------------------------------------------------------------------
+
+
+def test_build_coattributed_pair_skipped():
+    c1 = _make_campaign("c1")
+    c2 = _make_campaign("c2")
+    coattributed = {frozenset({"c1", "c2"})}
+
+    with patch("app.intelligence.actor_suggestions.compute_weighted_similarity") as mock_sim:
+        suggestions, total = build_actor_suggestions(
+            [c1, c2], coattributed, min_score=0.0, limit=20
+        )
+        mock_sim.assert_not_called()
+
+    assert suggestions == []
+    assert total == 0
+
+
+def test_build_coattributed_pair_not_counted_in_total():
+    c1 = _make_campaign("c1")
+    c2 = _make_campaign("c2")
+    c3 = _make_campaign("c3")
+    coattributed = {frozenset({"c1", "c2"})}
+
+    high = _make_result(total=0.90)
+    with patch(
+        "app.intelligence.actor_suggestions.compute_weighted_similarity",
+        return_value=high,
+    ):
+        suggestions, total = build_actor_suggestions(
+            [c1, c2, c3], coattributed, min_score=0.0, limit=20
+        )
+
+    # Only (c1,c3) and (c2,c3) are evaluated; (c1,c2) is coattributed
+    assert total == 2
+
+
+def test_build_pair_below_min_score_not_in_suggestions():
+    c1 = _make_campaign("c1")
+    c2 = _make_campaign("c2")
+    low = _make_result(total=0.70)
+
+    with patch(
+        "app.intelligence.actor_suggestions.compute_weighted_similarity",
+        return_value=low,
+    ):
+        suggestions, total = build_actor_suggestions([c1, c2], set(), min_score=0.85, limit=20)
+
+    assert suggestions == []
+    assert total == 1
+
+
+def test_build_pair_above_min_score_included():
+    c1 = _make_campaign("c1", "Campaign Alpha")
+    c2 = _make_campaign("c2", "Campaign Beta")
+    high = _make_result(sequence=0.90, timing=0.85, total=0.90)
+
+    with patch(
+        "app.intelligence.actor_suggestions.compute_weighted_similarity",
+        return_value=high,
+    ):
+        suggestions, total = build_actor_suggestions([c1, c2], set(), min_score=0.85, limit=20)
+
+    assert total == 1
+    assert len(suggestions) == 1
+    s = suggestions[0]
+    assert s["similarity_score"] == 0.90
+    assert s["campaign_a"]["id"] == "c1"
+    assert s["campaign_b"]["id"] == "c2"
+    assert "breakdown" in s
+    assert "suggested_relationship_type" in s
+
+
+def test_build_suggestion_fields_complete():
+    c1 = _make_campaign("c1", "Alpha")
+    c2 = _make_campaign("c2", "Beta")
+    high = _make_result(total=0.90)
+
+    with patch(
+        "app.intelligence.actor_suggestions.compute_weighted_similarity",
+        return_value=high,
+    ):
+        suggestions, _ = build_actor_suggestions([c1, c2], set(), min_score=0.85, limit=20)
+
+    s = suggestions[0]
+    assert set(s.keys()) == {
+        "campaign_a",
+        "campaign_b",
+        "similarity_score",
+        "breakdown",
+        "suggested_relationship_type",
+    }
+    for key in ("id", "name", "status", "last_seen", "member_ip_count"):
+        assert key in s["campaign_a"]
+        assert key in s["campaign_b"]
+
+
+# ---------------------------------------------------------------------------
+# build_actor_suggestions — sort order and limit
+# ---------------------------------------------------------------------------
+
+
+def test_build_suggestions_sorted_descending():
+    campaigns = [_make_campaign(f"c{i}") for i in range(3)]
+    scores = [0.90, 0.95, 0.88]
+    call_count = 0
+
+    def mock_sim(a, b, **kwargs):
+        nonlocal call_count
+        s = scores[call_count % len(scores)]
+        call_count += 1
+        return _make_result(total=s)
+
+    with patch(
+        "app.intelligence.actor_suggestions.compute_weighted_similarity", side_effect=mock_sim
+    ):
+        suggestions, _ = build_actor_suggestions(campaigns, set(), min_score=0.0, limit=20)
+
+    result_scores = [s["similarity_score"] for s in suggestions]
+    assert result_scores == sorted(result_scores, reverse=True)
+
+
+def test_build_limit_caps_results():
+    campaigns = [_make_campaign(f"c{i}") for i in range(5)]
+    high = _make_result(total=0.90)
+
+    with patch(
+        "app.intelligence.actor_suggestions.compute_weighted_similarity",
+        return_value=high,
+    ):
+        suggestions, total = build_actor_suggestions(campaigns, set(), min_score=0.0, limit=3)
+
+    assert len(suggestions) == 3
+    # 5 campaigns → C(5,2) = 10 pairs evaluated
+    assert total == 10
+
+
+def test_build_limit_does_not_affect_total_pairs_evaluated():
+    campaigns = [_make_campaign(f"c{i}") for i in range(4)]
+    high = _make_result(total=0.90)
+
+    with patch(
+        "app.intelligence.actor_suggestions.compute_weighted_similarity",
+        return_value=high,
+    ):
+        _, total_limit_1 = build_actor_suggestions(campaigns, set(), min_score=0.0, limit=1)
+        _, total_limit_100 = build_actor_suggestions(campaigns, set(), min_score=0.0, limit=100)
+
+    # C(4,2) = 6 regardless of limit
+    assert total_limit_1 == 6
+    assert total_limit_100 == 6
+
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+
+
+def test_no_ai_imports_in_actor_suggestions():
+    import inspect
+
+    import app.intelligence.actor_suggestions as mod
+
+    src = inspect.getsource(mod)
+    assert "from app.ai" not in src
+    assert "import app.ai" not in src
+    assert "openai" not in src.lower()
+    assert "anthropic" not in src.lower()
+
+
+def test_no_db_imports_in_actor_suggestions():
+    import inspect
+
+    import app.intelligence.actor_suggestions as mod
+
+    src = inspect.getsource(mod)
+    assert "get_session" not in src
+    assert "EventRepository" not in src
+    assert "from app.db" not in src


### PR DESCRIPTION
## Summary

Implements Phase 7 Group B3 — Actor Suggestion Engine.

This PR adds a read-only suggestion engine that surfaces possible campaign-to-actor relationship candidates based on representative fingerprint similarity.

### Included

* GET /api/actors/suggestions
* Configurable actor suggestion threshold
* Representative fingerprint comparison
* Existing co-attributed pair exclusion
* Advisory relationship type suggestion
* Pure computation module
* Repository support queries
* Unit, repository, and integration tests

### Design Principles

* Read-only suggestions
* No automatic attribution
* No actor creation
* No campaign_lineage writes
* No campaign mutation
* No AI
* No federation data

### Validation

* Black passed
* Ruff passed
* Pre-commit passed
* 1544 tests passed
* No regressions detected
