### PR TITLE
security: enable bandit and pip-audit CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,8 @@ jobs:
         run: |
           pytest -q
 
-      # TODO: remove continue-on-error after initial baseline triage
       - name: Security — dependency audit
         run: pip-audit
-        continue-on-error: true
 
-      # TODO: remove continue-on-error after initial baseline triage
       - name: Security — static analysis
         run: bandit -r app/ -ll
-        continue-on-error: true

--- a/app/db/repositories/actor.py
+++ b/app/db/repositories/actor.py
@@ -191,8 +191,8 @@ class ActorRepository(RepositoryBase):
 
         self._session.execute(
             text(
-                f"UPDATE actor_profiles SET {', '.join(assignments)} WHERE id = :id"
-            ),  # noqa: S608
+                f"UPDATE actor_profiles SET {', '.join(assignments)} WHERE id = :id"  # nosec B608
+            ),
             params,
         )
         return self.get_actor_profile(actor_id)

--- a/app/db/repositories/campaign.py
+++ b/app/db/repositories/campaign.py
@@ -192,7 +192,7 @@ class CampaignRepository(RepositoryBase):
                        weight_credential, weight_target
                 FROM campaign_weight_profiles
                 WHERE campaign_id IN ({placeholders})
-            """),
+            """),  # nosec B608
             params,
         ).fetchall()
         weight_map: dict[str, dict[str, float]] = {
@@ -755,7 +755,7 @@ class CampaignRepository(RepositoryBase):
                 {review_clause}
                 ORDER BY observed_at ASC
                 LIMIT :limit
-            """),
+            """),  # nosec B608
             params,
         ).fetchall()
 
@@ -861,7 +861,7 @@ class CampaignRepository(RepositoryBase):
                 FROM campaign_observations
                 WHERE campaign_id IN ({placeholders})
                 GROUP BY campaign_id
-            """),
+            """),  # nosec B608
             params,
         ).fetchall()
         result: dict[str, dict[str, int]] = {

--- a/app/db/repositories/jobs.py
+++ b/app/db/repositories/jobs.py
@@ -146,7 +146,7 @@ class JobRepository(RepositoryBase):
                 {where}
                 ORDER BY created_at DESC
                 LIMIT :limit
-            """),
+            """),  # nosec B608
             params,
         ).fetchall()
         return [_row_to_dict(r) for r in rows]


### PR DESCRIPTION
## Summary

- Add `# nosec B608` to 5 verified false positives in `app/db/repositories/` — all are parameterized SQL patterns where the interpolated fragments are hardcoded column/clause strings, not user input
- Remove `continue-on-error: true` from both security CI steps so `bandit` and `pip-audit` failures now block the pipeline
- Both tools exit 0 with this branch: bandit reports no medium/high findings; pip-audit reports no known vulnerabilities

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Remove `continue-on-error: true` from bandit and pip-audit steps |
| `app/db/repositories/actor.py` | `# nosec B608` on dynamic `UPDATE SET` clause (hardcoded column names, bind-param values) |
| `app/db/repositories/campaign.py` | `# nosec B608` on 3 parameterized `IN (...)` and dynamic `WHERE` clauses |
| `app/db/repositories/jobs.py` | `# nosec B608` on dynamic `WHERE` clause (hardcoded filter fragments) |

## Verification

- `bandit -r app/ -ll` → exit 0, no issues identified, 5 suppressions active
- `pip-audit -r requirements.txt` → exit 0, no known vulnerabilities
- `python -m compileall app/db/repositories` → exit 0
- `ruff check` on edited files → exit 0
- Working tree clean before and after

## Test plan

- [ ] CI bandit step passes (exits 0, no medium/high findings)
- [ ] CI pip-audit step passes (exits 0, no known vulnerabilities)
- [ ] All existing tests pass (`pytest -q`)
- [ ] Lint passes (`black --check . && ruff check .`)