### PR TITLE
test: extend actor endpoint coverage

### DIFF
--- a/tests/integration/test_actor_endpoints.py
+++ b/tests/integration/test_actor_endpoints.py
@@ -31,6 +31,7 @@ Coverage:
     - clears notes (explicit null)
     - omitted fields are not changed
     - invalid status returns 422
+    - blank display_name returns 422
     - returns 404 for unknown id
     - requires authentication
 
@@ -198,6 +199,15 @@ def test_list_actors_requires_auth():
     assert resp.status_code == 401
 
 
+def test_list_actors_newest_first():
+    r1 = client.post("/api/actors", json={"display_name": "Older"}, headers=_HEADERS).json()
+    r2 = client.post("/api/actors", json={"display_name": "Newer"}, headers=_HEADERS).json()
+    resp = client.get("/api/actors", headers=_HEADERS)
+    assert resp.status_code == 200
+    ids = [a["id"] for a in resp.json()["items"]]
+    assert ids.index(r2["id"]) < ids.index(r1["id"])
+
+
 # ---------------------------------------------------------------------------
 # GET /api/actors/{id}
 # ---------------------------------------------------------------------------
@@ -308,6 +318,16 @@ def test_patch_actor_invalid_confidence_returns_422():
         "/api/actors", json={"display_name": "Conf Test"}, headers=_HEADERS
     ).json()
     resp = client.patch(f"/api/actors/{created['id']}", json={"confidence": 2.0}, headers=_HEADERS)
+    assert resp.status_code == 422
+
+
+def test_patch_actor_blank_display_name_returns_422():
+    created = client.post(
+        "/api/actors", json={"display_name": "Valid Name"}, headers=_HEADERS
+    ).json()
+    resp = client.patch(
+        f"/api/actors/{created['id']}", json={"display_name": "   "}, headers=_HEADERS
+    )
     assert resp.status_code == 422
 
 

--- a/tests/integration/test_actor_suggestions_endpoints.py
+++ b/tests/integration/test_actor_suggestions_endpoints.py
@@ -16,6 +16,9 @@ Coverage:
     - min_score query param overrides config default
     - limit query param overrides config default
     - /suggestions route does not conflict with /{actor_id} route
+    - dormant campaigns are included in evaluation
+    - reactivated campaigns are included in evaluation
+    - historical campaigns are excluded from evaluation
 
   Invariants:
     - GET /suggestions never writes to actor_profiles
@@ -429,6 +432,56 @@ def test_min_score_out_of_range_returns_422():
         headers=_HEADERS,
     )
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Campaign status filtering — eligible vs excluded statuses
+# ---------------------------------------------------------------------------
+
+
+def test_suggestions_includes_dormant_campaigns():
+    d1 = _create_campaign(status="dormant", representative_fingerprint_json=_REP_FP_A)
+    d2 = _create_campaign(status="dormant", representative_fingerprint_json=_REP_FP_B)
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    pair_ids = {
+        frozenset({s["campaign_a"]["id"], s["campaign_b"]["id"]}) for s in data["suggestions"]
+    }
+    assert frozenset({d1, d2}) in pair_ids
+
+
+def test_suggestions_includes_reactivated_campaigns():
+    r1 = _create_campaign(status="reactivated", representative_fingerprint_json=_REP_FP_A)
+    r2 = _create_campaign(status="reactivated", representative_fingerprint_json=_REP_FP_B)
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    pair_ids = {
+        frozenset({s["campaign_a"]["id"], s["campaign_b"]["id"]}) for s in data["suggestions"]
+    }
+    assert frozenset({r1, r2}) in pair_ids
+
+
+def test_suggestions_excludes_historical_campaigns():
+    h1 = _create_campaign(status="historical", representative_fingerprint_json=_REP_FP_A)
+    h2 = _create_campaign(status="historical", representative_fingerprint_json=_REP_FP_B)
+    resp = client.get(
+        "/api/actors/suggestions",
+        params={"min_score": 0.0},
+        headers=_HEADERS,
+    )
+    data = resp.json()
+    pair_ids = {
+        frozenset({s["campaign_a"]["id"], s["campaign_b"]["id"]}) for s in data["suggestions"]
+    }
+    assert frozenset({h1, h2}) not in pair_ids
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds 5 targeted integration tests across 2 files, covering 3 high-priority gaps identified in the Stage 14A actor endpoint test coverage audit.

- Adds `test_list_actors_newest_first` — verifies `GET /api/actors` returns actors ordered newest-first (covered by `ORDER BY created_at DESC` in repository; previously untested)
- Adds `test_patch_actor_blank_display_name_returns_422` — verifies `PATCH /api/actors/{id}` with whitespace-only `display_name` returns 422 (covered by `ActorPatchRequest.display_name_nonempty` validator; previously untested via PATCH path)
- Adds `test_suggestions_includes_dormant_campaigns` — verifies dormant campaigns appear in actor suggestions
- Adds `test_suggestions_includes_reactivated_campaigns` — verifies reactivated campaigns appear in actor suggestions
- Adds `test_suggestions_excludes_historical_campaigns` — verifies historical campaigns are excluded from actor suggestions (all three cover `WHERE status IN ('active', 'dormant', 'reactivated')` filter in `list_campaigns_for_suggestions`; previously untested)

## Test plan

- [ ] Targeted files: `pytest tests/integration/test_actor_endpoints.py tests/integration/test_actor_suggestions_endpoints.py -q` → 60 passed locally
- [ ] Full actor suite: `pytest tests/integration/test_actor_endpoints.py tests/integration/test_actor_stability_endpoints.py tests/integration/test_actor_suggestions_endpoints.py tests/integration/test_actor_linking_endpoints.py -q` → 107 passed locally
- [ ] Ruff: `ruff check tests/integration/test_actor_endpoints.py tests/integration/test_actor_suggestions_endpoints.py` → clean locally
- [ ] No application code changed — test files only
- [ ] CI passes on this PR