### PR TITLE
docs: add LegionTrap explained guide

### DIFF
--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -1,0 +1,62 @@
+# DECISION LOG — LegionTrap TI
+
+_Last updated: 2026-05-30 by Claude (onboarding run)_
+
+> Each entry records a decision that is not obvious from reading the code — architectural choices, tradeoffs, rejected alternatives. Read before changing architecture, storage, deployment, or intelligence model.
+
+> **Note:** Entries marked "detected from codebase" are inferred from current implementation/docs and should be treated as operational memory, not guaranteed historical intent, unless confirmed by Stefan.
+
+---
+
+## D-001 — SQLite over PostgreSQL for primary storage
+**Date:** Pre-Phase 1 (detected from codebase)
+**Decision:** Default storage is SQLite in WAL mode (`storage/legiontrap.db`). PostgreSQL is explicitly supported via SQLAlchemy but not the default.
+**Rationale:** Local-first design. The operator owns the data entirely; no managed database service is required. SQLite is sufficient for single-operator honeypot scale.
+**Alternatives / tradeoffs noted:** Managed PostgreSQL would add operational complexity/cloud dependency; pure filesystem JSONL appears to have been superseded by SQLite for queryability.
+**Migration path:** SQLAlchemy ORM + Alembic make a PostgreSQL migration feasible when scale requires it.
+
+---
+
+## D-002 — Deterministic campaign clustering (no ML)
+**Date:** Pre-Phase 4 (detected from architecture docs)
+**Decision:** Campaign similarity scoring is deterministic — weighted per-dimension scores, same inputs always produce same output. No machine learning.
+**Rationale:** Explainability is an operational requirement. Operators must be able to read per-dimension similarity scores and understand why a source was assigned to a campaign. ML clustering may make this harder unless deliberately designed for explainability.
+**Alternatives / tradeoffs noted:** ML clustering approaches such as DBSCAN/k-means or embedding-based similarity may reduce explainability and add operational complexity unless carefully justified.
+
+---
+
+## D-003 — AI reasoning layer is read-only and isolated
+**Date:** Phase 5 (detected from architecture docs)
+**Decision:** The AI layer never writes to campaign, fingerprint, event, or actor tables. It reads structured data and returns natural-language analysis. It is disabled by default (`AI_BACKEND=none`).
+**Rationale:** Ingest path must function without any AI backend. AI is an analysis tool, not a decision layer. Removing the AI layer leaves ingest and clustering fully intact.
+**Alternatives rejected:** AI-in-the-loop clustering (would make the pipeline non-deterministic).
+
+---
+
+## D-004 — Conventional commits + semantic-release for versioning
+**Date:** Phase 0 or earlier (detected from CI config)
+**Decision:** All commits follow conventional commit format. Merges to `main` trigger semantic-release, which bumps version, generates CHANGELOG, and creates a GitHub Release automatically.
+**Rationale:** Removes manual versioning decisions; commit messages become the source of truth for changelog content.
+**Note:** Breaking changes require `!` suffix on commit type (e.g., `perf!:`).
+
+---
+
+## D-005 — Tests use in-memory SQLite, not fixtures or mocks
+**Date:** Detected from pytest.ini
+**Decision:** `DB_PATH=:memory:` is set in pytest.ini. All tests run against a real (in-memory) SQLite instance, not mocked repositories.
+**Rationale:** Avoids mock/prod divergence. Real SQL queries run in tests, catching schema-level bugs that mocks would miss.
+**Note:** This means tests are somewhat slower than pure unit tests but more reliable.
+
+---
+
+## D-006 — PRIVACY_MODE as first-class config, not an afterthought
+**Date:** Pre-Phase 3 (detected from architecture and config)
+**Decision:** IOC exports support three privacy modes: raw IPs, last-octet masking, and deterministic HMAC hashing. `PRIVACY_MODE` is a first-class env var, not a feature flag.
+**Rationale:** Operators may need to share block lists with partners without revealing observed IPs. The intelligence asset (raw data) is separated from the operational artifact (export).
+
+---
+
+## D-007 — AI authority level: may-edit
+**Date:** 2026-05-30 by Stefan (explicit instruction)
+**Decision:** Claude may edit files on a feature branch. Commits, merges, and deploys require explicit human approval.
+**Rationale:** This project is the testing ground for the autonomous Claude Code workflow. The authority level is intentionally permissive for editing but requires human sign-off on persistent state changes.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1,0 +1,81 @@
+# PROJECT BACKLOG — LegionTrap TI
+
+_Last updated: 2026-05-30 by Claude (onboarding run)_
+
+> Items discovered during initial onboarding. Not prioritized by the operator yet.
+> Owner: Stefan. Review and reprioritize before acting on any item.
+
+---
+
+## Epic A — Hygiene & Safety
+
+### A1 — Remove or gitignore committed `.bak` files
+**Priority:** medium
+**Why:** Multiple `.bak` files are tracked in git (`iocs_pf.py.bak.*`, `main.py.bak.*`, `test_privacy_and_auth.py.bak.*`, `docker-compose.edge.yml.bak`, etc.). These expose internal refactor history and add noise to diffs.
+**Done when:** All `.bak` files are reviewed, then either kept intentionally or removed from tracking going forward and added to `.gitignore`.
+**Note:** Do not rewrite Git history unless sensitive data or secrets are confirmed.
+**Risk:** Low — these are backup files, not production code.
+
+### A2 — Clean up root-level temp files
+**Priority:** low
+**Why:** `tmp.log` and `tmp_events_test.jsonl` exist in the repo root. These appear to be leftover artifacts from manual testing.
+**Done when:** Files deleted or gitignored.
+**Risk:** Low.
+
+### A3 — Ungate `bandit` and `pip-audit` in CI
+**Priority:** medium
+**Why:** Both security jobs run with `continue-on-error: true`, meaning findings never block a merge. The inline TODO confirms this is a known issue.
+**Done when:** Findings triaged; jobs run without `continue-on-error: true`.
+**Risk:** Medium — could reveal blocking findings that need fixes before ungating.
+
+---
+
+## Epic B — Phase 8: Behavioral Federation
+
+### B1 — Define fingerprint serialization format
+**Priority:** low (blocked)
+**Why:** Phase 8 requires a validated wire format for sharing behavioral fingerprints across independent deployments.
+**Done when:** Format documented, validated against two real deployments' data.
+**Blocked by:** Two willing pilot operators.
+
+### B2 — Recruit pilot operators for federation exchange
+**Priority:** low (blocked)
+**Why:** Phase 8 cannot begin without two real operators willing to participate.
+**Done when:** Two operators confirmed; data exchange agreement in place.
+**Blocked by:** Operator outreach.
+
+---
+
+## Epic C — Testing Infrastructure
+
+### C1 — Review and extend test coverage for actor endpoints
+**Priority:** medium
+**Why:** Actor intelligence (Phase 7) is the most recently added subsystem. Integration tests exist (`tests/integration/test_actor_endpoints.py`, `test_actor_stability_endpoints.py`, `test_actor_suggestions_endpoints.py`) but coverage of edge cases is unknown.
+**Done when:** Coverage report reviewed; gaps identified and filled.
+
+### C2 — Add smoke test to CI
+**Priority:** low
+**Why:** `scripts/smoke.sh` and `make smoke` exist locally but are not part of CI. A fast API smoke test after unit tests would catch startup/routing regressions.
+**Done when:** Smoke step added to `ci.yml`.
+
+---
+
+## Epic D — Documentation
+
+### D1 — Add frontend setup instructions to README
+**Priority:** low
+**Why:** README Quick Start covers the backend only. The React dashboard (`ui/dashboard/`) has no documented setup steps.
+**Done when:** README includes `npm install` + `npm run dev` steps for the frontend.
+
+### D2 — Update LEGIONTRAP_EXPLAINED.md status
+**Priority:** low
+**Why:** The `docs/LEGIONTRAP_EXPLAINED.md` file was added in the most recent commit (`cfa92ea`). Confirm it accurately reflects Phase 7 state.
+**Done when:** File reviewed and confirmed current.
+
+---
+
+## Icebox (no priority / no timeline)
+
+- Evaluate PostgreSQL migration for scale (currently SQLite only)
+- Consider formal OpenAPI documentation generation from FastAPI app
+- Verify whether `node_modules` is tracked by Git. If tracked, remove from tracking and add to `.gitignore`; if not tracked, no action needed.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,0 +1,77 @@
+# PROJECT STATUS — LegionTrap TI
+
+_Last updated: 2026-05-30 by Claude (onboarding run)_
+
+## Current phase
+Post-Phase 7 / documentation pass. Phase 7 (Actor Intelligence) is closed. Phase 8 (Behavioral Federation) is conditional on operational prerequisites (two willing pilot operators + validated fingerprint serialization format).
+
+## Project priority
+- **Level:** high
+- **Reason:** Active development testing ground for autonomous Claude Code workflow; real sensor data in use; production-like local deployment.
+
+## Production risk level
+- **Level:** medium
+- **Why:** Live SQLite database (`storage/legiontrap.db`) and real event JSONL files are present in the repo root. Not publicly deployed, but data is operational. 15 Alembic migrations are in place — schema changes carry rollback risk.
+
+## Active branch
+`docs/legiontrap-explained`
+
+## AI authority level
+`may-edit` — Claude may edit files on a feature branch, but must not commit, merge, or deploy without explicit human approval.
+
+## Current Agile context
+- **Current epic:** Documentation and onboarding hardening
+- **Current story:** Upgrade CLAUDE.md to global framework template + run project onboarding
+- **Acceptance criteria:** CLAUDE.md matches global template; PROJECT_STATUS, PROJECT_SUMMARY, PROJECT_BACKLOG, DECISION_LOG created with detected facts; CLAUDE.md commands section populated.
+- **Backlog:** see `PROJECT_BACKLOG.md`
+
+## Last completed task
+2026-05-30 — CLAUDE.md upgraded to global template format (AI authority: may-edit, placeholders replaced with detected values after onboarding).
+
+## Next task
+
+* **Action:** Review the created memory files (`PROJECT_SUMMARY.md`, `PROJECT_BACKLOG.md`, and `DECISION_LOG.md`) before committing them.
+* **Why it matters:** These files now define project memory and future Claude behaviour, so inaccurate assumptions should be corrected before they become trusted context.
+* **Done when:** All created memory files have been reviewed and approved or corrected.
+
+## Files changed this session
+- `CLAUDE.md` — upgraded to global framework template
+- `CLAUDE.md.bak` — backup of original
+- `PROJECT_STATUS.md` — created (this file)
+- `PROJECT_SUMMARY.md` — created
+- `PROJECT_BACKLOG.md` — created
+- `DECISION_LOG.md` — created
+
+## Commands / tests last run
+- **Command:** not run this session (inspect-only onboarding)
+  **Result:** n/a
+  **Date:** 2026-05-30
+  **Notes:** CI passes on main per GitHub Actions history.
+
+## Known risks
+- `bandit` and `pip-audit` run with `continue-on-error: true` in CI — security findings are not blocking. Should be triaged and either fixed or explicitly accepted.
+- Multiple `.bak` files committed to the repo (`iocs_pf.py.bak.*`, `main.py.bak.*`, `test_privacy_and_auth.py.bak.*`). These are noise and could expose internal implementation history.
+- `tmp.log` and `tmp_events_test.jsonl` in the repo root — leftover temp files, should be gitignored or deleted.
+- `storage/legiontrap.db` and `storage/events*.jsonl` contain real sensor data — must never be edited, exposed, or deleted.
+- Phase 8 (Behavioral Federation) has no timeline — blocked on finding two willing pilot operators.
+
+## Test status
+Pass (last known) — pytest -q on main. 3 test directories: `tests/unit/` (26 files), `tests/integration/` (26 files), `tests/db/` (10 files). Tests use in-memory SQLite (`DB_PATH=:memory:`) via pytest.ini env config.
+
+## Deployment status
+Not publicly deployed. Local only via `make run` (uvicorn :8088) or Docker Compose (`docker/docker-compose.edge.yml`). Current release: v0.34.0.
+
+## Human review required
+
+* **Required:** yes
+* **Reason:** Onboarding created new project memory files and updated CLAUDE.md. Human review is required before committing these files.
+
+## Open decisions
+- Should `.bak` files be deleted or gitignored? — options: delete / gitignore — owner: Stefan — blocking? no
+- Should `bandit`/`pip-audit` `continue-on-error` be removed? — options: fix findings first / accept with justification — owner: Stefan — blocking? no
+- Phase 8 prerequisites — options: wait / proactively seek pilot partners — owner: Stefan — blocking? no
+
+## Notes
+- The `docker/docker-compose.edge.yml` references `../ui/backend/Dockerfile`, which exists at `ui/backend/`. The main Makefile does not have a Docker build target — run docker-compose directly.
+- Release automation: semantic-release fires on every merge to `main`. Conventional commit type determines version bump.
+- The frontend dashboard (`ui/dashboard/`) is React 19 + Vite + TypeScript + Recharts. Dev server: `cd ui/dashboard && npm run dev`.

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -1,0 +1,83 @@
+# PROJECT SUMMARY — LegionTrap TI
+
+_Last updated: 2026-05-30 by Claude (onboarding run)_
+
+## What it is
+LegionTrap TI is a self-hosted behavioral threat intelligence platform for honeypot operators. It ingests attack events from a local sensor, builds behavioral fingerprints across five dimensions (timing, sequence, protocol, credential, target), clusters fingerprints into campaigns using a deterministic similarity algorithm, tracks longitudinal fingerprint history, and provides an optional AI-assisted reasoning layer for natural-language threat analysis. All storage is local (SQLite). No cloud dependency is required.
+
+## Why it exists
+Indicator-based threat intel (IPs, domains, hashes) decays fast because infrastructure is cheap to rotate. Behavioral patterns change slowly. LegionTrap bets on behavioral, longitudinal intelligence as the durable category — a fingerprint built over months survives infrastructure rotation that would expire any indicator. The operator owns the data entirely.
+
+## Current release
+v0.34.0 — Phase 7 (Actor Intelligence) complete. All planned phases from Phase 0 to Phase 7 shipped.
+
+## Architecture in one paragraph
+Two structurally isolated paths: (1) **ingest path** — events → GeoIP enrichment → fingerprint update → campaign clustering (deterministic, runs on every ingest); (2) **reasoning path** — AI analysis on operator request (read-only, never writes to campaign/fingerprint/actor tables). Backend: FastAPI (Python 3.11) + SQLAlchemy + Alembic (SQLite/PostgreSQL-compatible). Frontend: React 19 + Vite + TypeScript dashboard. Auth: JWT + API key + bcrypt. Rate limiting: slowapi.
+
+## Stack
+| Layer | Technology |
+|---|---|
+| Language | Python 3.11 |
+| API framework | FastAPI + uvicorn |
+| ORM / migrations | SQLAlchemy + Alembic (15 migrations) |
+| Storage | SQLite (WAL mode) — default: `storage/legiontrap.db` |
+| Auth | JWT (python-jose) + API key + bcrypt (passlib) |
+| Rate limiting | slowapi |
+| GeoIP | geoip2 + MaxMind GeoLite2 (`storage/GeoLite2-City.mmdb`) |
+| AI backends | Claude API or Ollama (optional, default: none) |
+| Frontend | React 19, TypeScript, Vite, Recharts (`ui/dashboard/`) |
+| Container | Docker + Docker Compose (`docker/docker-compose.edge.yml`) |
+| CI/CD | GitHub Actions (lint → test → pip-audit → bandit → semantic-release) |
+| Formatter | black (100 chars, py311) + ruff (E,F,I,B,UP,SIM) + isort |
+| Test runner | pytest (unit / integration / db tiers) |
+
+## Entry points
+- **API server:** `app/main.py` → `uvicorn app.main:app --port 8088`
+- **Frontend dev:** `ui/dashboard/` → `npm run dev` (Vite :5173)
+- **Docker:** `docker/docker-compose.edge.yml`
+
+## Key commands
+| Action | Command |
+|---|---|
+| Install | `pip install -r requirements.txt` |
+| Run API | `make run` |
+| Dev mode (fastapi) | `make ui` |
+| Test | `pytest -q` |
+| Test with coverage | `pytest -q --cov=app` |
+| Lint | `black --check . && ruff check .` |
+| Format (fix) | `black . && ruff check --fix .` |
+| Security audit | `pip-audit` + `bandit -r app/ -ll` |
+| DB migrate | `make db-migrate` |
+| DB status | `make db-status` |
+| Smoke test | `make smoke` |
+
+## Test structure
+```
+tests/
+  unit/         26 files — fingerprinting, similarity, AI, stability, actor logic
+  integration/  26 files — endpoint tests (FastAPI TestClient)
+  db/           10 files — repository layer tests
+  conftest.py   — shared fixtures
+  test_*.py     — additional root-level tests (auth, iocs, privacy)
+```
+Tests run against in-memory SQLite (`DB_PATH=:memory:` via pytest.ini).
+
+## Phase history
+| Phase | Topic | Status |
+|---|---|---|
+| 0 | Security & Infra Hygiene | ✅ |
+| 1 | SQLite Storage Foundation | ✅ |
+| 2 | HTTP Ingestion API | ✅ |
+| 3 | GeoIP Enrichment & IOC Exports | ✅ |
+| 4 | Campaign Intelligence & Export Maturity | ✅ |
+| 5 | AI Integration | ✅ |
+| 6 | Async AI, Output Persistence & Brief UI | ✅ |
+| 7 | Actor Intelligence | ✅ |
+| 8 | Behavioral Federation | ○ conditional |
+
+## Do-not-touch zones
+- `storage/legiontrap.db` — live SQLite database with real sensor data
+- `storage/events*.jsonl` — real event logs
+- `storage/GeoLite2-City.mmdb` — MaxMind binary, not regenerable from source
+- `.env` — secrets (not committed)
+- `app/db/migrations/` — Alembic migration history; never edit existing files

