### PR TITLE
test: cover remaining actor endpoint gaps

### DIFF
--- a/tests/integration/test_actor_endpoints.py
+++ b/tests/integration/test_actor_endpoints.py
@@ -33,6 +33,7 @@ Coverage:
     - updates confidence
     - clears notes (explicit null)
     - omitted fields are not changed
+    - empty body is a no-op, returns 200
     - invalid status returns 422
     - blank display_name returns 422
     - returns 404 for unknown id
@@ -324,6 +325,22 @@ def test_patch_actor_omitted_fields_unchanged():
     data = resp.json()
     assert data["notes"] == "keep this"
     assert data["display_name"] == "Stable Actor"
+
+
+def test_patch_actor_empty_body_is_no_op():
+    created = client.post(
+        "/api/actors",
+        json={"display_name": "No Change", "confidence": 0.5, "notes": "keep this"},
+        headers=_HEADERS,
+    ).json()
+    resp = client.patch(f"/api/actors/{created['id']}", json={}, headers=_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == created["id"]
+    assert data["display_name"] == "No Change"
+    assert data["status"] == "active"
+    assert data["confidence"] == pytest.approx(0.5)
+    assert data["notes"] == "keep this"
 
 
 def test_patch_actor_invalid_status_returns_422():

--- a/tests/integration/test_actor_linking_endpoints.py
+++ b/tests/integration/test_actor_linking_endpoints.py
@@ -16,6 +16,8 @@ Coverage:
   GET /api/actors/{id}/campaigns:
     - returns empty list when actor has no links
     - returns linked campaigns with metadata
+    - limit=0 returns 422
+    - limit=501 returns 422
     - 404 if actor not found
     - requires authentication
 
@@ -252,6 +254,18 @@ def test_list_actor_campaigns_returns_linked():
     assert "linked_at" in item
     assert "campaign_name" in item
     assert "campaign_status" in item
+
+
+def test_list_actor_campaigns_limit_zero_returns_422():
+    actor = _create_actor()
+    resp = client.get(f"/api/actors/{actor['id']}/campaigns?limit=0", headers=_HEADERS)
+    assert resp.status_code == 422
+
+
+def test_list_actor_campaigns_limit_over_max_returns_422():
+    actor = _create_actor()
+    resp = client.get(f"/api/actors/{actor['id']}/campaigns?limit=501", headers=_HEADERS)
+    assert resp.status_code == 422
 
 
 def test_list_actor_campaigns_404_actor_not_found():


### PR DESCRIPTION
Adds three integration tests for the two remaining low-priority C1 actor endpoint coverage gaps.

## Tests added

- `test_patch_actor_empty_body_is_no_op` — `PATCH /api/actors/{id}` with an empty JSON body returns 200 and leaves all actor fields unchanged (GAP-3)
- `test_list_actor_campaigns_limit_zero_returns_422` — `GET /api/actors/{id}/campaigns?limit=0` returns 422 (GAP-8)
- `test_list_actor_campaigns_limit_over_max_returns_422` — `GET /api/actors/{id}/campaigns?limit=501` returns 422; route maximum is 500 (GAP-8)

## Verification

- Targeted tests: 65 passed
- Full actor integration suite (all four actor test files): 114 passed
- Ruff: clean
- Black: clean
- No application code changed

## Test plan

- [ ] CI passes: lint, tests, pip-audit, bandit
- [ ] Only `tests/integration/test_actor_endpoints.py` and `tests/integration/test_actor_linking_endpoints.py` changed
- [ ] No application code, migrations, docs, config, or storage files modified