### PR TITLE
test: cover medium-priority actor endpoint gaps

### DIFF
--- a/tests/integration/test_actor_endpoints.py
+++ b/tests/integration/test_actor_endpoints.py
@@ -17,6 +17,8 @@ Coverage:
     - filters by status param
     - invalid status filter returns 422
     - respects limit param
+    - limit=0 returns 422
+    - limit=201 returns 422
     - requires authentication
 
   GET /api/actors/{id}:
@@ -27,6 +29,7 @@ Coverage:
   PATCH /api/actors/{id}:
     - updates display_name
     - updates status to archived
+    - reactivates from archived to active
     - updates confidence
     - clears notes (explicit null)
     - omitted fields are not changed
@@ -208,6 +211,16 @@ def test_list_actors_newest_first():
     assert ids.index(r2["id"]) < ids.index(r1["id"])
 
 
+def test_list_actors_limit_zero_returns_422():
+    resp = client.get("/api/actors?limit=0", headers=_HEADERS)
+    assert resp.status_code == 422
+
+
+def test_list_actors_limit_over_max_returns_422():
+    resp = client.get("/api/actors?limit=201", headers=_HEADERS)
+    assert resp.status_code == 422
+
+
 # ---------------------------------------------------------------------------
 # GET /api/actors/{id}
 # ---------------------------------------------------------------------------
@@ -257,6 +270,16 @@ def test_patch_actor_status_to_archived():
     )
     assert resp.status_code == 200
     assert resp.json()["status"] == "archived"
+
+
+def test_patch_actor_status_archived_to_active():
+    created = client.post(
+        "/api/actors", json={"display_name": "Reactivate Actor"}, headers=_HEADERS
+    ).json()
+    client.patch(f"/api/actors/{created['id']}", json={"status": "archived"}, headers=_HEADERS)
+    resp = client.patch(f"/api/actors/{created['id']}", json={"status": "active"}, headers=_HEADERS)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "active"
 
 
 def test_patch_actor_confidence():

--- a/tests/integration/test_actor_linking_endpoints.py
+++ b/tests/integration/test_actor_linking_endpoints.py
@@ -5,6 +5,7 @@ Tests hit the full stack: FastAPI TestClient → routers → EventRepository →
 Coverage:
   POST /api/actors/{id}/campaigns:
     - creates lineage, returns 201 with lineage dict
+    - evidence dict is stored and returned in evidence_json
     - 404 if actor not found
     - 404 if campaign not found
     - 422 if relationship_type is invalid
@@ -38,6 +39,7 @@ Coverage:
 
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import UTC, datetime
 
@@ -120,6 +122,21 @@ def test_link_campaign_response_has_expected_fields():
     assert data["confidence"] == 0.75
     assert data["id"] is not None
     assert data["created_at"] is not None
+
+
+def test_link_campaign_evidence_round_trip():
+    actor = _create_actor()
+    cid = _create_campaign()
+    evidence = {"source": "manual_review", "score": 0.9}
+    resp = client.post(
+        f"/api/actors/{actor['id']}/campaigns",
+        json={"campaign_id": cid, "relationship_type": "tactic_match", "evidence": evidence},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["evidence_json"] is not None
+    assert json.loads(data["evidence_json"]) == evidence
 
 
 def test_link_campaign_all_valid_relationship_types():


### PR DESCRIPTION
## Summary

Adds four integration tests covering three medium-priority C1 actor endpoint gaps identified in the Stage 14A coverage audit.

- Adds `test_list_actors_limit_zero_returns_422` — verifies `GET /api/actors?limit=0` returns 422 (violates `ge=1` on the `limit` Query param)
- Adds `test_list_actors_limit_over_max_returns_422` — verifies `GET /api/actors?limit=201` returns 422 (violates `le=200`)
- Adds `test_patch_actor_status_archived_to_active` — verifies `PATCH /api/actors/{id}` supports archived→active status reactivation (two-step: active→archived, then archived→active)
- Adds `test_link_campaign_evidence_round_trip` — verifies `POST /api/actors/{id}/campaigns` with an `evidence` dict stores and returns it correctly via `evidence_json` field; adds `import json` to the linking test file

## Test plan

- [ ] Targeted files: `pytest tests/integration/test_actor_endpoints.py tests/integration/test_actor_linking_endpoints.py -q` → 62 passed locally
- [ ] Full actor suite: `pytest tests/integration/test_actor_endpoints.py tests/integration/test_actor_stability_endpoints.py tests/integration/test_actor_suggestions_endpoints.py tests/integration/test_actor_linking_endpoints.py -q` → 111 passed locally
- [ ] Ruff: clean locally
- [ ] Black: `black --check` passes — both files left unchanged
- [ ] No application code changed — test files only
- [ ] CI passes on this PR