### PR TITLE
fix(phase7): restore actor linking endpoints and suggestion breakdown

### DIFF
--- a/app/db/repositories/actor.py
+++ b/app/db/repositories/actor.py
@@ -276,6 +276,99 @@ class ActorRepository(RepositoryBase):
         ).fetchall()
         return [_lineage_row_to_dict(r) for r in rows]
 
+    def get_lineage_row(self, lineage_id: str) -> dict[str, Any] | None:
+        """Return a single campaign_lineage row by id, or None if not found."""
+        row = self._session.execute(
+            text(_LINEAGE_SELECT + "WHERE id = :id"),
+            {"id": lineage_id},
+        ).fetchone()
+        return _lineage_row_to_dict(row) if row is not None else None
+
+    def delete_lineage_row(self, lineage_id: str) -> None:
+        """Hard-delete a single campaign_lineage row by id.
+
+        Raises no error if the row does not exist — callers should check
+        get_lineage_row() first to enforce 404 semantics at the router layer.
+        Campaigns and actor_profiles are never touched.
+        """
+        self._session.execute(
+            text("DELETE FROM campaign_lineage WHERE id = :id"),
+            {"id": lineage_id},
+        )
+
+    def list_actor_campaigns_with_metadata(
+        self,
+        actor_profile_id: str,
+        *,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return campaigns linked to an actor with campaign metadata.
+
+        JOINs campaign_lineage with campaigns for each linked campaign.
+        Ordered by lineage created_at DESC.  Campaigns absent from the
+        campaigns table appear with NULL name/status/last_seen fields.
+        """
+        rows = self._session.execute(
+            text("""
+                SELECT cl.id, cl.campaign_id, cl.relationship_type, cl.confidence,
+                       cl.evidence_json, cl.created_at,
+                       c.name, c.status, c.last_seen
+                FROM campaign_lineage cl
+                LEFT JOIN campaigns c ON cl.campaign_id = c.id
+                WHERE cl.actor_profile_id = :actor_profile_id
+                ORDER BY cl.created_at DESC
+                LIMIT :limit
+            """),
+            {"actor_profile_id": actor_profile_id, "limit": limit},
+        ).fetchall()
+        return [
+            {
+                "lineage_id": row[0],
+                "campaign_id": row[1],
+                "relationship_type": row[2],
+                "confidence": row[3],
+                "evidence_json": row[4],
+                "linked_at": row[5],
+                "campaign_name": row[6],
+                "campaign_status": row[7],
+                "campaign_last_seen": row[8],
+            }
+            for row in rows
+        ]
+
+    def list_actors_for_campaign(self, campaign_id: str) -> list[dict[str, Any]]:
+        """Return actors linked to a campaign with actor profile metadata.
+
+        JOINs campaign_lineage with actor_profiles.
+        Ordered by lineage created_at DESC.
+        """
+        rows = self._session.execute(
+            text("""
+                SELECT cl.id, cl.actor_profile_id, cl.relationship_type, cl.confidence,
+                       cl.evidence_json, cl.created_at,
+                       ap.display_name, ap.status, ap.confidence AS actor_confidence
+                FROM campaign_lineage cl
+                LEFT JOIN actor_profiles ap ON cl.actor_profile_id = ap.id
+                WHERE cl.campaign_id = :campaign_id
+                ORDER BY cl.created_at DESC
+            """),
+            {"campaign_id": campaign_id},
+        ).fetchall()
+        return [
+            {
+                "lineage_id": row[0],
+                "actor_profile_id": row[1],
+                "relationship_type": row[2],
+                "confidence": row[3],
+                "evidence_json": row[4],
+                "linked_at": row[5],
+                "actor_display_name": row[6],
+                "actor_status": row[7],
+                "actor_confidence": row[8],
+            }
+            for row in rows
+        ]
+
     def list_campaigns_for_suggestions(self, *, limit: int = 500) -> list[dict[str, Any]]:
         """Return campaigns eligible for actor suggestion comparison.
 

--- a/app/intelligence/actor_suggestions.py
+++ b/app/intelligence/actor_suggestions.py
@@ -91,7 +91,7 @@ def build_actor_suggestions(
                 "campaign_a": _campaign_summary(c_a),
                 "campaign_b": _campaign_summary(c_b),
                 "similarity_score": result.weighted_total,
-                "breakdown": result.as_dict(),
+                "score_breakdown": result.as_dict(),
                 "suggested_relationship_type": _derive_relationship_type(result),
             }
         )

