### PR TITLE
Fix migration guide stale paths and add operational hygiene notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ docs/strategic-intelligence-layer
 # Runtime-generated event and database files (must not be committed)
 *.jsonl
 *.db
+
+# Dashboard screenshot / thumbnail (binary asset, not version-controlled)
+Thumbnail.png

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ db-prune:
 	@test -n "$(PRUNE_BEFORE)" || { echo "Error: PRUNE_BEFORE is required. Usage: make db-prune PRUNE_BEFORE=2025-01-01T00:00:00+00:00" >&2; exit 1; }
 	PYTHONPATH=. python scripts/db_prune.py --before "$(PRUNE_BEFORE)"
 
+# WARNING: smoke includes POST /api/ingest, which writes a synthetic test event to the database.
+# Do NOT run this target against a database containing real sensor data.
 smoke:
 	@echo "[health]"; curl -s http://127.0.0.1:$(PORT)/api/health | python3 -m json.tool
 	@echo "[ingest]"; curl -s -H "$(H)" -H 'Content-Type: application/json' \

--- a/README.md
+++ b/README.md
@@ -177,16 +177,22 @@ make db-migrate
 # 4. Start the API
 make run
 
-# 5. Health check
+# 5. Start the dashboard (separate terminal, from project root)
+cd ui/dashboard && npm install  # first time only
+npm run dev                     # dashboard at http://localhost:5173, proxies /api to :8088
+
+# 6. Health check
 curl -s http://127.0.0.1:8088/api/health | python -m json.tool
 
-# 6. Ingest a test event
+# 7. Ingest a test event
+# NOTE: This writes a synthetic event to the selected database.
+# Skip this step if the database already contains real sensor data.
 H='x-api-key: <your-API_KEY>'
 curl -s -H "$H" -H 'Content-Type: application/json' \
   -d '{"events":[{"ts":"2025-10-28T18:31:08+00:00","source":"cowrie","type":"cowrie.login.failed","data":{"ip":"1.2.3.4","username":"root","password":"bad"}}]}' \
   http://127.0.0.1:8088/api/ingest | python -m json.tool
 
-# 7. Stats and IOC exports
+# 8. Stats and IOC exports
 curl -s -H "$H" http://127.0.0.1:8088/api/stats | python -m json.tool
 curl -s -H "$H" http://127.0.0.1:8088/api/iocs/ufw.txt
 curl -s -H "$H" http://127.0.0.1:8088/api/iocs/pf.conf
@@ -222,6 +228,7 @@ make db-prune PRUNE_BEFORE=2025-01-01T00:00:00+00:00
 make import-jsonl JSONL_FILES="storage/events.jsonl"
 
 # Verify migration correctness (tables, indexes, revision)
+# Validates against the expected head revision (currently 0013). Re-run after each migration cycle.
 make db-validate
 ```
 

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -125,13 +125,13 @@ sqlite3 storage/legiontrap.db ".tables"
 ### Step 3: Import existing JSONL data
 
 ```bash
-python -m app.tools.import_jsonl storage/events.jsonl
+PYTHONPATH=. python scripts/import_jsonl.py storage/events.jsonl
 ```
 
 If additional archived JSONL files exist (e.g., `storage/events-20251028-183613.jsonl`), import each:
 ```bash
-python -m app.tools.import_jsonl storage/events-20251028-183613.jsonl
-python -m app.tools.import_jsonl storage/events-20251028-181245.jsonl
+PYTHONPATH=. python scripts/import_jsonl.py storage/events-20251028-183613.jsonl
+PYTHONPATH=. python scripts/import_jsonl.py storage/events-20251028-181245.jsonl
 ```
 
 The import tool:
@@ -154,12 +154,12 @@ Import complete. Database: storage/legiontrap.db
 
 ### Step 4: Verify import correctness
 
-Run the verification query:
+Verify the database schema and migration state:
 ```bash