--- a/docs/LEGIONTRAP_EXPLAINED.md
+++ b/docs/LEGIONTRAP_EXPLAINED.md
@@ -1,0 +1,305 @@
+⏺ LegionTrap — In Plain English
+
+  A scene to start with
+
+  Imagine you have a server connected to the internet. From the moment it goes online, strangers start knocking on its door. Not metaphorically — literally,
+  every few seconds, automated systems somewhere in the world try to log in, probe its services, guess passwords, look for weaknesses. Most fail. Some are
+  clumsy. A few are sophisticated. They come from everywhere, all the time, forever.
+
+  You would like to know who is behind these attempts, whether the same groups keep coming back, what they want, and what they will probably do next.
+
+  Almost nothing in commercially available security tooling actually answers those questions. LegionTrap is an attempt to.
+
+  ---
+  What is LegionTrap?
+
+  LegionTrap is a software platform that turns raw attack data into structured intelligence about who is attacking you and how they behave.
+
+  It does not protect a network by itself. It is not a firewall, antivirus, or intrusion detection system. It is the layer that sits behind those tools and
+  tries to make sense of what they see — specifically the part of "what they see" that comes from honeypots.
+
+  A honeypot is a deliberately exposed system designed to look like a real target. Anyone who connects to it is, by definition, doing something they shouldn't
+   — there is no legitimate reason for a honeypot to receive traffic. Security researchers run honeypots specifically to study attacker behavior in a safe,
+  contained way. LegionTrap reads everything a honeypot sees and builds a long-term, structured memory of the activity.
+
+  That's the platform in one paragraph: it watches the attackers attacking the bait, and remembers.
+
+  ---
+  Why was it built?
+
+  Because the dominant model of cybersecurity intelligence is breaking.
+
+  For decades, the standard approach has been to keep lists of bad things. Bad IP addresses. Bad domain names. Bad file signatures. Bad email senders.
+  Security vendors maintain these lists, sell them as subscriptions, and security tools consult them — "is this address on the bad list? Yes? Block it."
+
+  This works until the attacker changes the bad thing. And the cost of changing has collapsed.
+
+  A new domain name costs a few dollars. A new server in a different country takes minutes to spin up. A new IP address is essentially free. AI tooling now
+  lets attackers generate plausible-looking domains, infrastructure, and even attack scripts at industrial scale. The half-life of any given "bad IP" or "bad
+  domain" — how long it stays useful as intelligence — is getting shorter every year.
+
+  The defender is on a treadmill. Block the IP. The attacker rotates. Block the next IP. The attacker rotates again. The list-based model has a structural
+  problem: it tracks things that are cheap to change.
+
+  LegionTrap was built on a different premise: track the things that are expensive to change.
+
+  ---
+  What problem does it solve?
+
+  Here is the core insight, in everyday terms.
+
+  Imagine you're trying to identify a burglar who keeps hitting houses in your neighborhood. The traditional approach is to write down their license plate.
+  That works once. Then they get a new car, and the license plate is useless.
+
+  The alternative is to describe how they operate. They prefer corner houses. They come between 2 and 3 in the morning. They pick locks with a specific
+  technique. They cut the alarm wire in a specific way. They take electronics but ignore jewelry.
+
+  If you have a description like that, it doesn't matter what car they drive next time. The behavior identifies them.
+
+  This is what LegionTrap does with attackers. It builds the behavioral description. Not the license plate.
+
+  Specifically, it tracks five categories of behavior for every attacker it observes:
+
+  1. Timing. When do they show up? At what rhythm? Random bursts, steady hourly probes, business hours, midnight only?
+  2. Sequence. In what order do they try things? Some attackers always test SSH before web ports. Some scan in alphabetical order. Some have signature
+  patterns.
+  3. Protocol behavior. What tools and versions are they using? How do they negotiate connections? What handshake quirks do they have?
+  4. Credentials. What usernames and passwords do they try? In what order? With what dictionaries?
+  5. Targets. Which of your services do they consistently come back to? Which do they ignore?
+
+  The combination of these five — what LegionTrap internally calls a behavioral fingerprint — is much harder to change than any IP address or domain. It
+  reflects the attacker's actual operational habits, the tools they have invested in, the muscle memory of how they work. Even when they rotate everything
+  else, these patterns tend to persist.
+
+  That is the problem LegionTrap solves: it produces intelligence that doesn't expire the moment the attacker changes hosting providers.
+
+  ---
+  What happens when an attack enters the system?
+
+  Step by step, in concrete terms:
+
+  1. The honeypot sees something. An attacker, somewhere in the world, connects to a honeypot. They try to log in. They probe a port. They run a script. The
+  honeypot logs everything they did.
+  2. The honeypot sends the event to LegionTrap. Over the internet, securely, with an API key.
+  3. LegionTrap records it. It stores the raw record, then enriches it: which country is the attacker coming from, which internet service provider, which
+  network. This is the only part where it uses outside data — geographic and network ownership lookups.
+  4. LegionTrap updates the attacker's behavioral fingerprint. Every event from this source contributes to a behavioral profile. The more events, the sharper
+  the profile.
+  5. LegionTrap compares this fingerprint to known campaigns. Has this kind of behavior shown up before? If yes, this activity is added to that existing
+  campaign. If it's close to a known campaign but not quite a match, it is flagged for human review. If it's genuinely new, a new campaign is created.
+  6. LegionTrap updates the long-term history. Every time the fingerprint changes — new patterns, new credentials, new targets — a snapshot is recorded. Over
+  months, this builds a longitudinal record: how is this attacker evolving? Are they stabilizing or drifting?
+  7. The operator sees it in the dashboard. Whoever is running LegionTrap — the operator — can browse all of this through a web interface. They can also
+  export blocklists for their actual firewall, request an AI-generated written summary of a particular campaign, and link campaigns to actors they've
+  identified.
+  8. Nothing happens automatically. This is important. LegionTrap does not block, alert, or act on its own. It surfaces information. The operator decides what
+   to do.
+
+  That entire flow runs continuously, in the background, on whatever machine the operator has chosen to run LegionTrap on. There is no cloud service. There is
+   no shared database. The intelligence belongs to the operator alone.
+
+  ---
+  What is a campaign?
+
+  A campaign, in LegionTrap, is a coordinated stretch of activity that shares behavioral characteristics — usually spanning many source addresses and a
+  meaningful period of time.
+
+  Think of it as an outbreak in disease surveillance. You don't necessarily know everyone involved. You don't know exactly where it started. But you can see
+  that this thing is happening, that it has identifiable features, that it has a start, that it sometimes goes quiet, and that it sometimes comes back.
+
+  A campaign is what LegionTrap calls that thing. It is not a person. It is not a group. It is a coherent pattern of activity that the platform has identified
+   and given a name.
+
+  Campaigns have lifecycles. They are first active when activity is ongoing. They become dormant if activity stops. They are marked reactivated if a dormant
+  campaign starts up again — which, in this kind of data, happens more than you would expect. They are marked historical if enough time passes that they're
+  considered concluded. None of these labels are permanent. A historical campaign can come back. That's part of the point.
+
+  ---
+  What is an actor?
+
+  An actor is what a campaign is not. A campaign is a pattern of activity. An actor is the entity — a person, a group, an organization, a government, a piece
+  of automation — that is presumed responsible for one or more campaigns.
+
+  The distinction matters because identifying actors is genuinely hard and often guesswork. Saying "this campaign exists" is a low-confidence claim — the data
+   shows it. Saying "this campaign was conducted by Group X" is a much higher-confidence claim that requires evidence the platform cannot fully verify.
+
+  LegionTrap handles this carefully. Actors are not created automatically. The platform may suggest that two campaigns look similar enough to potentially
+  share an actor, but the suggestion is advisory only. A human operator decides whether to accept it. The platform makes it easy to track these decisions,
+  link campaigns to actors explicitly, and review the evidence — but it never makes the attribution call by itself.
+
+  This is a deliberate design choice. Attribution mistakes in cybersecurity are common and consequential. The operator stays in charge of that judgment.
+
+  ---
+  Why is behavior important?
+
+  The IP address rotates. The domain rotates. The malware sample is regenerated by an AI tool with slight variations. The attacker's method of operating —
+  when they show up, what order they try things in, what tools they prefer, how they handle errors — changes much more slowly.
+
+  Behavior changes slowly because it reflects investment. An attacker who has spent six months refining a specific approach is not going to throw it out the
+  next morning. The tools they use have learning curves. The dictionaries they use are tuned. The infrastructure layouts they prefer have reasons. Changing
+  all of that costs real time and money.
+
+  So while infrastructure-based intelligence has a half-life of days or hours, behavioral intelligence has a half-life of weeks or months. In some cases,
+  years. That difference compounds: a defender who has been tracking behavior for two years has institutional memory that no commercial threat feed can sell,
+  because no feed has access to that defender's specific observations.
+
+  The longer LegionTrap runs in a given environment, the better its behavioral memory becomes. The intelligence accumulates with time. This is the opposite of
+   the indicator model, where intelligence depreciates with time.
+
+  ---
+  What can LegionTrap do today?
+
+  A focused list of what currently works:
+
+  - Ingest events from honeypots in a standard format
+  - Enrich events with geographic and network ownership information
+  - Build behavioral fingerprints for every observed attacker
+  - Group activity into campaigns automatically, using a deterministic similarity algorithm
+  - Track campaign lifecycles through active, dormant, reactivated, and historical states
+  - Detect reactivation when a dormant campaign returns
+  - Record behavioral history so the platform can show how an attacker's patterns have evolved
+  - Compute behavioral stability — has this campaign's tooling been steady, or is it drifting?
+  - Alert on behavioral drift when stability scores cross configured thresholds
+  - Surface uncertain cases for analyst review when clustering is borderline
+  - Improve over time by feeding analyst review decisions back into the clustering weights
+  - Create and manage actor profiles that link multiple campaigns to a presumed responsible party
+  - Suggest actor attribution candidates — read-only, advisory
+  - Generate firewall blocklists in standard formats, with optional privacy protections
+  - Export to standard threat intelligence formats (STIX, ATT&CK Navigator) for sharing with other tools
+  - Produce AI-generated narrative summaries of campaigns and threat briefs, when the operator requests them, with full audit trail
+  - Display everything in a web dashboard
+  - Audit every action
+
+  It does this on a single machine, with no cloud dependency, no shared intelligence feed, and no subscription requirement.
+
+  ---
+  What can it not do yet?
+
+  An honest list of gaps:
+
+  - It cannot predict the future. It tells you what happened and what is happening. It does not yet forecast which dormant campaigns are likely to return,
+  when a campaign's behavior is likely to cross a threshold, or what an attacker is likely to do next.
+  - It cannot share intelligence with other deployments. Each LegionTrap is an island. If two operators are both being attacked by the same group, neither
+  knows that the other is seeing it.
+  - It cannot deploy detections to your defenses automatically. It produces blocklists, but it does not yet generate detection rules for intrusion detection
+  systems, host monitors, or other defensive tooling.
+  - It is built for a single operator. Multi-user workflows, role separation, team collaboration — none of that exists.
+  - It assumes a single sensor type. It was designed and tested primarily with one kind of honeypot. Operators running multiple sensor types may find rough
+  edges.
+  - It has not been production-hardened at scale. The storage layer is designed to support migration to a heavier database, but that migration has not been
+  needed and not been performed.
+  - It does not pull in external threat intelligence. It builds intelligence from your own observations only. Integration with outside data sources is not
+  part of the current platform.
+
+  These are not embarrassments. They are choices about what to build first and what to build later.
+
+  ---
+  Why is it different from traditional security tools?
+
+  Traditional threat intelligence platforms tend to share three properties: they are indicator-based (centered on bad IPs, domains, file hashes), they are
+  externally curated (a vendor decides what's bad), and they are generic (the same intelligence is sold to everyone).
+
+  LegionTrap inverts all three.
+
+  It is behavior-based. What it remembers about an attacker is not the address they came from but how they operated when they got there.
+
+  It is locally built. No vendor curates this data. The operator's own observations are the only source of truth. There is no opinion that has been filtered
+  through someone else's business model.
+
+  It is specific to one operator's exposure. Two LegionTrap deployments running in different environments will, over time, develop completely different
+  intelligence — because they are seeing different attackers attacking different targets. This is not a bug. It is the entire point. Generic intelligence
+  about everyone's attackers is less useful than specific intelligence about your own.
+
+  It is also different in a less obvious way: it is deliberately conservative about AI. The AI layer in LegionTrap reads structured, deterministic data and
+  produces written summaries on operator request. It does not make decisions. It does not categorize campaigns. It does not assign attribution. Every
+  conclusion the platform draws is reachable through a transparent, repeatable calculation that an operator can audit. AI is a writer. It is not a judge.
+
+  This stands in contrast to a growing tendency in the industry to put machine learning models at the center of decision-making, where neither the operator
+  nor the vendor can fully explain why a particular threat was flagged.
+
+  ---
+  What is the long-term vision?
+
+  The long-term thesis has three layers.
+
+  Layer one: behavioral intelligence compounds. A LegionTrap deployment that has been running for one year is meaningfully more valuable than one running for
+  six months. After two or three years, the institutional memory it has accumulated — about specific attackers, their evolution, their dormancy and
+  reactivation patterns — becomes something no commercial product can replicate. The platform gets better just by continuing to run.
+
+  Layer two: prediction. Eventually, this longitudinal data should support forecasting. Which dormant campaigns are likely to come back, and when? Which
+  active campaigns are about to drift, and where? These predictions are not yet built, but the data structures that will make them possible are already
+  accumulating. The platform is being built such that the predictive layer can be added when there is enough history to justify it.
+
+  Layer three: federation. In the longer term, multiple operators running LegionTrap could share behavioral patterns with each other — not raw data, not
+  source addresses, just the behavioral signature — so that an attacker first observed by operator A is recognized faster when they show up at operator B.
+  This is harder than it sounds. It requires trust models, quality controls, and incentive structures that don't exist yet. It is a real long-term direction
+  but explicitly not the next step.
+
+  Underneath all three layers is a single belief: that as AI accelerates the rate at which traditional indicators (IPs, domains, hashes) lose their value,
+  behavioral intelligence becomes the only kind that holds up. LegionTrap is a bet on that future.
+
+  ---
+  The three explanations
+
+  One sentence: LegionTrap is a software platform that watches attackers hitting honeypot servers, records how each attacker operates, and builds long-term
+  intelligence about who is attacking — based on behavior patterns instead of throwaway IP addresses or domain names.
+
+  Thirty seconds: Most cybersecurity intelligence is organized around indicators — IP addresses, domain names, file fingerprints — which attackers can rotate
+  in minutes for almost no money. That makes traditional intelligence stale almost as fast as it's produced. LegionTrap takes a different approach: it watches
+   attackers hitting honeypots and records how they operate — their timing patterns, the order they probe things, the credentials they try, the targets they
+  prefer. That kind of behavioral information is much harder for attackers to change, so it stays useful much longer. Over months and years, a LegionTrap
+  deployment builds a long-term behavioral memory of its specific attackers, which a defender can use to recognize them across infrastructure changes.
+  Everything runs locally — there is no cloud service, no shared feed, no vendor. The operator owns the data, the analysis, and the conclusions.
+
+  Two minutes: LegionTrap is a self-hosted intelligence platform for honeypot operators. A honeypot is a deliberately exposed fake server whose only purpose
+  is to attract attackers so they can be studied safely. LegionTrap takes everything a honeypot sees and turns it into structured, long-term intelligence.
+
+  The platform was built because the dominant model of threat intelligence is breaking down. Most security tools rely on lists of bad IP addresses, bad domain
+   names, and bad file signatures. These lists go stale fast because attackers can change all of those things cheaply — and AI tooling is making the change
+  cheaper every year. Defenders end up on a treadmill of blocking what's already been rotated away.
+
+  LegionTrap tracks behavior instead. For every attacker it sees, it builds a profile across five dimensions: when they show up, in what order they try
+  things, which tools they use, what credentials they try, and which targets they consistently come back to. The combination is what the platform calls a
+  behavioral fingerprint. Behavioral fingerprints change much more slowly than infrastructure because they reflect the attacker's actual operational habits —
+  habits that take real time and effort to change. So while a list of bad IPs goes stale in days, a behavioral fingerprint stays useful for months or years.
+
+  When events come in, LegionTrap groups related activity into campaigns. Campaigns have lifecycles: they are active, then dormant, sometimes reactivated,
+  eventually marked historical. Operators can also create actor profiles — people, groups, or organizations they believe are responsible for one or more
+  campaigns. The platform suggests possible matches but never makes attribution decisions automatically. The operator stays in charge of every consequential
+  The three explanations
+
+  One sentence: LegionTrap is a software platform that watches attackers hitting honeypot servers, records how each attacker operates, and builds long-term
+  intelligence about who is attacking — based on behavior patterns instead of throwaway IP addresses or domain names.
+
+  Thirty seconds: Most cybersecurity intelligence is organized around indicators — IP addresses, domain names, file fingerprints — which attackers can rotate
+  in minutes for almost no money. That makes traditional intelligence stale almost as fast as it's produced. LegionTrap takes a different approach: it watches
+   attackers hitting honeypots and records how they operate — their timing patterns, the order they probe things, the credentials they try, the targets they
+  prefer. That kind of behavioral information is much harder for attackers to change, so it stays useful much longer. Over months and years, a LegionTrap
+  deployment builds a long-term behavioral memory of its specific attackers, which a defender can use to recognize them across infrastructure changes.
+  Everything runs locally — there is no cloud service, no shared feed, no vendor. The operator owns the data, the analysis, and the conclusions.
+
+  Two minutes: LegionTrap is a self-hosted intelligence platform for honeypot operators. A honeypot is a deliberately exposed fake server whose only purpose
+  is to attract attackers so they can be studied safely. LegionTrap takes everything a honeypot sees and turns it into structured, long-term intelligence.
+
+  The platform was built because the dominant model of threat intelligence is breaking down. Most security tools rely on lists of bad IP addresses, bad domain
+   names, and bad file signatures. These lists go stale fast because attackers can change all of those things cheaply — and AI tooling is making the change
+  cheaper every year. Defenders end up on a treadmill of blocking what's already been rotated away.
+
+  LegionTrap tracks behavior instead. For every attacker it sees, it builds a profile across five dimensions: when they show up, in what order they try
+  things, which tools they use, what credentials they try, and which targets they consistently come back to. The combination is what the platform calls a
+  behavioral fingerprint. Behavioral fingerprints change much more slowly than infrastructure because they reflect the attacker's actual operational habits —
+  habits that take real time and effort to change. So while a list of bad IPs goes stale in days, a behavioral fingerprint stays useful for months or years.
+
+  When events come in, LegionTrap groups related activity into campaigns. Campaigns have lifecycles: they are active, then dormant, sometimes reactivated,
+  eventually marked historical. Operators can also create actor profiles — people, groups, or organizations they believe are responsible for one or more
+  campaigns. The platform suggests possible matches but never makes attribution decisions automatically. The operator stays in charge of every consequential
+  judgment.
+
+  What LegionTrap can do today: ingest events, build fingerprints, identify campaigns, track lifecycle changes, detect reactivations, surface behavioral
+  drift, manage actor attribution, generate firewall blocklists, export to standard intelligence formats, and produce AI-written summaries on demand with a
+  full audit trail. What it does not do yet: predict future activity, share intelligence with other deployments, generate detection rules automatically for
+  non-firewall defenses, or support multi-user workflows.
+
+  The long-term direction is predictive intelligence built on the longitudinal data the platform accumulates, and eventually federated behavioral pattern
+  sharing between consenting operators. The deeper bet is that as traditional indicator-based intelligence becomes cheaper to defeat, behavioral intelligence
+  becomes the only kind that holds up.


### PR DESCRIPTION
## Summary

Adds a new high-level documentation guide:

* docs/LEGIONTRAP_EXPLAINED.md

This document explains LegionTrap in plain English and is intended for:

* founders
* contributors
* advisors
* recruiters
* investors
* non-specialist readers

The guide focuses on:

* what LegionTrap is
* why it exists
* how it works
* campaigns and actors
* behavioral intelligence
* current capabilities
* current limitations
* long-term vision

## Motivation

As the project evolved through multiple phases, knowledge became distributed across architecture, roadmap, and phase closeout documents.

This guide provides a single narrative explanation of the platform that can be read independently without requiring familiarity with the codebase or technical documentation.

## Impact

Documentation only.

No code changes.
No database changes.
No API changes.
No functional changes.