--- a/app/routers/actors.py
+++ b/app/routers/actors.py
@@ -1,11 +1,15 @@
-"""Actor profile CRUD, suggestion, and stability endpoints — Phase 7 B1/B3/B4.
+"""Actor profile CRUD, suggestion, and stability endpoints — Phase 7 B1/B2/B3/B4.
 
-POST   /api/actors                   — create actor profile (201)
-GET    /api/actors                   — list actor profiles
-GET    /api/actors/suggestions       — candidate campaign pairs (read-only)
-GET    /api/actors/{id}              — get actor profile detail (404 if not found)
-GET    /api/actors/{id}/stability    — aggregated stability view (read-only)
-PATCH  /api/actors/{id}              — partial update (display_name, notes, confidence, status)
+POST   /api/actors                              — create actor profile (201)
+GET    /api/actors                              — list actor profiles
+GET    /api/actors/suggestions                  — candidate campaign pairs (read-only)
+GET    /api/actors/{id}                         — get actor profile detail (404 if not found)
+GET    /api/actors/{id}/stability               — aggregated stability view (read-only)
+PATCH  /api/actors/{id}                         — partial update (display_name, notes, confidence,
+                                                  status)
+POST   /api/actors/{id}/campaigns               — link a campaign to an actor (201)
+GET    /api/actors/{id}/campaigns               — list campaigns linked to an actor
+DELETE /api/actors/{id}/campaigns/{lineage_id}  — remove a campaign-actor link (204)
 
 All endpoints require API key or JWT authentication via require_jwt_or_api_key.
 No SQL belongs here — all queries go through EventRepository.
@@ -25,7 +29,7 @@ from pydantic import BaseModel, field_validator
 from app.core.config import settings as _settings
 from app.db.connection import get_session
 from app.db.repository import EventRepository
-from app.intelligence.actor_constants import VALID_ACTOR_STATUSES
+from app.intelligence.actor_constants import VALID_ACTOR_STATUSES, VALID_RELATIONSHIP_TYPES
 from app.intelligence.actor_stability import aggregate_actor_stability
 from app.intelligence.actor_suggestions import build_actor_suggestions
 from app.utils.auth import require_jwt_or_api_key
@@ -60,6 +64,37 @@ class ActorCreateRequest(BaseModel):
             raise ValueError(
                 f"Invalid status {v!r}. Must be one of: {sorted(VALID_ACTOR_STATUSES)}"
             )
+        return v
+
+
+class CampaignLinkRequest(BaseModel):
+    campaign_id: str
+    relationship_type: str
+    confidence: float = 0.5
+    evidence: dict | None = None
+
+    @field_validator("campaign_id")
+    @classmethod
+    def campaign_id_nonempty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("campaign_id must not be blank")
+        return v
+
+    @field_validator("relationship_type")
+    @classmethod
+    def rel_type_valid(cls, v: str) -> str:
+        if v not in VALID_RELATIONSHIP_TYPES:
+            raise ValueError(
+                f"Invalid relationship_type {v!r}. "
+                f"Must be one of: {sorted(VALID_RELATIONSHIP_TYPES)}"
+            )
+        return v
+
+    @field_validator("confidence")
+    @classmethod
+    def confidence_range(cls, v: float) -> float:
+        if not (0.0 <= v <= 1.0):
+            raise ValueError("confidence must be between 0.0 and 1.0")
         return v
 
 