-python -m app.tools.verify_migration storage/events-20251028-183613.jsonl
+make db-validate
 ```
 
-The verify tool counts lines in the JSONL file and rows in SQLite and asserts they match. It also checks that `unique_ips` in SQLite matches the count from `iocs_pf.py`'s recursive IP extraction.
+`make db-validate` checks that all expected tables and indexes are present and that the Alembic revision matches the installed head. It does not compare row counts against the JSONL source file — use the post-migration SQL queries in the section below for count verification.
 
 ### Step 5: Switch read endpoints to SQLite
 
@@ -190,19 +190,19 @@ After confirming the migrated endpoints work correctly, enable the write-through
 
 ## Import Tool Specification
 
-`app/tools/import_jsonl.py` is a command-line tool, not a library. It must not be imported by application code.
+`scripts/import_jsonl.py` is a command-line tool, not a library. It must not be imported by application code.
 
 ```
-usage: python -m app.tools.import_jsonl <path> [--dry-run] [--batch-size N]
+usage: PYTHONPATH=. python scripts/import_jsonl.py <file> [<file> ...] [--db-path PATH]
 
 positional arguments:
-  path              Path to JSONL file to import
+  file              One or more JSONL files to import
 
 options:
-  --dry-run         Parse and validate without inserting (shows what would be imported)
-  --batch-size N    Rows per SQLite transaction (default: 500)
-  --errors-file F   Path for import error log (default: storage/import_errors.jsonl)
+  --db-path PATH    SQLite DB path (overrides DB_PATH env var / settings)
 ```
+
+Alternatively: `make import-jsonl JSONL_FILES="storage/events.jsonl"`
 
 **Idempotency:** The import tool uses `INSERT OR IGNORE` on `raw_events` (primary key is the event `id`). Running the same file twice produces the same database state. This means JSONL files can be re-imported after schema changes without risk of duplication.
 
@@ -270,8 +270,8 @@ For operators upgrading from a JSONL-only deployment to the SQLite-backed versio
 3. **Update the application** (git pull or image pull)
 4. **Install new dependencies:** `pip install -r requirements.txt`
 5. **Run the migration:** `alembic upgrade head`
-6. **Import existing events:** `python -m app.tools.import_jsonl storage/events.jsonl`
-7. **Verify the import:** `python -m app.tools.verify_migration storage/events.jsonl`
+6. **Import existing events:** `PYTHONPATH=. python scripts/import_jsonl.py storage/events.jsonl`
+7. **Verify the migration:** `make db-validate`
 8. **Start the application**
 9. **Smoke test** the API endpoints
 10. **Monitor `storage/import_errors.jsonl`** for any events that failed validation


### PR DESCRIPTION
## Summary

- Replace stale `python -m app.tools.import_jsonl` paths with `PYTHONPATH=. python scripts/import_jsonl.py` (`app/tools/` does not exist)
- Replace non-existent `python -m app.tools.verify_migration` with `make db-validate` throughout the migration guide
- Remove undocumented `--dry-run`, `--batch-size`, `--errors-file` flags from import tool specification (unimplemented; cause argparse errors)
- Add `WARNING` comment above `make smoke` target — it writes a synthetic event via `POST /api/ingest` and must not be run against real data
- Add `Thumbnail.png` to `.gitignore` (1.6M untracked binary, no prior ignore rule)
- Add frontend startup instructions to README Quick Start (`cd ui/dashboard && npm run dev`, port 5173)
- Add caution note to README Quick Start ingest example (writes to live database)
- Add revision note to `make db-validate` entry in README (validates against head revision 0013)

## Test plan

- [ ] Confirm CI passes
- [ ] Verify `docs/MIGRATION_GUIDE.md` import commands match `scripts/import_jsonl.py` CLI
- [ ] Verify `docs/MIGRATION_GUIDE.md` verification step references `make db-validate`
- [ ] Verify `Makefile` smoke target comment is present and accurate
- [ ] Verify `Thumbnail.png` does not appear in `git status` after branch checkout
- [ ] Verify README Quick Start step 5 shows frontend startup via `npm run dev`