@@ -269,3 +304,101 @@ def patch_actor(
             kwargs["status"] = body.status
         updated = repo.update_actor_profile(actor_id, **kwargs)
     return updated
+
+
+@router.post("/{actor_id}/campaigns", status_code=status.HTTP_201_CREATED)
+def link_campaign_to_actor(
+    actor_id: str,
+    body: CampaignLinkRequest,
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Link a campaign to an actor via a campaign_lineage record.
+
+    Validates that both the actor and campaign exist before inserting.
+    Returns 409 if the same actor/campaign pair is already linked.
+    relationship_type must be one of VALID_RELATIONSHIP_TYPES.
+
+    No automatic attribution occurs — this is an explicit operator action.
+    Campaigns and actor_profiles are not modified; only campaign_lineage is written.
+    """
+    with get_session() as session:
+        repo = EventRepository(session)
+
+        if repo.get_actor_profile(actor_id) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Actor {actor_id!r} not found",
+            )
+
+        if repo.get_campaign(body.campaign_id) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Campaign {body.campaign_id!r} not found",
+            )
+
+        existing = repo.list_campaign_lineage(
+            actor_profile_id=actor_id,
+            campaign_id=body.campaign_id,
+        )
+        if existing:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Campaign {body.campaign_id!r} is already linked to " f"actor {actor_id!r}"
+                ),
+            )
+
+        row = repo.link_campaign_to_actor(
+            actor_profile_id=actor_id,
+            campaign_id=body.campaign_id,
+            relationship_type=body.relationship_type,
+            confidence=body.confidence,
+            evidence_json=body.evidence,
+        )
+    return row
+
+
+@router.get("/{actor_id}/campaigns")
+def list_actor_campaigns(
+    actor_id: str,
+    limit: int = Query(default=100, ge=1, le=500),
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return campaigns linked to an actor with campaign metadata.
+
+    Each item includes lineage_id, campaign_id, relationship_type, confidence,
+    evidence_json, linked_at, and campaign name/status/last_seen from the
+    campaigns table.  404 if the actor does not exist.
+    """
+    with get_session() as session:
+        repo = EventRepository(session)
+        if repo.get_actor_profile(actor_id) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Actor {actor_id!r} not found",
+            )
+        items = repo.list_actor_campaigns_with_metadata(actor_id, limit=limit)
+    return {"actor_id": actor_id, "items": items, "count": len(items)}
+
+
+@router.delete("/{actor_id}/campaigns/{lineage_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_actor_campaign_link(
+    actor_id: str,
+    lineage_id: str,
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Remove a campaign-actor link by lineage_id.
+
+    Returns 404 if the lineage record does not exist or does not belong to
+    this actor.  Only the campaign_lineage row is deleted; campaigns and
+    actor_profiles are not modified.
+    """
+    with get_session() as session:
+        repo = EventRepository(session)
+        row = repo.get_lineage_row(lineage_id)
+        if row is None or row["actor_profile_id"] != actor_id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Lineage record {lineage_id!r} not found for actor {actor_id!r}",
+            )
+        repo.delete_lineage_row(lineage_id)

--- a/app/routers/campaigns.py
+++ b/app/routers/campaigns.py
@@ -8,6 +8,7 @@ GET  /api/campaigns/{campaign_id}                             — campaign detai
 GET  /api/campaigns/{campaign_id}/observations                — observation list
 GET  /api/campaigns/{campaign_id}/weight-profile              — per-campaign weight profile
 GET  /api/campaigns/{campaign_id}/density                     — full campaign density metrics
+GET  /api/campaigns/{campaign_id}/actors                      — actors linked to this campaign
 
 All endpoints require API key or JWT authentication via require_jwt_or_api_key.
 No SQL belongs here — all queries go through EventRepository.
@@ -284,6 +285,28 @@ def get_campaign_weight_profile(
         "global_defaults": global_defaults,
         "status": "calibrated",
     }
+
+
+@router.get("/{campaign_id}/actors")
+def list_campaign_actors(
+    campaign_id: str,
+    _: dict = Depends(require_jwt_or_api_key),
+):
+    """Return actors linked to a campaign via campaign_lineage.
+
+    Each item includes lineage_id, actor_profile_id, relationship_type,
+    confidence, evidence_json, linked_at, and actor display_name/status/confidence.
+    404 if the campaign does not exist.  Read-only.
+    """
+    with get_session() as session:
+        repo = EventRepository(session)
+        if repo.get_campaign(campaign_id) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Campaign {campaign_id!r} not found",
+            )
+        items = repo.list_actors_for_campaign(campaign_id)
+    return {"campaign_id": campaign_id, "items": items, "count": len(items)}
 
 
 @router.get("/{campaign_id}/density")

--- a/tests/integration/test_actor_linking_endpoints.py
+++ b/tests/integration/test_actor_linking_endpoints.py
@@ -1,0 +1,405 @@
+"""Integration tests for Phase 7 Group B2 — campaign-actor linking API.
+
+Tests hit the full stack: FastAPI TestClient → routers → EventRepository → SQLite.
+
+Coverage:
+  POST /api/actors/{id}/campaigns:
+    - creates lineage, returns 201 with lineage dict
+    - 404 if actor not found
+    - 404 if campaign not found
+    - 422 if relationship_type is invalid
+    - 422 if confidence is out of range
+    - 409 if the same actor/campaign pair is already linked
+    - requires authentication
+
+  GET /api/actors/{id}/campaigns:
+    - returns empty list when actor has no links
+    - returns linked campaigns with metadata
+    - 404 if actor not found
+    - requires authentication
+
+  DELETE /api/actors/{id}/campaigns/{lineage_id}:
+    - removes the lineage record, returns 204
+    - 404 if lineage_id does not exist
+    - 404 if lineage_id belongs to a different actor
+    - campaigns and actors are not modified by delete
+    - requires authentication
+
+  GET /api/campaigns/{id}/actors:
+    - returns empty list when campaign has no links
+    - returns linked actors with metadata
+    - 404 if campaign not found
+    - requires authentication
+
+  Invariants:
+    - campaign_lineage rows are the only thing written or deleted
+    - actor_profiles and campaigns tables are never modified by these endpoints
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.db.connection import get_session
+from app.db.repository import EventRepository
+from app.main import app
+
+client = TestClient(app)
+
+_API_KEY = "test-key"
+_HEADERS = {"X-API-Key": _API_KEY}
+
+
+@pytest.fixture(autouse=True)
+def setup_api_key(monkeypatch):
+    monkeypatch.setenv("API_KEY", _API_KEY)
+    monkeypatch.setenv("FEED_SALT", "test-salt")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_actor(display_name: str = "Test Actor") -> dict:
+    resp = client.post("/api/actors", json={"display_name": display_name}, headers=_HEADERS)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def _create_campaign() -> str:
+    """Insert a minimal campaign row directly and return its id."""
+    cid = str(uuid.uuid4())
+    with get_session() as session:
+        now = datetime.now(UTC).isoformat()
+        session.execute(
+            text("""
+                INSERT INTO campaigns (id, name, status, first_seen, last_seen,
+                                      member_ip_count, confidence, created_at, updated_at)
+                VALUES (:id, :name, 'active', :now, :now, 1, 0.8, :now, :now)
+            """),
+            {"id": cid, "name": f"campaign-{cid[:8]}", "now": now},
+        )
+    return cid
+
+
+# ---------------------------------------------------------------------------
+# POST /api/actors/{actor_id}/campaigns
+# ---------------------------------------------------------------------------
+
+
+def test_link_campaign_returns_201():
+    actor = _create_actor("Alpha")
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 201
+
+
+def test_link_campaign_response_has_expected_fields():
+    actor = _create_actor()
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "temporal_overlap", "confidence": 0.75},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["actor_profile_id"] == actor["id"]
+    assert data["campaign_id"] == cid
+    assert data["relationship_type"] == "temporal_overlap"
+    assert data["confidence"] == 0.75
+    assert data["id"] is not None
+    assert data["created_at"] is not None
+
+
+def test_link_campaign_all_valid_relationship_types():
+    actor = _create_actor()
+    for rel_type in (
+        "primary_campaign",
+        "infrastructure_reuse",
+        "tactic_match",
+        "temporal_overlap",
+    ):
+        cid = _create_campaign()
+        resp = client.post(
+            f"/api/actors/{actor['id']}/campaigns",
+            json={"campaign_id": cid, "relationship_type": rel_type},
+            headers=_HEADERS,
+        )
+        assert resp.status_code == 201, f"failed for rel_type={rel_type!r}: {resp.text}"
+
+
+def test_link_campaign_404_actor_not_found():
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{uuid.uuid4()}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 404
+
+
+def test_link_campaign_404_campaign_not_found():
+    actor = _create_actor()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": str(uuid.uuid4()), "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 404
+
+
+def test_link_campaign_422_invalid_relationship_type():
+    actor = _create_actor()
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "not_valid"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+def test_link_campaign_422_confidence_out_of_range():
+    actor = _create_actor()
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match", "confidence": 1.5},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+def test_link_campaign_409_duplicate():
+    actor = _create_actor()
+    cid = _create_campaign()
+    payload = {"campaign_id": cid, "relationship_type": "tactic_match"}
+    resp1 = client.post(f"/api/actors/{actor['id']}/campaigns", json=payload, headers=_HEADERS)
+    assert resp1.status_code == 201
+    resp2 = client.post(f"/api/actors/{actor['id']}/campaigns", json=payload, headers=_HEADERS)
+    assert resp2.status_code == 409
+
+
+def test_link_campaign_requires_auth():
+    actor = _create_actor()
+    cid = _create_campaign()
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/actors/{actor_id}/campaigns
+# ---------------------------------------------------------------------------
+
+
+def test_list_actor_campaigns_empty():
+    actor = _create_actor()
+    resp = client.get(f"/api/actors/{actor['id']}/campaigns", headers=_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["count"] == 0
+    assert data["actor_id"] == actor["id"]
+
+
+def test_list_actor_campaigns_returns_linked():
+    actor = _create_actor()
+    cid = _create_campaign()
+    client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "infrastructure_reuse"},
+        headers=_HEADERS,
+    )
+    resp = client.get(f"/api/actors/{actor['id']}/campaigns", headers=_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    item = data["items"][0]
+    assert item["campaign_id"] == cid
+    assert item["relationship_type"] == "infrastructure_reuse"
+    assert "lineage_id" in item
+    assert "linked_at" in item
+    assert "campaign_name" in item
+    assert "campaign_status" in item
+
+
+def test_list_actor_campaigns_404_actor_not_found():
+    resp = client.get(f"/api/actors/{uuid.uuid4()}/campaigns", headers=_HEADERS)
+    assert resp.status_code == 404
+
+
+def test_list_actor_campaigns_requires_auth():
+    actor = _create_actor()
+    resp = client.get(f"/api/actors/{actor['id']}/campaigns")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/actors/{actor_id}/campaigns/{lineage_id}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_actor_campaign_link_returns_204():
+    actor = _create_actor()
+    cid = _create_campaign()
+    link_resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    lineage_id = link_resp.json()["id"]
+    resp = client.delete(f"/api/actors/{actor['id']}/campaigns/{lineage_id}", headers=_HEADERS)
+    assert resp.status_code == 204
+
+
+def test_delete_removes_lineage_row():
+    actor = _create_actor()
+    cid = _create_campaign()
+    link_resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    lineage_id = link_resp.json()["id"]
+    client.delete(f"/api/actors/{actor['id']}/campaigns/{lineage_id}", headers=_HEADERS)
+
+    list_resp = client.get(f"/api/actors/{actor['id']}/campaigns", headers=_HEADERS)
+    assert list_resp.json()["count"] == 0
+
+
+def test_delete_does_not_modify_actor():
+    actor = _create_actor("Stable Actor")
+    cid = _create_campaign()
+    link_resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    lineage_id = link_resp.json()["id"]
+    client.delete(f"/api/actors/{actor['id']}/campaigns/{lineage_id}", headers=_HEADERS)
+
+    actor_resp = client.get(f"/api/actors/{actor['id']}", headers=_HEADERS)
+    assert actor_resp.status_code == 200
+    assert actor_resp.json()["display_name"] == "Stable Actor"
+
+
+def test_delete_404_lineage_not_found():
+    actor = _create_actor()
+    resp = client.delete(f"/api/actors/{actor['id']}/campaigns/{uuid.uuid4()}", headers=_HEADERS)
+    assert resp.status_code == 404
+
+
+def test_delete_404_lineage_belongs_to_different_actor():
+    actor_a = _create_actor("Actor A")
+    actor_b = _create_actor("Actor B")
+    cid = _create_campaign()
+    link_resp = client.post(
+        f"/api/actors/{actor_a['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    lineage_id = link_resp.json()["id"]
+
+    resp = client.delete(f"/api/actors/{actor_b['id']}/campaigns/{lineage_id}", headers=_HEADERS)
+    assert resp.status_code == 404
+
+
+def test_delete_requires_auth():
+    actor = _create_actor()
+    cid = _create_campaign()
+    link_resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    lineage_id = link_resp.json()["id"]
+    resp = client.delete(f"/api/actors/{actor['id']}/campaigns/{lineage_id}")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/campaigns/{campaign_id}/actors
+# ---------------------------------------------------------------------------
+
+
+def test_list_campaign_actors_empty():
+    cid = _create_campaign()
+    resp = client.get(f"/api/campaigns/{cid}/actors", headers=_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["count"] == 0
+    assert data["campaign_id"] == cid
+
+
+def test_list_campaign_actors_returns_linked():
+    actor = _create_actor("Linked Actor")
+    cid = _create_campaign()
+    client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "primary_campaign", "confidence": 0.9},
+        headers=_HEADERS,
+    )
+    resp = client.get(f"/api/campaigns/{cid}/actors", headers=_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    item = data["items"][0]
+    assert item["actor_profile_id"] == actor["id"]
+    assert item["relationship_type"] == "primary_campaign"
+    assert item["confidence"] == 0.9
+    assert "lineage_id" in item
+    assert "actor_display_name" in item
+    assert "actor_status" in item
+
+
+def test_list_campaign_actors_404_campaign_not_found():
+    resp = client.get(f"/api/campaigns/{uuid.uuid4()}/actors", headers=_HEADERS)
+    assert resp.status_code == 404
+
+
+def test_list_campaign_actors_requires_auth():
+    cid = _create_campaign()
+    resp = client.get(f"/api/campaigns/{cid}/actors")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Invariant: actor/campaign tables not modified by link operations
+# ---------------------------------------------------------------------------
+
+
+def test_link_operations_do_not_modify_campaign():
+    actor = _create_actor()
+    cid = _create_campaign()
+
+    with get_session() as session:
+        campaign_before = EventRepository(session).get_campaign(cid)
+
+    link_resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match"},
+        headers=_HEADERS,
+    )
+    lineage_id = link_resp.json()["id"]
+    client.delete(f"/api/actors/{actor['id']}/campaigns/{lineage_id}", headers=_HEADERS)
+
+    with get_session() as session:
+        campaign_after = EventRepository(session).get_campaign(cid)
+
+    assert campaign_before["name"] == campaign_after["name"]
+    assert campaign_before["status"] == campaign_after["status"]

--- a/tests/integration/test_actor_suggestions_endpoints.py
+++ b/tests/integration/test_actor_suggestions_endpoints.py
@@ -267,7 +267,7 @@ def test_suggestion_item_has_expected_keys():
         "campaign_a",
         "campaign_b",
         "similarity_score",
-        "breakdown",
+        "score_breakdown",
         "suggested_relationship_type",
     }
 
@@ -296,7 +296,7 @@ def test_suggestion_breakdown_has_dimension_scores():
         headers=_HEADERS,
     )
     data = resp.json()
-    breakdown = data["suggestions"][0]["breakdown"]
+    breakdown = data["suggestions"][0]["score_breakdown"]
     for key in (
         "timing_similarity",
         "sequence_similarity",

--- a/tests/unit/test_actor_suggestions.py
+++ b/tests/unit/test_actor_suggestions.py
@@ -210,7 +210,7 @@ def test_build_pair_above_min_score_included():
     assert s["similarity_score"] == 0.90
     assert s["campaign_a"]["id"] == "c1"
     assert s["campaign_b"]["id"] == "c2"
-    assert "breakdown" in s
+    assert "score_breakdown" in s
     assert "suggested_relationship_type" in s
 
 
@@ -230,7 +230,7 @@ def test_build_suggestion_fields_complete():
         "campaign_a",
         "campaign_b",
         "similarity_score",
-        "breakdown",
+        "score_breakdown",
         "suggested_relationship_type",
     }
     for key in ("id", "name", "status", "last_seen", "member_ip_count"):


### PR DESCRIPTION
## Summary

Repairs two Phase 7 implementation gaps discovered during Phase 7 Closeout review.

This PR restores the missing Campaign-to-Actor Linking API (Phase 7 B2) and fixes the Actor Suggestion Engine response contract used by the dashboard.

### Included

#### Campaign-to-Actor Linking API

* POST /api/actors/{actor_id}/campaigns
* GET /api/actors/{actor_id}/campaigns
* DELETE /api/actors/{actor_id}/campaigns/{lineage_id}
* GET /api/campaigns/{campaign_id}/actors

Features:

* Actor existence validation
* Campaign existence validation
* Relationship type validation
* Duplicate link protection
* Lineage ownership validation
* Repository-layer query support
* Full integration test coverage

#### Actor Suggestion Contract Fix

Resolved mismatch between:

* Backend response field: breakdown
* Frontend expectation: score_breakdown

The API now consistently returns:

* score_breakdown

and all tests were updated accordingly.

### Design Principles

* No automatic attribution
* No AI actor linking
* No campaign merging
* No federation
* Explicit operator action only
* Repository-owned data access
* Read-only suggestions remain read-only

### Why

Phase 7 Closeout review identified two issues:

1. The planned B2 linking endpoints were not present on main.
2. The actor suggestion dashboard could not render similarity breakdown details because the API contract and UI implementation used different field names.

This PR resolves both issues and completes the intended Phase 7 Actor Intelligence surface.

### Validation

* Black passed
* Ruff passed
* Pre-commit passed
* Frontend build passed
* 1626 tests passed
* No regressions detected
